### PR TITLE
Miscellaneous docker QoL improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
     pip3 install torch pipx && \
     python3 -m pipx ensurepath
 
-RUN mkdir -p ~/.ssh /app && \
+RUN mkdir -p ~/.ssh /app /job && \
     echo 'Host *' > ~/.ssh/config && \
     echo '    StrictHostKeyChecking no' >> ~/.ssh/config && \
     echo 'AuthorizedKeysFile     .ssh/authorized_keys' >> /etc/ssh/sshd_config && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,5 +21,6 @@ RUN sh ./install_deepspeed.sh
 
 COPY requirements.txt /app
 RUN pip install -r requirements.txt
+RUN git remote set-url origin https://github.com/EleutherAI/gpt-neox/
 
 COPY . /app

--- a/deploy_k8s.sh
+++ b/deploy_k8s.sh
@@ -4,10 +4,10 @@ ssh-keygen -t rsa -f id_rsa -N ""
 echo Waiting for deploy to complete...
 kubectl wait --for=condition=available --timeout=600s deployment/eleuther-neox || exit
 
-kubectl get pods -o wide | grep eleuther-neox | awk '{print $6 " slots=8"}' > hosts
+kubectl get pods -o wide | grep eleuther-neox | awk '{print $6 " slots=8"}' > hostfile
 export MASTER_ID=$(kubectl get pods | grep eleuther-neox | awk '{print $1}' | head -n 1)
 echo $MASTER_ID
-kubectl cp $PWD/hosts $MASTER_ID:/app
+kubectl cp $PWD/hostfile $MASTER_ID:/job
 kubectl cp $PWD/id_rsa $MASTER_ID:/root/.ssh
 
 mv id_rsa.pub authorized_keys
@@ -18,7 +18,7 @@ do
     kubectl cp $PWD/authorized_keys $id:/root/.ssh/
     echo 'chmod 600 ~/.ssh/authorized_keys && chmod 700 ~/.ssh && chown -R root /root/.ssh' | kubectl exec --stdin $id -- /bin/bash
 done
-rm authorized_keys hosts
+rm authorized_keys hostfile
 rm id_rsa*
 
 kubectl exec --stdin --tty $MASTER_ID -- /bin/bash

--- a/install_deepspeed.sh
+++ b/install_deepspeed.sh
@@ -1,3 +1,3 @@
 sudo apt-get -y install llvm-9-dev cmake
-git clone https://github.com/microsoft/DeepSpeed.git /tmp/Deepspeed
+git clone https://github.com/EleutherAI/DeeperSpeed.git /tmp/Deepspeed
 cd /tmp/Deepspeed && DS_BUILD_SPARSE_ATTN=1 ./install.sh -r


### PR DESCRIPTION
From @StellaAthena:

> 1. Store the hostfile in /job/hostfile so that the code automatically finds it and we don't need to provide it as an argument.
> 2. Install DeeperSpeed instead of DeepSpeed
> 3. The script lands you in ~/app/, which contains the contents of the GPT-NeoX repository. Would it be possible to have the GPT-NeoX repo be one layer deeper, so that it drops you in ~/app/ which contains the directory gpt-neox? That would be very pleasant but isn't necessary.

Addresses 1 & 2, fixes XY behind 3