### PR TITLE
Added copyright disclaimers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GPT-NeoX
 
-This repository records EleutherAI's work-in-progress for training large scale GPU language models. Our current frameowkr is based on NVIDIA's [Megatron Language Model](https://github.com/NVIDIA/Megatron-LM) and has been augmented with techniques from [DeepSpeed](https://www.deepspeed.ai) as well as some novel optimizations. 
+This repository records [EleutherAI](www.eleuther.ai)'s work-in-progress for training large scale GPU language models. Our current frameowkr is based on NVIDIA's [Megatron Language Model](https://github.com/NVIDIA/Megatron-LM) and has been augmented with techniques from [DeepSpeed](https://www.deepspeed.ai) as well as some novel optimizations. 
 
 If you are looking for our TPU codebase, see [GPT-Neo](https://github.com/EleutherAI/gpt-neo).
 
@@ -50,3 +50,5 @@ This repository hosts code that is part of EleutherAI's GPT-NeoX project. Copyri
     along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 This repository is based off code written by NVIDIA that is licensed under the Apache License, Version 2.0. In accordance with the Apache License, all files that are modifications of code originally written by NIVIDIA maintain a NVIDIA copyright header. All files that do not contain such a header are original to EleutherAI. When the NVIDIA code has been modified from its original version, that fact is noted in the copyright header. All derivative works of this repository must preserve these headers under the terms of the Apache License.
+
+If you have any questions, comments, or concerns about licensing please email us at contact@eleuther.ai.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # GPT-NeoX
 
-This repository records EleutherAI's work-in-progress for training large scale GPU language models. Our current frameowkr is based on NVIDIA's Megatron model and has been augmented with techniques from DeepSpeed as well as some novel optimizations. If you are looking for our TPU codebase, see [GPT-Neo](https://github.com/EleutherAI/gpt-neo).
+This repository records EleutherAI's work-in-progress for training large scale GPU language models. Our current frameowkr is based on NVIDIA's [Megatron Language Model](https://github.com/NVIDIA/Megatron-LM) and has been augmented with techniques from [DeepSpeed](https://www.deepspeed.ai) as well as some novel optimizations. 
+
+If you are looking for our TPU codebase, see [GPT-Neo](https://github.com/EleutherAI/gpt-neo).
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -51,4 +51,4 @@ This repository hosts code that is part of EleutherAI's GPT-NeoX project. Copyri
 
 This repository is based off code written by NVIDIA that is licensed under the Apache License, Version 2.0. In accordance with the Apache License, all files that are modifications of code originally written by NIVIDIA maintain a NVIDIA copyright header. All files that do not contain such a header are original to EleutherAI. When the NVIDIA code has been modified from its original version, that fact is noted in the copyright header. All derivative works of this repository must preserve these headers under the terms of the Apache License.
 
-If you have any questions, comments, or concerns about licensing please email us at contact@eleuther.ai.
+For full terms, see the `LICENSE` file. If you have any questions, comments, or concerns about licensing please email us at contact@eleuther.ai.

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -12,6 +12,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# This file has been modified from its original version
+#
+
 
 """Megatron arguments."""
 

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -1,4 +1,7 @@
 # coding=utf-8
+#
+# Copyright 2021 Biderman et al. This file is based on code by the authors denoted below and has been modified from its original version.
+#
 # Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,9 +15,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# This file has been modified from its original version
-#
 
 
 """Megatron arguments."""

--- a/megatron/checkpointing.py
+++ b/megatron/checkpointing.py
@@ -12,6 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# This file has been modified from its original version
+#
 
 """Input/output checkpointing."""
 

--- a/megatron/checkpointing.py
+++ b/megatron/checkpointing.py
@@ -1,4 +1,7 @@
 # coding=utf-8
+#
+# Copyright 2021 Biderman et al. This file is based on code by the authors denoted below and has been modified from its original version.
+#
 # Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,9 +15,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# This file has been modified from its original version
-#
 
 """Input/output checkpointing."""
 

--- a/megatron/data/dataset_utils.py
+++ b/megatron/data/dataset_utils.py
@@ -1,4 +1,6 @@
 # coding=utf-8
+# Copyright 2021 Biderman et al. This code is based in code by the authors denoted below and has been modified from its original version.
+#
 # Copyright 2018 The Google AI Language Team Authors, and NVIDIA.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +14,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 
 # Most of the code here has been copied from:
 #   https://github.com/google-research/albert/blob/master/create_pretraining_data.py

--- a/megatron/data/dataset_utils.py
+++ b/megatron/data/dataset_utils.py
@@ -1,5 +1,6 @@
 # coding=utf-8
-# Copyright 2021 Biderman et al. This code is based in code by the authors denoted below and has been modified from its original version.
+#
+# Copyright 2021 Biderman et al. This file is based in code by the authors denoted below and has been modified from its original version.
 #
 # Copyright 2018 The Google AI Language Team Authors, and NVIDIA.
 #

--- a/megatron/data/gpt2_dataset.py
+++ b/megatron/data/gpt2_dataset.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 #
-# Copyright 2021 Biderman et al. This code is based in code by the authors denoted below and has been modified from its original version.
+# Copyright 2021 Biderman et al. This file is based in code by the authors denoted below and has been modified from its original version.
 #
 # Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
 #

--- a/megatron/data/gpt2_dataset.py
+++ b/megatron/data/gpt2_dataset.py
@@ -1,4 +1,7 @@
 # coding=utf-8
+#
+# Copyright 2021 Biderman et al. This code is based in code by the authors denoted below and has been modified from its original version.
+#
 # Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/megatron/model/__init__.py
+++ b/megatron/model/__init__.py
@@ -1,4 +1,7 @@
 # coding=utf-8
+#
+# Copyright 2021 Biderman et al. This file is based on code by the authors denoted below and has been modified from its original version.
+#
 # Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/megatron/model/gpt2_model.py
+++ b/megatron/model/gpt2_model.py
@@ -1,4 +1,7 @@
 # coding=utf-8
+#
+# Copyright 2021 Biderman et al. This file is based on code by the authors denoted below and has been modified from its original version.
+#
 # Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/megatron/model/language_model.py
+++ b/megatron/model/language_model.py
@@ -1,4 +1,7 @@
 # coding=utf-8
+#
+# Copyright 2021 Biderman et al. This file is based on code by the authors denoted below and has been modified from its original version.
+#
 # Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -1,4 +1,7 @@
 # coding=utf-8
+#
+# Copyright 2021 Biderman et al. This file is based on code by the authors denoted below and has been modified from its original version.
+#
 # Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/megatron/model/utils.py
+++ b/megatron/model/utils.py
@@ -1,4 +1,7 @@
 # coding=utf-8
+#
+# Copyright 2021 Biderman et al. This file is based on code by the authors denoted below and has been modified from its original version.
+#
 # Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/megatron/mpu/initialize.py
+++ b/megatron/mpu/initialize.py
@@ -1,4 +1,7 @@
 # coding=utf-8
+#
+# Copyright 2021 Biderman et al. This file is based on code by the authors denoted below and has been modified from its original version.
+#
 # Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/megatron/mpu/layers.py
+++ b/megatron/mpu/layers.py
@@ -1,4 +1,7 @@
 # coding=utf-8
+#
+# Copyright 2021 Biderman et al. This file is based on code by the authors denoted below and has been modified from its original version.
+#
 # Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/megatron/tokenizer/gpt2_tokenization.py
+++ b/megatron/tokenizer/gpt2_tokenization.py
@@ -1,4 +1,7 @@
 # coding=utf-8
+#
+# Copyright 2021 Biderman et al. This file is based on code by the authors denoted below and has been modified from its original version.
+#
 # Copyright 2018 The Open AI Team Authors and The HuggingFace Inc. team.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/megatron/tokenizer/tokenizer.py
+++ b/megatron/tokenizer/tokenizer.py
@@ -1,4 +1,7 @@
 # coding=utf-8
+#
+# Copyright 2021 Biderman et al. This file is based on code by the authors denoted below and has been modified from its original version.
+#
 # Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -1,4 +1,7 @@
 # coding=utf-8
+#
+# Copyright 2021 Biderman et al. This file is based on code by the authors denoted below and has been modified from its original version.
+#
 # Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -12,6 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# This file has been modified from its original version
+#
 
 """Pretrain utilities."""
 

--- a/pretrain_gpt2.py
+++ b/pretrain_gpt2.py
@@ -1,4 +1,7 @@
 # coding=utf-8
+#
+# Copyright 2021 Biderman et al. This file is based on code by the authors denoted below and has been modified from its original version.
+#
 # Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tasks/main.py
+++ b/tasks/main.py
@@ -1,4 +1,7 @@
 # coding=utf-8
+#
+# Copyright 2021 Biderman et al. This file is based on code by the authors denoted below and has been modified from its original version.
+#
 # Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
In accordance with the Megatron-LM terms of use and NVIDIA's license, I have added text to the header of each file that was originally authored by NVIDIA and subsequently modified by us. This test reads

    # Copyright 2021 Biderman et al. This file is based on code by the authors denoted below and has been modified from its original version.

I went with Biderman et al. because 1) updating every single file with new collaborators gets tiresome 2) we will fail to do it and 3) our license doesn't require headers on every file, so a minimal disclaimer to accord with the terms of NVIDIA's license is sufficient.

Hopefully nobody whose name comes before mine alphabetically will be added because going back and re-edit all the headers will be annoying.