### PR TITLE
Wandb

### DIFF
--- a/deepy.py
+++ b/deepy.py
@@ -25,7 +25,8 @@ def get_wandb_api_key():
 
 # Generate unique run group name
 wandb_group = shortuuid.uuid()
-sys.argv.extend(['--group_name', wandb_group])
+sys.argv.extend(['--wandb_group', wandb_group])
+sys.argv.extend(['--wandb_team', 'eleutherai'])
 
 # Extract wandb API key and inject into worker environments
 wandb_token = get_wandb_api_key()

--- a/deepy.py
+++ b/deepy.py
@@ -26,7 +26,10 @@ def get_wandb_api_key():
 # Generate unique run group name
 wandb_group = shortuuid.uuid()
 sys.argv.extend(['--wandb_group', wandb_group])
-sys.argv.extend(['--wandb_team', 'eleutherai'])
+
+wandb_team = os.environ.get('WANDB_TEAM')
+if wandb_team:
+    sys.argv.extend(['--wandb_team', wandb_team])
 
 # Extract wandb API key and inject into worker environments
 wandb_token = get_wandb_api_key()

--- a/examples/ds_pretrain_gpt2.sh
+++ b/examples/ds_pretrain_gpt2.sh
@@ -127,7 +127,9 @@ fi
 
 full_options="${gpt_options} ${deepspeed_options} ${chkp_opt}"
 
-run_cmd="deepspeed --num_nodes ${DLWS_NUM_WORKER} --num_gpus ${DLWS_NUM_GPU_PER_WORKER} pretrain_gpt2.py $@ ${full_options}"
+DS_EXE="${DS_EXE:-deepspeed}"
+
+run_cmd="$DS_EXE --num_nodes ${DLWS_NUM_WORKER} --num_gpus ${DLWS_NUM_GPU_PER_WORKER} pretrain_gpt2.py $@ ${full_options}"
 echo ${run_cmd}
 eval ${run_cmd}
 

--- a/examples/ds_pretrain_gpt2_2-7B_pipe.sh
+++ b/examples/ds_pretrain_gpt2_2-7B_pipe.sh
@@ -149,7 +149,9 @@ fi
 
 full_options="${gpt_options} ${deepspeed_options} ${chkp_opt}"
 
-run_cmd="deepspeed pretrain_gpt2.py $@ ${full_options}"
+DS_EXE="${DS_EXE:-deepspeed}"
+
+run_cmd="$DS_EXE pretrain_gpt2.py $@ ${full_options}"
 echo ${run_cmd}
 eval ${run_cmd}
 

--- a/examples/ds_pretrain_gpt2_XL_pipe.sh
+++ b/examples/ds_pretrain_gpt2_XL_pipe.sh
@@ -148,7 +148,9 @@ fi
 
 full_options="${gpt_options} ${deepspeed_options} ${chkp_opt}"
 
-run_cmd="deepspeed pretrain_gpt2.py $@ ${full_options}"
+DS_EXE="${DS_EXE:-deepspeed}"
+
+run_cmd="$DS_EXE pretrain_gpt2.py $@ ${full_options}"
 echo ${run_cmd}
 eval ${run_cmd}
 

--- a/examples/ds_pretrain_gpt2_XL_pipe_onebit.sh
+++ b/examples/ds_pretrain_gpt2_XL_pipe_onebit.sh
@@ -149,7 +149,9 @@ fi
 
 full_options="${gpt_options} ${deepspeed_options} ${chkp_opt}"
 
-run_cmd="/home/mchorse/gpt-neox/deepy.py pretrain_gpt2.py $@ ${full_options}"
+DS_EXE="${DS_EXE:-deepspeed}"
+
+run_cmd="$DS_EXE pretrain_gpt2.py $@ ${full_options}"
 echo ${run_cmd}
 eval ${run_cmd}
 

--- a/examples/ds_pretrain_gpt2_XL_pipe_onebit.sh
+++ b/examples/ds_pretrain_gpt2_XL_pipe_onebit.sh
@@ -149,7 +149,7 @@ fi
 
 full_options="${gpt_options} ${deepspeed_options} ${chkp_opt}"
 
-run_cmd="deepspeed pretrain_gpt2.py $@ ${full_options}"
+run_cmd="/home/mchorse/gpt-neox/deepy.py pretrain_gpt2.py $@ ${full_options}"
 echo ${run_cmd}
 eval ${run_cmd}
 

--- a/examples/ds_pretrain_gpt2_large_pipe.sh
+++ b/examples/ds_pretrain_gpt2_large_pipe.sh
@@ -148,7 +148,9 @@ fi
 
 full_options="${gpt_options} ${deepspeed_options} ${chkp_opt}"
 
-run_cmd="deepspeed pretrain_gpt2.py $@ ${full_options}"
+DS_EXE="${DS_EXE:-deepspeed}"
+
+run_cmd="$DS_EXE pretrain_gpt2.py $@ ${full_options}"
 echo ${run_cmd}
 eval ${run_cmd}
 

--- a/examples/ds_pretrain_gpt2_medium_pipe.sh
+++ b/examples/ds_pretrain_gpt2_medium_pipe.sh
@@ -148,7 +148,9 @@ fi
 
 full_options="${gpt_options} ${deepspeed_options} ${chkp_opt}"
 
-run_cmd="deepspeed pretrain_gpt2.py $@ ${full_options}"
+DS_EXE="${DS_EXE:-deepspeed}"
+
+run_cmd="$DS_EXE pretrain_gpt2.py $@ ${full_options}"
 echo ${run_cmd}
 eval ${run_cmd}
 

--- a/examples/ds_pretrain_gpt2_pipe_flops_profile.sh
+++ b/examples/ds_pretrain_gpt2_pipe_flops_profile.sh
@@ -136,7 +136,9 @@ fi
 
 full_options="${gpt_options} ${deepspeed_options} ${chkp_opt}"
 
-run_cmd="deepspeed pretrain_gpt2.py $@ ${full_options}"
+DS_EXE="${DS_EXE:-deepspeed}"
+
+run_cmd="$DS_EXE pretrain_gpt2.py $@ ${full_options}"
 echo ${run_cmd}
 eval ${run_cmd}
 

--- a/examples/ds_pretrain_gpt2_small_pipe.sh
+++ b/examples/ds_pretrain_gpt2_small_pipe.sh
@@ -148,7 +148,9 @@ fi
 
 full_options="${gpt_options} ${deepspeed_options} ${chkp_opt}"
 
-run_cmd="deepspeed pretrain_gpt2.py $@ ${full_options}"
+DS_EXE="${DS_EXE:-deepspeed}"
+
+run_cmd="$DS_EXE pretrain_gpt2.py $@ ${full_options}"
 echo ${run_cmd}
 eval ${run_cmd}
 

--- a/kubernetes/deploy_cluster.sh
+++ b/kubernetes/deploy_cluster.sh
@@ -35,6 +35,8 @@ ssh-keygen -t rsa -f $WD/id_rsa -N ""
 
 post_start_script="
 echo 'export DATA_DIR=/mnt/ssd-cluster/data' >> /home/mchorse/.bashrc;
+echo 'export WANDB_TEAM=eleutherai' >> /home/mchorse/.bashrc;
+echo 'export DS_EXE=/home/mchorse/gpt-neox/deepy.py' >> /home/mchorse/.bashrc;
 sudo cp /secrets/id_rsa.pub /home/mchorse/.ssh/authorized_keys;
 sudo chown mchorse:mchorse /home/mchorse/.ssh/authorized_keys;
 sudo chown -R mchorse:mchorse /home/mchorse/.ssh;

--- a/megatron/global_vars.py
+++ b/megatron/global_vars.py
@@ -29,7 +29,7 @@ _GLOBAL_TOKENIZER = None
 _GLOBAL_TENSORBOARD_WRITER = None
 _GLOBAL_ADLR_AUTORESUME = None
 _GLOBAL_TIMERS = None
-
+_GLOBAL_USE_WANDB = False
 
 def get_args():
     """Return arguments."""
@@ -231,3 +231,11 @@ class Timers:
                 print(string, flush=True)
         else:
             print(string, flush=True)
+
+def get_use_wandb():
+    global _GLOBAL_USE_WANDB
+    return _GLOBAL_USE_WANDB
+
+def set_use_wandb(b: bool):
+    global _GLOBAL_USE_WANDB
+    _GLOBAL_USE_WANDB = b

--- a/pretrain_gpt2.py
+++ b/pretrain_gpt2.py
@@ -17,8 +17,10 @@
 # limitations under the License.
 
 """Pretrain GPT2"""
+import socket
 
 import torch
+from wandb import UsageError
 
 from megatron import get_args
 from megatron import print_rank_0
@@ -26,12 +28,13 @@ from megatron import get_timers
 from megatron import get_tokenizer
 from megatron import mpu
 from megatron.data.gpt2_dataset import build_train_valid_test_datasets
+from megatron.global_vars import set_use_wandb, get_use_wandb
 from megatron.model import GPT2Model, GPT2ModelPipe
 from megatron.training import pretrain
-from megatron.utils import get_ltor_masks_and_position_ids
+from megatron.utils import get_ltor_masks_and_position_ids, is_local_main, local_rank, get_wandb_api_key, neox_args
 from megatron.utils import reduce_losses
 from megatron.fp16 import fp32_to_fp16
-
+import wandb
 
 def model_provider():
     """Build the model."""
@@ -46,6 +49,27 @@ def model_provider():
         # This is a hack to give us a reference to get_batch_pipe from within training.py
         # We need to call model.set_batch_fn after deepspeed.initialize
         model._megatron_batch_fn = get_batch_pipe
+
+    ## Wandb
+    use_wandb = get_wandb_api_key() is not None
+    set_use_wandb(use_wandb)
+    args_dict = vars(args)
+    if use_wandb:
+        # only display system stats from one worker per machine
+        wandb_settings = wandb.Settings() if is_local_main() else wandb.Settings(_disable_stats=True)
+        group_name = args_dict.get('wandb_group')
+        name = f'{socket.gethostname()}-{local_rank()}' if group_name else None
+
+        try:
+            wandb.init(project="neox", group=group_name, name=name, save_code=False,
+                       force=False, entity=args_dict.get('wandb_team'), settings=wandb_settings)
+        except UsageError as e:
+            set_use_wandb(False)
+            print(e)
+            print('Skipping wandb. Execute `wandb login` on local or main node machine to enable.')
+
+    if use_wandb:
+        wandb.config.update(args_dict)
 
     return model
 
@@ -130,8 +154,14 @@ def forward_step(data_iterator, model):
     loss_mask = loss_mask.view(-1)
     loss = torch.sum(losses.view(-1) * loss_mask) / loss_mask.sum()
 
+    if get_use_wandb():
+        wandb.log({'loss': loss.item()})
+
     # Reduce loss for logging.
     reduced_loss = reduce_losses([loss])
+
+    if get_use_wandb():
+        wandb.log({'reduced_loss': loss.item()})
 
     return loss, {'lm loss': reduced_loss[0]}
 
@@ -157,4 +187,4 @@ def train_valid_test_datasets_provider(train_val_test_num_samples):
 
 if __name__ == "__main__":
     pretrain(train_valid_test_datasets_provider, model_provider, forward_step,
-             args_defaults={'tokenizer_type': 'GPT2BPETokenizer'})
+             args_defaults={'tokenizer_type': 'GPT2BPETokenizer'}, extra_args_provider=neox_args)

--- a/pretrain_gpt2.py
+++ b/pretrain_gpt2.py
@@ -154,14 +154,8 @@ def forward_step(data_iterator, model):
     loss_mask = loss_mask.view(-1)
     loss = torch.sum(losses.view(-1) * loss_mask) / loss_mask.sum()
 
-    if get_use_wandb():
-        wandb.log({'loss': loss.item()})
-
     # Reduce loss for logging.
     reduced_loss = reduce_losses([loss])
-
-    if get_use_wandb():
-        wandb.log({'reduced_loss': loss.item()})
 
     return loss, {'lm loss': reduced_loss[0]}
 


### PR DESCRIPTION
Add weight and biases reporting to new Megatron based code.

deploy_cluster.sh now sets two enviroment variables to enable the wandb code:
* `DS_EXE`: the path to the `deepy.py` executable. If not set the examples reset to using the `deepspeed` command
* `WANDB_TEAM`: the wandb org account (e.g. eleutherai)