### PR TITLE
HOTFIX BUG: circular import

### DIFF
--- a/megatron/utils.py
+++ b/megatron/utils.py
@@ -31,7 +31,6 @@ from megatron import get_args
 from megatron import print_rank_0
 from megatron import get_adlr_autoresume
 from megatron import mpu
-from megatron.checkpointing import save_checkpoint
 from megatron.data.samplers import DistributedBatchSampler
 from megatron.fp16 import FP16_Optimizer
 
@@ -83,6 +82,8 @@ def print_params_min_max_norm(optimizer, iteration):
 def check_adlr_autoresume_termination(iteration, model,
                                       optimizer, lr_scheduler):
     """Check for autoresume signal and exit if it is received."""
+    # to prevent circular import
+    from megatron.checkpointing import save_checkpoint
     args = get_args()
     autoresume = get_adlr_autoresume()
     # Add barrier to ensure consistnecy.


### PR DESCRIPTION
Fixes:

```
Traceback (most recent call last):
  File "./deepy.py", line 25, in <module>
    from megatron.config_monster import ConfigMonster
  File "/home/mchorse/gpt-neox/megatron/config_monster.py", line 10, in <module>
    from megatron.utils import obtain_resource_pool
  File "/home/mchorse/gpt-neox/megatron/utils.py", line 34, in <module>
    from megatron.checkpointing import save_checkpoint
  File "/home/mchorse/gpt-neox/megatron/checkpointing.py", line 35, in <module>
    from megatron.utils import natural_sort
ImportError: cannot import name 'natural_sort' from partially initialized module 'megatron.utils' (most likely due to a circular import) (/h
```