### PR TITLE
Dockerfile and dependency improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,14 @@ FROM nvidia/cuda:11.1.1-devel-ubuntu20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-#### System package (uses Python 3.8)
+#### System package (uses default Python 3 version in Ubuntu 20.04)
 RUN apt-get update -y && \
     apt-get install -y \
-        git python3 python3-dev libpython3-dev  python3-pip sudo pdsh \
+        git python3 python3-dev libpython3-dev python3-pip sudo pdsh \
         htop llvm-9-dev tmux zstd software-properties-common build-essential autotools-dev \
         nfs-common pdsh cmake g++ gcc curl wget tmux less unzip htop iftop iotop ca-certificates ssh \
         rsync iputils-ping net-tools libcupti-dev && \
-    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1 && \
-    update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1 && \
+    update-alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
     update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1 && \
     pip install --upgrade pip && \
     pip install gpustat
@@ -32,8 +31,8 @@ RUN echo 'password' >> password.txt && \
 EXPOSE 22
 
 #### OPENMPI
-ENV OPENMPI_BASEVERSION=4.0
-ENV OPENMPI_VERSION=${OPENMPI_BASEVERSION}.1
+ENV OPENMPI_BASEVERSION=4.1
+ENV OPENMPI_VERSION=${OPENMPI_BASEVERSION}.0
 RUN mkdir -p /build && \
     cd ${STAGE_DIR} && \
     wget -q -O - https://download.open-mpi.org/release/open-mpi/v${OPENMPI_BASEVERSION}/openmpi-${OPENMPI_VERSION}.tar.gz | tar xzf - && \

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ We run our experiments on a Kubernetes cluster generously provided by [CoreWeave
 
 ## Licensing
 
-This repository hosts code that is part of EleutherAI's GPT-NeoX project. Copyright (c) 2021 Stella Biderman, Sid Black, Josh Levy-Kramer, Michael Pieler, and Shivanshu Purohit.
+This repository hosts code that is part of EleutherAI's GPT-NeoX project. Copyright (c) 2021 Stella Biderman, Sid Black, Josh Levy-Kramer, Michael Pieler, Shivanshu Purohit, and Eric Hallahan.
 
     GPT-NeoX is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ We run our experiments on a Kubernetes cluster generously provided by [CoreWeave
 
 ## Licensing
 
-This repository hosts code that is part of EleutherAI's GPT-NeoX project. Copyright (c) 2021 Stella Biderman, Sid Black, Josh Levy-Kramer, Michael Pieler, Shivanshu Purohit, and Eric Hallahan.
+This repository hosts code that is part of EleutherAI's GPT-NeoX project. Copyright (c) 2021 Stella Biderman, Sid Black, Eric Hallahan, Josh Levy-Kramer, Michael Pieler, Shivanshu Purohit.
 
     GPT-NeoX is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pybind11==2.6.2
 six
 regex
-numpy==1.19.5
+numpy==1.20.1
 nltk==3.5
 tensorflow==2.4.1
 -e git+git://github.com/EleutherAI/DeeperSpeed.git@cac19a86b67e6e98b9dca37128bc01e50424d9e9#egg=deepspeed

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ six
 regex
 numpy==1.20.1
 nltk==3.5
-tensorflow==2.4.1
 -e git+git://github.com/EleutherAI/DeeperSpeed.git@cac19a86b67e6e98b9dca37128bc01e50424d9e9#egg=deepspeed
 autopep8==1.5.5
 zstandard==0.15.1


### PR DESCRIPTION
**Objectives:**
- Clean up remaining remnants of overriding `python3` to `python3.8` in Ubuntu 18.09 LTS.
- Build with Open MPI 4.1 to follow the recommendation to use the latest stable version available.
- Switch to the latest stable NumPy release. (NumPy 1.20.1)

**Other Changes:**
- Remove mostly unneeded TensorFlow dependency from `requirements.txt`