### PR TITLE
Add pipe-partition-method arg

### DIFF
--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -435,6 +435,12 @@ def _add_distributed_args(parser):
                        help='Size of the model parallel.')
     group.add_argument('--pipe-parallel-size', type=int, default=0,
                        help='Size of the pipeline parallel. Disable with 0.')
+    group.add_argument('--pipe-partition-method', type=str, default='type:transformer',
+                       help='method used to distribute model layers across pipeline stages. Choose from "parameters", '
+                            'which balances the number of parameters on each pipeline stage, "uniform", which naively '
+                            'balances the number of layers per stage, or "type:[regex]" (in our instance this will '
+                            'basically only be type:transformer), which balances layers whose class names match [regex]'
+                       )
     group.add_argument('--distributed-backend', default='nccl',
                        choices=['nccl', 'gloo', 'mpi'],
                        help='Which backend to use for distributed training.')

--- a/megatron/model/gpt2_model.py
+++ b/megatron/model/gpt2_model.py
@@ -286,4 +286,4 @@ class GPT2ModelPipe(PipelineModule, MegatronModule):
                          loss_fn=loss_fn,
                          topology=topology,
                          activation_checkpoint_interval=interval,
-                         partition_method='type:transformer')
+                         partition_method=args.pipe_partition_method)  # 'type:transformer' / 'parameters'


### PR DESCRIPTION
Adds an argument which allows you to control the method used to distribute model layers across pipeline stages. 

Choose from "parameters", which balances the number of parameters on each pipeline stage, "uniform", which naively balances the number of layers per stage, or "type:[regex]" (in our instance this will basically only be type:transformer), which balances layers whose class names match [regex]

ignore commit message, it's old lol