### PR TITLE
Rotary fixes

### DIFF
--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -288,6 +288,8 @@ def _add_training_args(parser):
     pos_emb_choices = ['learned', 'sinusoidal', 'rpe', 'rotary', 'none']
     group.add_argument('--pos-emb', type=str, choices=pos_emb_choices, default='learned',
                        help=f'Type of positional embedding to use - choose from {pos_emb_choices}')
+    group.add_argument('--rotary-emb-theta', type=int, default=10000,
+                       help=f'Theta for rotary positional embedding')
     group.add_argument('--rpe-num-buckets', type=int, default=32,
                        help='T5 relative positional encoding number of buckets, default 32.')
     group.add_argument('--rpe-max-distance', type=int, default=128,

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -288,8 +288,8 @@ def _add_training_args(parser):
     pos_emb_choices = ['learned', 'sinusoidal', 'rpe', 'rotary', 'none']
     group.add_argument('--pos-emb', type=str, choices=pos_emb_choices, default='learned',
                        help=f'Type of positional embedding to use - choose from {pos_emb_choices}')
-    group.add_argument('--rotary-emb-theta', type=int, default=10000,
-                       help=f'Theta for rotary positional embedding')
+    group.add_argument('--rotary-emb-base', type=int, default=10000,
+                       help=f'Base for rotary positional embedding')
     group.add_argument('--rpe-num-buckets', type=int, default=32,
                        help='T5 relative positional encoding number of buckets, default 32.')
     group.add_argument('--rpe-max-distance', type=int, default=128,

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -288,6 +288,7 @@ def _add_training_args(parser):
     pos_emb_choices = ['learned', 'sinusoidal', 'rpe', 'rotary', 'none']
     group.add_argument('--pos-emb', type=str, choices=pos_emb_choices, default='learned',
                        help=f'Type of positional embedding to use - choose from {pos_emb_choices}')
+    group.add_argument('--rotary-pct', type=float, help='pct of hidden dims to apply rotary positional embedding to', default=1)
     group.add_argument('--rotary-emb-base', type=int, default=10000,
                        help=f'Base for rotary positional embedding')
     group.add_argument('--rpe-num-buckets', type=int, default=32,

--- a/megatron/model/positional_embeddings.py
+++ b/megatron/model/positional_embeddings.py
@@ -4,9 +4,9 @@ from megatron.module import MegatronModule
 
 class SinusoidalPositionalEmbedding(MegatronModule):
 
-    def __init__(self, dim, theta=10000):
+    def __init__(self, dim, base=10000):
         super().__init__()
-        inv_freq = 1. / (theta ** (torch.arange(0, dim, 2).float() / dim))
+        inv_freq = 1. / (base ** (torch.arange(0, dim, 2).float() / dim))
         self.register_buffer('inv_freq', inv_freq)
 
     def forward(self, x, seq_dim=1):
@@ -18,9 +18,9 @@ class SinusoidalPositionalEmbedding(MegatronModule):
 
 class RotaryEmbedding(MegatronModule):
     
-    def __init__(self, dim, theta=10000):
+    def __init__(self, dim, base=10000):
         super().__init__()
-        inv_freq = 1. / (theta ** (torch.arange(0, dim, 2).float() / dim))
+        inv_freq = 1. / (base ** (torch.arange(0, dim, 2).float() / dim))
         self.register_buffer('inv_freq', inv_freq)
         self.seq_len_cached = None
         self.cos_cached = None

--- a/megatron/model/positional_embeddings.py
+++ b/megatron/model/positional_embeddings.py
@@ -31,7 +31,7 @@ class RotaryEmbedding(MegatronModule):
             self.seq_len_cached = seq_len
             t = torch.arange(x.shape[seq_dim], device=x.device).type_as(self.inv_freq)
             freqs = torch.einsum('i,j->ij', t, self.inv_freq)
-            emb = torch.cat((freqs, freqs), dim=-1)
+            emb = torch.cat((freqs, freqs), dim=-1).to(x.device)
             self.cos_cached = emb.cos()[:, None, None, :]
             self.sin_cached = emb.sin()[:, None, None, :]
         return self.cos_cached, self.sin_cached

--- a/megatron/model/positional_embeddings.py
+++ b/megatron/model/positional_embeddings.py
@@ -40,7 +40,6 @@ class RotaryEmbedding(MegatronModule):
 
 # rotary pos emb helpers:
 
-@torch.jit.script
 def rotate_half(x):
     x1, x2 = x[..., :x.shape[-1] // 2], x[..., x.shape[-1] // 2:]
     return torch.cat((-x2, x1), dim=x1.ndim - 1) # dim=-1 triggers a bug in earlier torch versions

--- a/megatron/model/positional_embeddings.py
+++ b/megatron/model/positional_embeddings.py
@@ -1,0 +1,53 @@
+import torch
+from megatron.module import MegatronModule
+
+
+class SinusoidalPositionalEmbedding(MegatronModule):
+
+    def __init__(self, dim, theta=10000):
+        super().__init__()
+        inv_freq = 1. / (theta ** (torch.arange(0, dim, 2).float() / dim))
+        self.register_buffer('inv_freq', inv_freq)
+
+    def forward(self, x, seq_dim=1):
+        t = torch.arange(x.shape[seq_dim], device=x.device).type_as(self.inv_freq)
+        sinusoid_inp = torch.einsum("i,j->ij", t, self.inv_freq)
+        emb = torch.cat((sinusoid_inp.sin(), sinusoid_inp.cos()), dim=-1)
+        return emb[None, :, :]
+
+
+class RotaryEmbedding(MegatronModule):
+    def __init__(self, dim, theta=10000):
+        super().__init__()
+        inv_freq = 1. / (theta ** (torch.arange(0, dim, 2).float() / dim))
+        self.register_buffer('inv_freq', inv_freq)
+        self.seq_len_cached = None
+        self.cos_cached = None
+        self.sin_cached = None
+
+    def forward(self, x, seq_dim=1):
+        seq_len = x.shape[seq_dim]
+        if seq_len != self.seq_len_cached:
+            self.seq_len_cached = seq_len
+            t = torch.arange(x.shape[seq_dim], device=x.device).type_as(self.inv_freq)
+            freqs = torch.einsum('i,j->ij', t, self.inv_freq)
+            emb = torch.cat((freqs, freqs), dim=-1)
+            self.cos_cached = emb.cos()[:, None, ...].permute((2, 0, 1, 3))
+            self.sin_cached = emb.sin()[:, None, ...].permute((2, 0, 1, 3))
+        return self.cos_cached, self.sin_cached
+
+
+# rotary pos emb helpers:
+
+@torch.jit.script
+def rotate_half(x):
+    x1 = x[..., :x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2:]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+@torch.jit.script
+def apply_rotary_pos_emb(q, k, cos, sin):
+    q = (q * cos) + (rotate_half(q) * sin)
+    k = (k * cos) + (rotate_half(k) * sin)
+    return q, k

--- a/megatron/model/positional_embeddings.py
+++ b/megatron/model/positional_embeddings.py
@@ -42,12 +42,9 @@ class RotaryEmbedding(MegatronModule):
 
 @torch.jit.script
 def rotate_half(x):
-    x1 = x[..., :x.shape[-1] // 2]
-    x2 = x[..., x.shape[-1] // 2:]
+    x1, x2 = x[..., :x.shape[-1] // 2], x[..., x.shape[-1] // 2:]
     return torch.cat((-x2, x1), dim=x1.ndim - 1) # dim=-1 triggers a bug in earlier torch versions
 
 @torch.jit.script
 def apply_rotary_pos_emb(q, k, cos, sin):
-    q = (q * cos) + (rotate_half(q) * sin)
-    k = (k * cos) + (rotate_half(k) * sin)
-    return q, k
+    return (q * cos) + (rotate_half(q) * sin), (k * cos) + (rotate_half(k) * sin)

--- a/megatron/model/positional_embeddings.py
+++ b/megatron/model/positional_embeddings.py
@@ -40,11 +40,13 @@ class RotaryEmbedding(MegatronModule):
 # rotary pos emb helpers:
 # we should be able to torch.jit.script these but we get a weird bug
 
+@torch.jit.script
 def rotate_half(x):
     x1 = x[..., :x.shape[-1] // 2]
     x2 = x[..., x.shape[-1] // 2:]
-    return torch.cat((-x2, x1), dim=-1)
+    return torch.cat((-x2, x1), dim=x1.ndim - 1) # dim=-1 triggers a bug in earlier torch versions
 
+@torch.jit.script
 def apply_rotary_pos_emb(q, k, cos, sin):
     q = (q * cos) + (rotate_half(q) * sin)
     k = (k * cos) + (rotate_half(k) * sin)

--- a/megatron/model/positional_embeddings.py
+++ b/megatron/model/positional_embeddings.py
@@ -17,6 +17,7 @@ class SinusoidalPositionalEmbedding(MegatronModule):
 
 
 class RotaryEmbedding(MegatronModule):
+    
     def __init__(self, dim, theta=10000):
         super().__init__()
         inv_freq = 1. / (theta ** (torch.arange(0, dim, 2).float() / dim))
@@ -38,7 +39,6 @@ class RotaryEmbedding(MegatronModule):
 
 
 # rotary pos emb helpers:
-# we should be able to torch.jit.script these but we get a weird bug
 
 @torch.jit.script
 def rotate_half(x):

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -202,7 +202,7 @@ class ParallelSelfAttention(MegatronModule):
 
         self.rpe = rpe
         if rotary:
-            self.rotary_emb = RotaryEmbedding(self.hidden_size_per_attention_head, theta=args.rotary_emb_theta)
+            self.rotary_emb = RotaryEmbedding(self.hidden_size_per_attention_head, base=args.rotary_emb_base)
         else:
             self.rotary_emb = None
 

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -31,9 +31,10 @@ from megatron.model.fused_softmax import FusedScaleMaskSoftmax
 from megatron.model.fused_bias_gelu import bias_gelu_impl
 from megatron.model.utils import openai_gelu, erf_gelu, exists
 from megatron.mpu import ParallelRelativePositionBias
+from megatron.model.positional_embeddings import SinusoidalPositionalEmbedding, RotaryEmbedding, apply_rotary_pos_emb
+
 import deepspeed
 from deepspeed.ops.sparse_attention import SparseSelfAttention, VariableSparsityConfig
-from einops import rearrange, repeat
 
 # flags required to enable jit fusion kernels
 torch._C._jit_set_profiling_mode(False)
@@ -61,36 +62,6 @@ torch._C._jit_override_can_fuse_on_gpu(True)
                masked-attention-scores = attention_mask_func(
                                      unmaksed-attention-scores, attention-mask)
 """
-
-class SinusoidalPositionalEmbedding(MegatronModule):
-    def __init__(self, dim):
-        super().__init__()
-        inv_freq = 1. / (10000 ** (torch.arange(0, dim, 2).float() / dim))
-        self.register_buffer('inv_freq', inv_freq)
-
-    def forward(self, x, seq_dim=1):
-        t = torch.arange(x.shape[seq_dim], device=x.device).type_as(self.inv_freq)
-        sinusoid_inp = torch.einsum("i,j->ij", t, self.inv_freq)
-        emb = torch.cat((sinusoid_inp.sin(), sinusoid_inp.cos()), dim=-1)
-        return emb[None, :, :]
-
-## rotary pos emb helpers: 
-
-def rotate_every_two(x):
-    x = rearrange(x, '... (d j) -> ... d j', j=2)
-    x1, x2 = x.unbind(dim=-1)
-    x = torch.stack((-x2, x1), dim=-1)
-    return rearrange(x, '... d j -> ... (d j)')
-
-
-def apply_rotary_pos_emb(q, k, sinu_pos):
-    # TODO: get rid of these premutes if poss
-    q, k = map(lambda t: t.permute(1, 2, 0, 3), (q, k))
-    sinu_pos = rearrange(sinu_pos, '() n (j d) -> n j d', j=2)
-    sin, cos = sinu_pos.unbind(dim=-2)
-    sin, cos = map(lambda t: repeat(t, 'b n -> b (n j)', j=2), (sin, cos))
-    q, k = map(lambda t: (t * cos) + (rotate_every_two(t) * sin), (q, k))
-    return map(lambda t: t.permute(2, 0, 1, 3), (q, k))
 
 
 class GEGLU(MegatronModule):
@@ -196,7 +167,7 @@ class ParallelSelfAttention(MegatronModule):
 
     def __init__(self, attention_mask_func, init_method,
                  output_layer_init_method, layer_number, sparse=False,
-                 rpe=None):
+                 rpe=None, rotary=False):
         super(ParallelSelfAttention, self).__init__()
         args = get_args()
         self.fp16 = args.fp16
@@ -230,6 +201,10 @@ class ParallelSelfAttention(MegatronModule):
             self.norm_factor *= coeff
 
         self.rpe = rpe
+        if rotary:
+            self.rotary_emb = RotaryEmbedding(self.hidden_size_per_attention_head, theta=10000)
+        else:
+            self.rotary_emb = None
 
         self.sparse = sparse
         if self.sparse:
@@ -306,7 +281,7 @@ class ParallelSelfAttention(MegatronModule):
 
         return mixed_layer
 
-    def forward(self, hidden_states, attention_mask, rotary_pos_emb=None, layer_past=None,
+    def forward(self, hidden_states, attention_mask, layer_past=None,
                 get_key_value=False):
         # hidden_states: [sq, b, h]
 
@@ -337,8 +312,9 @@ class ParallelSelfAttention(MegatronModule):
          key_layer,
          value_layer) = mpu.split_tensor_along_last_dim(mixed_x_layer, 3)
 
-        if exists(rotary_pos_emb):
-            query_layer, key_layer = apply_rotary_pos_emb(query_layer, key_layer, rotary_pos_emb)
+        if exists(self.rotary_emb):
+            cos, sin = self.rotary_emb(query_layer, seq_dim=0)
+            query_layer, key_layer = apply_rotary_pos_emb(query_layer, key_layer, cos, sin)
 
         # ==================================
         # Adjust key and value for inference
@@ -514,7 +490,7 @@ class ParallelTransformerLayer(MegatronModule):
     """
 
     def __init__(self, attention_mask_func, init_method,
-                 output_layer_init_method, layer_number, sparse=False, rpe=None):
+                 output_layer_init_method, layer_number, sparse=False, rpe=None, rotary=False):
         args = get_args()
 
         super(ParallelTransformerLayer, self).__init__()
@@ -543,7 +519,8 @@ class ParallelTransformerLayer(MegatronModule):
                                                output_layer_init_method,
                                                layer_number,
                                                sparse=sparse,
-                                               rpe=rpe)
+                                               rpe=rpe,
+                                               rotary=rotary)
         self.hidden_dropout = args.hidden_dropout
         self.bias_dropout_fusion = args.bias_dropout_fusion
 
@@ -556,7 +533,7 @@ class ParallelTransformerLayer(MegatronModule):
         self.mlp = ParallelMLP(init_method,
                                output_layer_init_method)
 
-    def forward(self, hidden_states, attention_mask, rotary_pos_emb=None, layer_past=None,
+    def forward(self, hidden_states, attention_mask, layer_past=None,
                 get_key_value=False):
         # hidden_states: [b, s, h]
 
@@ -566,7 +543,6 @@ class ParallelTransformerLayer(MegatronModule):
         attention_output, attention_bias = \
             self.attention(layernorm_output,
                            attention_mask,
-                           rotary_pos_emb=rotary_pos_emb,
                            layer_past=layer_past,
                            get_key_value=get_key_value)
 
@@ -631,10 +607,8 @@ class ParallelTransformerLayerPipe(ParallelTransformerLayer):
     def forward(self, args):
         if len(args) == 2:
             hidden_states, attention_mask = args
-        elif len(args) == 3:
-            hidden_states, rotary_pos_emb, attention_mask = args
-            args = hidden_states, attention_mask, rotary_pos_emb
-            return super().forward(*args), rotary_pos_emb, attention_mask
+        else:
+            raise ValueError(f'Incorrect number of args in {self.__class__.__name__}')
         return super().forward(*args), attention_mask
 
 
@@ -678,7 +652,9 @@ class ParallelTransformer(MegatronModule):
                 raise ValueError(f'Sparsity type {sparsity} not recognized')
             return ParallelTransformerLayer(
                 attention_mask_func, init_method,
-                output_layer_init_method, layer_number, sparse=sparse, rpe=rpe_emb if args.pos_emb == 'rpe' else None)
+                output_layer_init_method, layer_number, sparse=sparse,
+                rpe=rpe_emb if args.pos_emb == 'rpe' else None,
+                rotary=args.pos_emb == 'rotary')
 
         self.layers = torch.nn.ModuleList(
             [build_layer(i + 1) for i in range(self.num_unique_layers)])
@@ -746,7 +722,7 @@ class ParallelTransformer(MegatronModule):
 
         return hidden_states
 
-    def forward(self, hidden_states, attention_mask, rotary_pos_emb=None, layer_past=None,
+    def forward(self, hidden_states, attention_mask, layer_past=None,
                 get_key_value=False):
 
         # Checks
@@ -776,8 +752,7 @@ class ParallelTransformer(MegatronModule):
                 hidden_states = layer(hidden_states,
                                       attention_mask,
                                       layer_past=past,
-                                      get_key_value=get_key_value,
-                                      rotary_pos_emb=rotary_pos_emb)
+                                      get_key_value=get_key_value)
                 if get_key_value:
                     hidden_states, present = hidden_states
                     presents.append(present)
@@ -813,7 +788,6 @@ class Embedding(MegatronModule):
                  max_sequence_length,
                  embedding_dropout_prob,
                  init_method,
-                 rotary_pos_emb=False,
                  num_tokentypes=0):
         super(Embedding, self).__init__()
         args = get_args()
@@ -836,9 +810,6 @@ class Embedding(MegatronModule):
             self.init_method(self.position_embeddings.weight)
         elif self.embedding_type == "sinusoidal":
             self.position_embeddings = SinusoidalPositionalEmbedding(self.hidden_size)
-        elif self.embedding_type == 'rotary':
-            hidden_size_per_attention_head = mpu.divide(args.hidden_size, args.num_attention_heads)
-            self.rotary_pos_emb = SinusoidalPositionalEmbedding(hidden_size_per_attention_head)
 
         # Token type embedding.
         # Add this as an optional field that can be added through
@@ -880,9 +851,6 @@ class Embedding(MegatronModule):
             embeddings = words_embeddings + position_embeddings
         else:
             embeddings = words_embeddings
-        if self.embedding_type == 'rotary':
-            rotary_pos_emb = self.rotary_pos_emb(words_embeddings, seq_dim=1)
-            embeddings = words_embeddings
         if tokentype_ids is not None:
             assert self.tokentype_embeddings is not None
             embeddings = embeddings + self.tokentype_embeddings(tokentype_ids)
@@ -891,10 +859,7 @@ class Embedding(MegatronModule):
 
         # Dropout.
         embeddings = self.embedding_dropout(embeddings)
-        if self.embedding_type == 'rotary':
-            return embeddings, rotary_pos_emb
-        else:
-            return embeddings
+        return embeddings
 
     def state_dict_for_save_checkpoint(self, destination=None, prefix='',
                                        keep_vars=False):
@@ -979,8 +944,4 @@ class EmbeddingPipe(Embedding):
             tokentype_ids = None
 
         embeddings = super().forward(input_ids, position_ids, tokentype_ids=tokentype_ids)
-        if self.embedding_type == 'rotary':
-            embeddings, rotary_pos_emb = embeddings
-            return embeddings, rotary_pos_emb, attention_mask
-        else:
-            return embeddings, attention_mask
+        return embeddings, attention_mask

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -202,7 +202,7 @@ class ParallelSelfAttention(MegatronModule):
 
         self.rpe = rpe
         if rotary:
-            self.rotary_emb = RotaryEmbedding(self.hidden_size_per_attention_head, theta=10000)
+            self.rotary_emb = RotaryEmbedding(self.hidden_size_per_attention_head, theta=args.rotary_emb_theta)
         else:
             self.rotary_emb = None
 


### PR DESCRIPTION
This should bring rotary up to almost the same speeds as learned embeddings, remove permutations and fix rotary + pipeline parallel, which wasn't working previously.

Also some mild reorganisation + added rotary pos emb 'base' as a configurable argument.

tests on a small model:
rotary old = pink, rotary new = purple, learned = orange
![Screenshot from 2021-04-18 22-34-15](https://user-images.githubusercontent.com/46172032/115160021-4e0dd500-a096-11eb-8a3d-96718120d706.png)
![Screenshot from 2021-04-18 22-34-03](https://user-images.githubusercontent.com/46172032/115160022-4ea66b80-a096-11eb-80f2-36ed0cd41eaf.png)
