### PR TITLE
Refactor how we configure sparsity 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,4 @@ test_checkpoint/
 test_logs/
 logs/
 tensorboard/
+src/

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ You can also optionally pass in a config prefix, which will assume all your conf
 Example usage:
 
 ```bash
-./deepy.py pretrain_gpt2.py -d configs small_1.yml local_setup.yml
+./deepy.py pretrain_gpt2.py -d configs small.yml local_setup.yml
 ```
 
 This will deploy the `pretrain_gpt2.py` script on all nodes with one process per GPU. The worker nodes and number of GPUs are specified in the `/job/hostfile` file (see [parameter documentation](configs)), or can simply be passed in as the `num_gpus` arg if running on a single node setup.

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ You can also optionally pass in a config prefix, which will assume all your conf
 Example usage:
 
 ```bash
-./deepy.py pretrain_gpt2.py -d configs small.yml local_setup.yml
+./deepy.py pretrain_gpt2.py -d configs small_1.yml local_setup.yml
 ```
 
 This will deploy the `pretrain_gpt2.py` script on all nodes with one process per GPU. The worker nodes and number of GPUs are specified in the `/job/hostfile` file (see [parameter documentation](configs)), or can simply be passed in as the `num_gpus` arg if running on a single node setup.

--- a/configs/sparse.yml
+++ b/configs/sparse.yml
@@ -1,0 +1,13 @@
+# Add this to your config for sparse attention every other layer
+{
+  "attention_config": [[["global", "sparse_variable"], "all"]],
+  # sparse attention config (these are the defaults, training will work without this here, but it's left in for
+  # illustrative purposes)
+  "sparsity_config": {
+    "block": 16, # block size
+    "different_layout_per_head": false,
+    "num_global_blocks": 1, # "local" in the attention config defaults this to zero - otherwise the value here is respected
+    "num_local_blocks": 4, # number of local blocks. If local attention only, local window size = block * num_local_blocks
+    "num_random_blocks": 1, # 0 = no randomness
+  }
+}

--- a/configs/sparse.yml
+++ b/configs/sparse.yml
@@ -1,16 +1,15 @@
 # Add this to your config for sparse attention every other layer
 {
-  "attention_config": [[["sparse_variable", "global"], "all"]],
+  "attention_config": [[["local"], "all"]],
 
   # sparsity config:
-  # (these are the defaults for variable sparsity, training will work without this here, but it's left in for
+  # (these are the defaults for local sliding window sparsity, training will work without this here, but it's left in for
   # illustrative purposes)
   # see https://www.deepspeed.ai/tutorials/sparse-attention/#how-to-config-sparsity-structures for
   # more detailed config instructions and available parameters
 
   "sparsity_config": {
     "block": 16, # block size
-    "different_layout_per_head": false,
-    "num_random_blocks": 0, # 0 = no randomness
+    "num_local_blocks": 32,
   }
 }

--- a/configs/sparse.yml
+++ b/configs/sparse.yml
@@ -1,13 +1,16 @@
 # Add this to your config for sparse attention every other layer
 {
-  "attention_config": [[["global", "sparse_variable"], "all"]],
-  # sparse attention config (these are the defaults, training will work without this here, but it's left in for
+  "attention_config": [[["sparse_variable", "global"], "all"]],
+
+  # sparsity config:
+  # (these are the defaults for variable sparsity, training will work without this here, but it's left in for
   # illustrative purposes)
+  # see https://www.deepspeed.ai/tutorials/sparse-attention/#how-to-config-sparsity-structures for
+  # more detailed config instructions and available parameters
+
   "sparsity_config": {
     "block": 16, # block size
     "different_layout_per_head": false,
-    "num_global_blocks": 1, # "local" in the attention config defaults this to zero - otherwise the value here is respected
-    "num_local_blocks": 4, # number of local blocks. If local attention only, local window size = block * num_local_blocks
-    "num_random_blocks": 1, # 0 = no randomness
+    "num_random_blocks": 0, # 0 = no randomness
   }
 }

--- a/megatron/model/gpt2_model.py
+++ b/megatron/model/gpt2_model.py
@@ -152,12 +152,6 @@ class GPT2ModelPipe(PipelineModule, torch.nn.Module):
 
         # Transformer layers
         for x in range(self.neox_args.num_layers):
-            if self.neox_args.sparsity == 'none':
-                sparse = False
-            elif self.neox_args.sparsity == 'all':
-                sparse = True
-            elif self.neox_args.sparsity == 'interspersed':
-                sparse = not x % 2 == 0
             self.specs.append(
                 LayerSpec(
                     ParallelTransformerLayerPipe,
@@ -166,7 +160,6 @@ class GPT2ModelPipe(PipelineModule, torch.nn.Module):
                     init_method=self.init_method,
                     output_layer_init_method=self.output_layer_init_method,
                     layer_number=x,
-                    sparse=sparse,
                     rpe=rpe_emb if self.neox_args.pos_emb == 'rpe' else None,
                     rotary=self.neox_args.pos_emb == 'rotary',
                     get_key_value=self.get_key_value

--- a/megatron/model/utils.py
+++ b/megatron/model/utils.py
@@ -21,6 +21,8 @@
 import math
 
 import torch
+from deepspeed.ops.sparse_attention import SparseSelfAttention, VariableSparsityConfig, \
+    FixedSparsityConfig
 
 
 def init_method_normal(sigma):
@@ -161,3 +163,41 @@ class SequentialWrapper(torch.nn.Module):
                 else:
                     x = exec_range_func(start_idx, end_idx)(*x)
         return x
+
+
+def configure_sparse_attention(neox_args, attention_type, num_attention_heads, mpu):
+    if attention_type in ["sparse_fixed", "local"]:
+        # local attention = FixedSparsityConfig with no global blocks
+        num_global_blocks = neox_args.sparsity_config.get("num_global_blocks", 1) if \
+            attention_type == "sparse_fixed" else 0
+        # you can think of local window size as `block_size` * `num_local_blocks`.
+        # so if you wanted to set a local window size of 256, set block size to 16 and `num_local_blocks` to 16
+        sparsity_config = FixedSparsityConfig(
+            num_heads=num_attention_heads,
+            block=neox_args.sparsity_config.get("block", 16),
+            different_layout_per_head=neox_args.sparsity_config.get("different_layout_per_head", False),
+            num_local_blocks=neox_args.sparsity_config.get("num_local_blocks", 4),
+            num_global_blocks=num_global_blocks,
+            num_different_global_patterns=neox_args.sparsity_config.get("num_different_global_patterns", 1),
+            attention='unidirectional',
+            horizontal_global_attention=False,
+        )
+    elif attention_type == "sparse_variable":
+        sparsity_config = VariableSparsityConfig(
+            num_heads=num_attention_heads,
+            block=neox_args.sparsity_config.get("block", 16),
+            different_layout_per_head=neox_args.sparsity_config.get("different_layout_per_head", False),
+            num_random_blocks=neox_args.sparsity_config.get("num_random_blocks", 0),
+            local_window_blocks=neox_args.sparsity_config.get("local_window_blocks", [4]),
+            global_block_indices=neox_args.sparsity_config.get("global_block_indices", [0]),
+            global_block_end_indices=neox_args.sparsity_config.get("global_block_end_indices", None),
+            attention="unidirectional",
+            horizontal_global_attention=False,
+        )
+    else:
+        raise ValueError(f"Attention type {attention_type} not recognized")
+    return SparseSelfAttention(
+        sparsity_config=sparsity_config,
+        max_seq_length=neox_args.seq_length,
+        attn_mask_mode='add',
+        mpu=mpu)

--- a/megatron/model/utils.py
+++ b/megatron/model/utils.py
@@ -21,8 +21,8 @@
 import math
 
 import torch
-from deepspeed.ops.sparse_attention import SparseSelfAttention, VariableSparsityConfig, \
-    FixedSparsityConfig, LocalSlidingWindowSparsityConfig
+from deepspeed.ops.sparse_attention import SparseSelfAttention, VariableSparsityConfig, FixedSparsityConfig
+from deepspeed.ops.sparse_attention.sparsity_config import LocalSlidingWindowSparsityConfig
 
 
 def init_method_normal(sigma):

--- a/megatron/neox_arguments/arguments.py
+++ b/megatron/neox_arguments/arguments.py
@@ -14,10 +14,10 @@ from typing import Literal, Dict
 from deepspeed.launcher.runner import DLTS_HOSTFILE
 from megatron.logging import Tee
 from megatron.tokenizer import build_tokenizer
-from megatron.utils import obtain_resource_pool
+from megatron.utils import obtain_resource_pool, expand_attention_types
 from .deepspeed_args import NeoXArgsDeepspeedConfig, NeoXArgsDeepspeedRunner
 from .neox_args import NeoXArgsModel, NeoXArgsTokenizer, NeoXArgsTraining, NeoXArgsParallelism, \
-    NeoXArgsLogging, NeoXArgsOther, NeoXArgsTextgen, NeoXArgsOptimizer, NeoXArgsLRScheduler
+    NeoXArgsLogging, NeoXArgsOther, NeoXArgsTextgen, NeoXArgsOptimizer, NeoXArgsLRScheduler, ATTENTION_TYPE_CHOICES
 
 # ZERO defaults by deespeed
 # These values should not be changed unless defaults in deepspeed are changed
@@ -581,6 +581,14 @@ class NeoXArgs(*BASE_CLASSES):
         # if we set pipe_parallel_size to 0 or 1, GPT2ModelPipe.to_sequential() is called, and we run training with
         # the sequential model without the PipelineModule wrapper to avoid the overhead it incurs
         self.update_value("is_pipe_parallel", self.pipe_parallel_size >= 1)
+
+        # Attention config
+        if self.attention_config is None:
+            self.update_value("attention_config", [[["global"], self.num_layers]])
+        self.update_value("attention_config", expand_attention_types(self.attention_config))
+        assert len(self.attention_config) == self.num_layers, "Length of attention config list must equal num_layers"
+        for item in self.attention_config:
+            assert item in ATTENTION_TYPE_CHOICES, f"Attention type {item} not recognized"
 
     ############################################################################################################################
     # start of validation functions

--- a/megatron/neox_arguments/arguments.py
+++ b/megatron/neox_arguments/arguments.py
@@ -585,10 +585,15 @@ class NeoXArgs(*BASE_CLASSES):
         # Attention config
         if self.attention_config is None:
             self.update_value("attention_config", [[["global"], self.num_layers]])
-        self.update_value("attention_config", expand_attention_types(self.attention_config))
+        self.update_value("attention_config", expand_attention_types(self.attention_config, self.num_layers))
         assert len(self.attention_config) == self.num_layers, "Length of attention config list must equal num_layers"
         for item in self.attention_config:
             assert item in ATTENTION_TYPE_CHOICES, f"Attention type {item} not recognized"
+
+        # Sparsity config
+        if self.sparsity_config is None:
+            # Can't have a default value as an empty dict so need to set it here
+            self.update_value("sparsity_config", {})
 
     ############################################################################################################################
     # start of validation functions

--- a/megatron/neox_arguments/neox_args.py
+++ b/megatron/neox_arguments/neox_args.py
@@ -3,6 +3,9 @@ from dataclasses import dataclass
 from .template import NeoXArgsTemplate
 from typing import Literal
 
+ATTENTION_TYPE_CHOICES = ['global', 'local', 'sparse_fixed', 'sparse_variable',
+                          'bigbird', 'bslongformer']
+
 
 def get_git_commit_hash():
     """ Gets the git commit hash of your current repo (if it exists) """
@@ -120,9 +123,55 @@ class NeoXArgsModel(NeoXArgsTemplate):
     Enable geglu activation function (WARNING: will increase memory usage, adjust embd dims accordingly)
     """
 
-    sparsity: Literal['all', 'interspersed', 'none'] = "none"
+    attention_config: list = None
+
     """
-    Sparse attention layer configuration: none = all regular attn, all = all sparse attn, interspersed = sparse on odd layers, dense on even.
+    Attention configuration for gpt-neox
+    
+    The first item in the list specifies the attention type(s), and should be a list of strings. The second item 
+    specifies the number of times to repeat those attention types in the full list.
+    
+    attention type choices:  [global, local (`sparse_fixed` with no global tokens), sparse_fixed, sparse_variable, 
+                                bigbird, bslongformer]
+                                
+    So a 12 layer network with only global attention could be specified like:
+        [[[`global`], 12]]
+        
+    or a 12 layer network with alternating global / local like:
+        [[[`global`, `local`], 6]]
+        
+    If none is specified, this defaults to
+        [[[`global`], n_layers]]
+    """
+
+    sparsity_config: dict = None
+
+    """
+    Sparsity configuration dict as defined in https://www.deepspeed.ai/docs/config-json/#sparse-attention
+    
+    Note that since neox is autoregressive, attention is always "unidirectional" and `horizontal_global_attention` is 
+    always false.
+    
+    There are two main differences between our sparsity config and deepspeed's: 
+    
+        - Unless specified, `num_random_blocks` in `bigbird` defaults to 1 - since that is the core thesis of the paper,
+          but in `variable` it defaults to 0.
+    
+        - `mode` is ignored - since it is instead specified in the attention config defining each layer.
+    
+    An example config is given below:
+          "sparse_attention": {
+            "block": 16,
+            "different_layout_per_head": true,
+            "num_local_blocks": 4,
+            "num_global_blocks": 1,
+            "num_different_global_patterns": 4,
+            "num_random_blocks": 0,
+            "local_window_blocks": [4],
+            "global_block_indices": [0],
+            "global_block_end_indices": None,
+            "num_sliding_window_blocks": 3
+          }
     """
 
     num_unique_layers: int = None
@@ -279,7 +328,6 @@ class NeoXArgsLRScheduler(NeoXArgsTemplate):
 
 @dataclass
 class NeoXArgsLogging(NeoXArgsTemplate):
-
     use_wandb: bool = None
     """Flag indicating if wandb is to be used."""
 
@@ -465,7 +513,7 @@ class NeoXArgsTokenizer(NeoXArgsTemplate):
     as it's dependent on the parallelism size.
     """
 
-    tokenizer =  None
+    tokenizer = None
     """
     tokenizer object loaded into memory and accesible by other functions
     """

--- a/megatron/neox_arguments/neox_args.py
+++ b/megatron/neox_arguments/neox_args.py
@@ -150,12 +150,8 @@ class NeoXArgsModel(NeoXArgsTemplate):
     Note that since neox is autoregressive, attention is always "unidirectional" and `horizontal_global_attention` is 
     always false.
     
-    There are two main differences between our sparsity config and deepspeed's: 
-    
-        - Unless specified, `num_random_blocks` in `bigbird` defaults to 1 - since that is the core thesis of the paper,
-          but in `variable` it defaults to 0.
-    
-        - `mode` is ignored - since it is instead specified in the attention config defining each layer.
+    The main difference between our sparsity config and deepspeed's is that `mode` is ignored - since it is instead 
+    specified in attention_config defining each layer.
     
     An example config is given below:
           "sparse_attention": {

--- a/megatron/neox_arguments/neox_args.py
+++ b/megatron/neox_arguments/neox_args.py
@@ -3,8 +3,7 @@ from dataclasses import dataclass
 from .template import NeoXArgsTemplate
 from typing import Literal
 
-ATTENTION_TYPE_CHOICES = ['global', 'local', 'sparse_fixed', 'sparse_variable',
-                          'bigbird', 'bslongformer']
+ATTENTION_TYPE_CHOICES = ['global', 'local', 'sparse_fixed', 'sparse_variable']
 
 
 def get_git_commit_hash():
@@ -131,8 +130,7 @@ class NeoXArgsModel(NeoXArgsTemplate):
     The first item in the list specifies the attention type(s), and should be a list of strings. The second item 
     specifies the number of times to repeat those attention types in the full list.
     
-    attention type choices:  [global, local (`sparse_fixed` with no global tokens), sparse_fixed, sparse_variable, 
-                                bigbird, bslongformer]
+    attention type choices:  [global, local (`sparse_fixed` with no global tokens), sparse_fixed, sparse_variable]
                                 
     So a 12 layer network with only global attention could be specified like:
         [[[`global`], 12]]

--- a/megatron/utils.py
+++ b/megatron/utils.py
@@ -71,7 +71,8 @@ def check_adlr_autoresume_termination(neox_args, iteration, model, optimizer, lr
     torch.distributed.barrier()
     if neox_args.adlr_autoresume_object.termination_requested():
         if neox_args.save:
-            save_checkpoint(neox_args=neox_args, iteration=iteration, model=model, optimizer=optimizer, lr_scheduler=lr_scheduler)
+            save_checkpoint(neox_args=neox_args, iteration=iteration, model=model, optimizer=optimizer,
+                            lr_scheduler=lr_scheduler)
         print_rank_0(">>> autoresume termination request found!")
         if torch.distributed.get_rank() == 0:
             neox_args.adlr_autoresume_object.request_resume()
@@ -171,6 +172,7 @@ def local_rank():
         local_rank = 0
     return int(local_rank)
 
+
 def is_local_main():
     """ True if is the local main process """
     return local_rank() == 0
@@ -191,11 +193,12 @@ def get_wandb_api_key():
     if wandb_token is not None:
         return wandb_token[1]
 
+
 def init_wandb(neox_args):
     # Wandb. (one worker per machine)
     if neox_args.use_wandb == False:
         return
-    
+
     use_wandb = is_local_main() and (get_wandb_api_key() is not None)
     neox_args.update_value("use_wandb", use_wandb)
     if neox_args.use_wandb:
@@ -209,6 +212,7 @@ def init_wandb(neox_args):
             print(e)
             print('Skipping wandb. Execute `wandb login` on local or main node machine to enable.', flush=True)
         wandb.config.update(neox_args.all_config)
+
 
 def obtain_resource_pool(hostfile_path, include_arg, exclude_arg) -> Dict[str, List[int]]:
     """
@@ -255,7 +259,6 @@ def ddb(rank=0):
         pdb = Pdb(skip=["torch.distributed.*"])
         pdb.set_trace(sys._getframe().f_back)
     torch.distributed.barrier()
-
 
 
 class Timer:
@@ -345,3 +348,25 @@ class Timers:
         else:
             print(string, flush=True)
 
+
+def expand_attention_types(attention_config):
+    """
+    Expands an `attention_config` list in the following format:
+
+        [
+        [['attention_type_1', ..., `attention_type_n`], 12]
+        ]
+
+    to a flattened list of length `num_layers`.
+
+    :param params_list:
+    :return:
+    """
+    # if only strings are found in the config, we assume it's already expanded
+    if all([isinstance(i, str) for i in attention_config]):
+        return attention_config
+    newlist = []
+    for item in attention_config:
+        for _ in range(item[1]):
+            newlist.extend(item[0])
+    return newlist

--- a/megatron/utils.py
+++ b/megatron/utils.py
@@ -349,7 +349,7 @@ class Timers:
             print(string, flush=True)
 
 
-def expand_attention_types(attention_config):
+def expand_attention_types(attention_config, num_layers):
     """
     Expands an `attention_config` list in the following format:
 
@@ -367,6 +367,11 @@ def expand_attention_types(attention_config):
         return attention_config
     newlist = []
     for item in attention_config:
+        # instead of specifying a number - we can specify 'all' to extend this pattern across all layers
+        if item[1] == "all":
+            assert num_layers % len(item[0]) == 0, f"Number of layers ({num_layers}) is not divisible by the length " \
+                                                   f"of pattern: {item[0]}"
+            return item[0] * (num_layers // len(item[0]))
         for _ in range(item[1]):
             newlist.extend(item[0])
     return newlist

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,7 +2,7 @@ pybind11==2.6.2
 six
 regex
 numpy==1.20.2
--e git+git://github.com/EleutherAI/DeeperSpeed.git@750f2140bf782cffeb578ce14a4e4cdb076f4326#egg=deepspeed
+-e git+git://github.com/EleutherAI/DeeperSpeed.git@311de8b82456da81998c14f33a07d73436cf11be#egg=deepspeed
 mpi4py==3.0.3
 wandb==0.10.28
 einops==0.3.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,7 +2,7 @@ pybind11==2.6.2
 six
 regex
 numpy==1.20.2
--e git+git://github.com/EleutherAI/DeeperSpeed.git@311de8b82456da81998c14f33a07d73436cf11be#egg=deepspeed
+-e git+git://github.com/EleutherAI/DeeperSpeed.git@73dfe6b1ae6209a4195defcc271866986337e95b#egg=deepspeed
 mpi4py==3.0.3
 wandb==0.10.28
 einops==0.3.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,7 +2,7 @@ pybind11==2.6.2
 six
 regex
 numpy==1.20.2
--e git+git://github.com/EleutherAI/DeeperSpeed.git@73dfe6b1ae6209a4195defcc271866986337e95b#egg=deepspeed
+-e git+git://github.com/EleutherAI/DeeperSpeed.git@353387d794b4083f4333b717b90862cb3d6bc53b#egg=deepspeed
 mpi4py==3.0.3
 wandb==0.10.28
 einops==0.3.0

--- a/tests/model/test_configs/test_sparse.yml
+++ b/tests/model/test_configs/test_sparse.yml
@@ -1,0 +1,15 @@
+# Add this to your config for sparse attention every other layer
+{
+  "attention_config": [[["local"], "all"]],
+
+  # sparsity config:
+  # (these are the defaults for local sliding window sparsity, training will work without this here, but it's left in for
+  # illustrative purposes)
+  # see https://www.deepspeed.ai/tutorials/sparse-attention/#how-to-config-sparsity-structures for
+  # more detailed config instructions and available parameters
+
+  "sparsity_config": {
+    "block": 16, # block size
+    "num_local_blocks": 32,
+  }
+}

--- a/tests/model/test_model_instantiation.py
+++ b/tests/model/test_model_instantiation.py
@@ -60,8 +60,10 @@ class TestModelInstantiation(unittest.TestCase):
     def test_model_instantiation_medium_test(self):
         self.run_instantiation_test(get_test_configs_with_path(["test_local_setup.yml", "test_medium.yml"]), DeepSpeedEngine)
 
+    def test_model_instantiation_small_sparse_test(self):
+        self.run_instantiation_test(get_test_configs_with_path(["test_local_setup.yml", "test_small.yml", "test_sparse.yml"]), DeepSpeedEngine)
+
 if __name__ == "__main__":
     suite = unittest.TestSuite()
-    suite.addTest(TestModelInstantiation("test_model_instantiation_small_test"))
-    suite.addTest(TestModelInstantiation("test_model_instantiation_medium_test"))
+    suite.addTest(TestModelInstantiation("test_model_instantiation_small_sparse_test"))
     unittest.TextTestRunner(failfast=True).run(suite)

--- a/tests/neox_args/test_neoxargs_usage.py
+++ b/tests/neox_args/test_neoxargs_usage.py
@@ -24,7 +24,7 @@ class TestNeoXArgsArgumentUsage(unittest.TestCase):
         neox_args_attributes = set(NeoXArgs.__dataclass_fields__.keys())
 
         # we exlude a number of properties (implemented with the @property decorator) or functions that we know exists
-        exclude = set(['params_dtype', 'deepspeed_config', 'get', 'pop', 'get_deepspeed_main_args', 'optimizer["params"]', 'adlr_autoresume_object', 'update_value', 'all_config', 'tensorboard_writer', 'tokenizer'])
+        exclude = set(['params_dtype', 'deepspeed_config', 'get', 'pop', 'get_deepspeed_main_args', 'optimizer["params"]', 'attention_config[layer_number]', 'adlr_autoresume_object', 'update_value', 'all_config', 'tensorboard_writer', 'tokenizer'])
 
         # test file by file
         for filename in (get_root_directory() / "megatron").glob('**/*.py'):

--- a/tests/neox_args/test_neoxargs_usage.py
+++ b/tests/neox_args/test_neoxargs_usage.py
@@ -24,7 +24,7 @@ class TestNeoXArgsArgumentUsage(unittest.TestCase):
         neox_args_attributes = set(NeoXArgs.__dataclass_fields__.keys())
 
         # we exlude a number of properties (implemented with the @property decorator) or functions that we know exists
-        exclude = set(['params_dtype', 'deepspeed_config', 'get', 'pop', 'get_deepspeed_main_args', 'optimizer["params"]', 'attention_config[layer_number]', 'adlr_autoresume_object', 'update_value', 'all_config', 'tensorboard_writer', 'tokenizer'])
+        exclude = set(['params_dtype', 'deepspeed_config', 'get', 'pop', 'get_deepspeed_main_args', 'optimizer["params"]', 'adlr_autoresume_object', 'update_value', 'all_config', 'tensorboard_writer', 'tokenizer'])
 
         # test file by file
         for filename in (get_root_directory() / "megatron").glob('**/*.py'):


### PR DESCRIPTION
- adds 'attention_config' param which inherits from neo

```
    """
    Attention configuration for gpt-neox
    
    The first item in the list specifies the attention type(s), and should be a list of strings. The second item 
    specifies the number of times to repeat those attention types in the full list.
    
    attention type choices:  [global, local (`sparse_fixed` with no global tokens), sparse_fixed, sparse_variable]
                                
    So a 12 layer network with only global attention could be specified like:
        [[[`global`], 12]]
    
    or a 12 layer network with alternating global / local like:
        [[[`global`, `local`], 6]]
    
    You can set a pattern to propagate across all layers like:
        [[[`global`, `local`], "all"]]

    If no attention_config is specified, this defaults to
        [[[`global`], n_layers]]

    """
```
- adds a `sparsity_config` param - exactly the same as the way deepspeed defines it [here]( https://www.deepspeed.ai/docs/config-json/#sparse-attention) with some minor differences

```
    """
    Sparsity configuration dict as defined in https://www.deepspeed.ai/docs/config-json/#sparse-attention
    
    Note that since neox is autoregressive, attention is always "unidirectional" and `horizontal_global_attention` is 
    always false.
    
    The main difference between our sparsity config and deepspeed's is that `mode` is ignored - since it is instead 
    specified in attention_config defining each layer.
    
    An example config is given below:
          "sparse_attention": {
            "block": 16,
            "different_layout_per_head": true,
            "num_local_blocks": 4,
            "num_global_blocks": 1,
            "num_different_global_patterns": 4,
            "num_random_blocks": 0,
            "local_window_blocks": [4],
            "global_block_indices": [0],
            "global_block_end_indices": None,
            "num_sliding_window_blocks": 3
          }
    """
```

Just adding `sparse.yml` to your deepy command should be the same as setting "sparsity": "interspersed" before.
i.e `./deepy.py pretrain_gpt2.py -d configs small local_setup sparse` 

adding `local` to the attention config is identical to adding `sparse_variable` and setting num_global_blocks to 0.

For `local` to work you need to update deeperspeed to git+git://github.com/EleutherAI/DeeperSpeed.git@311de8b82456da81998c14f33a07d73436cf11be#egg=deepspeed 