### PR TITLE
scale d_ff for equal parameter count with geglu + fix geglu bias

### DIFF
--- a/megatron/neox_arguments/neox_args.py
+++ b/megatron/neox_arguments/neox_args.py
@@ -186,7 +186,6 @@ class NeoXArgsModel(NeoXArgsTemplate):
     activation : Literal["gelu", "geglu", "relu", "softsign", "swish", "mish"] = "gelu"
     """
     Activation function to use - choose from ["gelu", "geglu", "relu", "softsign", "swish", "mish"]
-    (WARNING: Enabling geglu activation function will increase parameter count - multiply hidden dim by 2/3 to keep parameters equal.)
     """
 
     scaled_upper_triang_masked_softmax_fusion: bool = False


### PR DESCRIPTION
Fixes geglu bias to be in accordance with https://arxiv.org/pdf/2002.05202.pdf (GELU(xW+b)⊗(xV+c))

and scales down the ff dims by 2/3 so we don't need to worry about parametrizing d_ff or balancing gelu vs. geglu experiments

