### PR TITLE
Fix passing the init method to the output layer

### DIFF
--- a/megatron/model/gpt2_model.py
+++ b/megatron/model/gpt2_model.py
@@ -235,6 +235,7 @@ class GPT2ModelPipe(PipelineModule, torch.nn.Module):
                 LayerSpec(
                     ParallelLinearPipe,
                     neox_args=self.neox_args,
+                    init_method=self.output_layer_init_method,
                     parallel_output=self.parallel_output
                 )
             )


### PR DESCRIPTION
Apparently, the init method set in the configs for the final output layer (but not other layers) never got passed along. This fixes that.