### PR TITLE
save original configs with checkpoint

### DIFF
--- a/deepy.py
+++ b/deepy.py
@@ -17,9 +17,7 @@ import logging
 import os
 
 import deepspeed
-import requests
 from deepspeed.launcher.runner import main
-
 
 logging.basicConfig(level=os.environ.get("LOGLEVEL", "INFO"))
 

--- a/megatron/neox_arguments/arguments.py
+++ b/megatron/neox_arguments/arguments.py
@@ -6,6 +6,7 @@ import shortuuid
 import copy
 import torch
 import argparse
+import shutil
 
 from dataclasses import dataclass
 from typing import List
@@ -95,8 +96,6 @@ class NeoXArgs(*BASE_CLASSES):
 
         if not self.validate_values():
             raise ValueError(self.__class__.__name__ + ".__post_init__() NeoXArgs values cannot be validated")
-
-        self.save_yml()
 
     def build_tokenizer(self):
         self.tokenizer = build_tokenizer(self)
@@ -228,6 +227,21 @@ class NeoXArgs(*BASE_CLASSES):
         # load args
         neox_args = cls.from_ymls(paths_to_yml_files=conf_files, overwrite_values=overwrite_values)
 
+
+        # save a copy of yaml configs to the save directory
+        if neox_args.save is not None:
+            configs_directory = os.path.join(neox_args.save, "configs")
+            
+            # delete the configs subdirectory in save if it already exists
+            # only the latest version of the configs are stored
+            if os.path.isdir(configs_directory):
+                shutil.rmtree(configs_directory)
+
+            # create configs directory and copy config files
+            os.makedirs(configs_directory)
+            for conf_file in conf_files:
+                shutil.copy(conf_file, os.path.join(configs_directory, os.path.basename(conf_file)))
+
         return neox_args
 
     @classmethod
@@ -357,16 +371,6 @@ class NeoXArgs(*BASE_CLASSES):
             file_prefix = os.path.join(self.log_dir, hostname)
             Tee(file_prefix + '_stdout.txt', err=False)
             Tee(file_prefix + '_stderr.txt', err=True)
-
-    def save_yml(self):
-        """
-        saves the configured value to the configured save directory (if any)
-        """
-        if self.save is not None:
-            os.makedirs(self.save, exist_ok=True)
-            config_file = os.path.join(self.save, 'config.yml')
-            with open(config_file, 'w') as f:
-                json.dump(self.all_config, f, indent=4)
 
     def print(self):
         """Print arguments."""

--- a/megatron/neox_arguments/arguments.py
+++ b/megatron/neox_arguments/arguments.py
@@ -374,7 +374,7 @@ class NeoXArgs(*BASE_CLASSES):
 
     def print(self):
         """Print arguments."""
-        if self.rank == 0:
+        if self.rank == 0 or self.rank is None:
             print('-------------------- arguments --------------------', flush=True)
             str_list = []
             for arg in vars(self):


### PR DESCRIPTION
Problem: neox args could not be instantiated from configs.yml saved with the checkpoint. Reason is the exponential notation which got saved as e.g. "1e10" (instead of "1.0e10"). On load of yaml this is interpreted as string. 

Solution: copy the original config files to the checkpoint directory. This way also potential comments are not lost. Files are copied upon instantiation of neox args in deepy.py

Assumption (unchanged): only of version of config is saved. A potential history of changed configs during training is not available in the checkpoint directory.