### PR TITLE
fix blendable datasets + model parallel

### DIFF
--- a/megatron/data/data_utils.py
+++ b/megatron/data/data_utils.py
@@ -281,7 +281,6 @@ def build_train_valid_test_data_iterators(neox_args):
                 valid_ds = BlendableDataset(valid_datasets, valid_weights)
             if test_datasets:
                 test_ds = BlendableDataset(test_datasets, test_weights)
-
         else:
             # when just data_path is provided
             # split dataset into train, valid and test from data_path
@@ -354,3 +353,16 @@ def build_train_valid_test_data_iterators(neox_args):
         test_data_iterator = None
 
     return train_data_iterator, valid_data_iterator, test_data_iterator 
+
+
+def compile_helper():
+    """Compile helper function at runtime. Make sure this
+    is invoked on a single process."""
+    import os
+    import subprocess
+    path = os.path.abspath(os.path.dirname(__file__))
+    ret = subprocess.run(['make', '-C', path])
+    if ret.returncode != 0:
+        print("Making C++ dataset helpers module failed, exiting.")
+        import sys
+        sys.exit(1)

--- a/megatron/data/gpt2_dataset.py
+++ b/megatron/data/gpt2_dataset.py
@@ -118,8 +118,6 @@ def _build_index_mappings(name, data_prefix, documents, sizes,
             # sample-idx.
             start_time = time.time()
             # Use C++ implementation for speed.
-            # First compile and then import.
-            compile_helper()
             from megatron.data import helpers
             assert doc_idx.dtype == np.int32
             assert sizes.dtype == np.int32
@@ -257,14 +255,3 @@ def _build_shuffle_idx(size, np_rng):
     return shuffle_idx
 
 
-def compile_helper():
-    """Compile helper function at runtime. Make sure this
-    is invoked on a single process."""
-    import os
-    import subprocess
-    path = os.path.abspath(os.path.dirname(__file__))
-    ret = subprocess.run(['make', '-C', path])
-    if ret.returncode != 0:
-        print("Making C++ dataset helpers module failed, exiting.")
-        import sys
-        sys.exit(1)

--- a/megatron/data/helpers.cpp
+++ b/megatron/data/helpers.cpp
@@ -38,7 +38,8 @@ void build_blending_indices(py::array_t<uint8_t>& dataset_index,
 			    py::array_t<int64_t>& dataset_sample_index,
 			    const py::array_t<double>& weights,
 			    const int32_t num_datasets,
-			    const int64_t size, const bool verbose) {
+			    const int64_t size, 
+          const bool verbose) {
   /* Given multiple datasets and a weighting array, build samples
    such that it follows those wieghts.*/
 

--- a/megatron/initialize.py
+++ b/megatron/initialize.py
@@ -80,6 +80,13 @@ def initialize_megatron(neox_args, allow_no_cuda=False):
         # Autoresume.
         _init_autoresume(neox_args)
 
+
+        if neox_args.local_rank == 0:
+            # Compile dataset C++ code.
+            from megatron.data.data_utils import compile_helper
+            compile_helper()
+
+
         # Write arguments to tensorboard.
         _write_args_to_tensorboard(neox_args=neox_args)
         # No continuation function

--- a/megatron/initialize.py
+++ b/megatron/initialize.py
@@ -80,12 +80,10 @@ def initialize_megatron(neox_args, allow_no_cuda=False):
         # Autoresume.
         _init_autoresume(neox_args)
 
-
+        # Compile dataset C++ code.
         if neox_args.local_rank == 0:
-            # Compile dataset C++ code.
             from megatron.data.data_utils import compile_helper
             compile_helper()
-
 
         # Write arguments to tensorboard.
         _write_args_to_tensorboard(neox_args=neox_args)


### PR DESCRIPTION
blendable datasets were hanging when mp > 1 due to the barrier in blendable_dataset.py 
This should fix that, and also moves `compile_helpers` to initialize_megatron so it only runs once 