### PR TITLE
fix(readme): add missing contributors v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ If you have found GPT-Neo helpful in your work, you can cite this repository as
 
 ```
 @software{gpt-neo,
-  author = {Andonian, Alex and Biderman, Stella and Black, Sid and Gali, Preetham and Gao, Leo and Hallahan, Eric and Levy-Kramer, Josh and Leahy, Connor and Parker, Kip and Pieler, Michael and Purohit, Shivanshu and Wang, Phil and Weinbach, Samuel},
+  author = {Andonian, Alex and Biderman, Stella and Black, Sid and Gali, Preetham and Gao, Leo and Hallahan, Eric and Levy-Kramer, Josh and Leahy, Connor and Nestler, Lucas and Parker, Kip and Pieler, Michael and Purohit, Shivanshu and Songz, Tri and Wang, Phil and Weinbach, Samuel},
   title = {{GPT-NeoX}: Large Scale Autoregressive Language Modeling in PyTorch},
   url = {http://github.com/eleutherai/gpt-neox},
   year = {2021}

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ In the above bibtex entry, names are in alphabetical order, the version number i
 
 ## Licensing
 
-This repository hosts code that is part of EleutherAI's GPT-NeoX project. Copyright (c) 2021, EleutherAI contributors (in alphabetical order): Alex Andonian, Stella Biderman, Sid Black, Preetham Gali, Leo Gao, Eric Hallahan, Josh Levy-Kramer, Connor Leahy, Kip Parker, Michael Pieler, Shivanshu Purohit, Phil Wang, Samuel Weinbach. Licensed under the Apache License:
+This repository hosts code that is part of EleutherAI's GPT-NeoX project. Copyright (c) 2021, EleutherAI contributors (in alphabetical order): Alex Andonian, Stella Biderman, Sid Black, Preetham Gali, Leo Gao, Eric Hallahan, Josh Levy-Kramer, Connor Leahy, Lucas Nestler, Kip Parker, Michael Pieler, Shivanshu Purohit, Tri Songz, Phil Wang, Samuel Weinbach. Licensed under the Apache License:
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
this is purely based on the list of contributors available to me (screenshotted the small one). Perhaps there is another internal version I don't have access to, to which Alex, Preetham, Connor, Kip, and Phil Wang contribute, but at least according to my GitHub UI, they are not marked as contributors.

According to GitHub (as seen in #335):
![image](https://user-images.githubusercontent.com/39779310/118739448-ca3c3980-b849-11eb-9a6b-e213b65a4310.png)
![image](https://user-images.githubusercontent.com/39779310/118739341-89442500-b849-11eb-87f5-f1bcc35444bc.png)

This branch:
![image](https://user-images.githubusercontent.com/39779310/118739465-d627fb80-b849-11eb-8fde-2ef2bf9d80e7.png)

