### PR TITLE
Fix small error in text generation utils

### DIFF
--- a/megatron/text_generation_utils.py
+++ b/megatron/text_generation_utils.py
@@ -398,7 +398,7 @@ def generate_samples_from_prompt(neox_args, model, text: Union[List[str], str], 
                     generated_text = None
                     message = "WARNING: generated token which doesn't exist."
             else:
-                generated_tokens = list()
+                generated_text = None
                 message = "WARNING: text generation did not start; try different batching or adjust parameters"
             if is_mp_rank_0():
                 data = {

--- a/megatron/text_generation_utils.py
+++ b/megatron/text_generation_utils.py
@@ -399,6 +399,7 @@ def generate_samples_from_prompt(neox_args, model, text: Union[List[str], str], 
                     message = "WARNING: generated token which doesn't exist."
             else:
                 generated_text = None
+                generated_tokens = []
                 message = "WARNING: text generation did not start; try different batching or adjust parameters"
             if is_mp_rank_0():
                 data = {


### PR DESCRIPTION
if we hit this codepath (which happens when the first token is an eos token) then generated text is not defined.