### PR TITLE
fix save config files to the load directory

### DIFF
--- a/megatron/neox_arguments/arguments.py
+++ b/megatron/neox_arguments/arguments.py
@@ -235,16 +235,29 @@ class NeoXArgs(*BASE_CLASSES):
         if neox_args.save is not None:
             configs_directory = os.path.join(neox_args.save, "configs")
             
-            # delete the configs subdirectory in save if it already exists
-            # only the latest version of the configs are stored
+            # If loading the conf files from the save directory
+            # deleting the conf files in the following step would
+            # naturally prevent the later copy. Therefore we are first
+            # loading the files into memory. 
+            conf_files_memory = dict()
+            for conf_file in conf_files:
+                conf_files_memory[os.path.basename(conf_file)] = open(conf_file, "r").read()
+            
+            # Delete the configs subdirectory in save if it already exists.
+            # Reason: only the latest version of the configs are stored
+            # All files are deleted because selecting a subset of configs 
+            # is a valid option. We would like to prevent keeping files
+            # which are not part of the latest config. If data is saved to
+            # a previously non-empty save directory. 
             if os.path.isdir(configs_directory):
                 shutil.rmtree(configs_directory)
 
-            # create configs directory and copy config files
+            # create configs directory and save config files
             os.makedirs(configs_directory)
-            for conf_file in conf_files:
-                shutil.copy(conf_file, os.path.join(configs_directory, os.path.basename(conf_file)))
-
+            for conf_file_name, conf_data in conf_files_memory.items():
+                with open(os.path.join(configs_directory, conf_file_name), "w") as f:
+                    f.write(conf_data)
+            
         return neox_args
 
     @classmethod


### PR DESCRIPTION
Problem: If load == save, the config save failes because we cannot copy files from the already deleted directory.
Solution: load config files into memory first, delete the directory, then save from memory.


Note: Overwriting may not be the best option as it is completely valid to instantiate with just some and not all of the config files. Simply overwriting with the files with the same name would result in left over config files, which are not part of the actual config any more. The simple option without comparing filenames and file contents is the deletion of the directory.