### PR TITLE
Eval harness update + Fix rotary bug

### DIFF
--- a/eval_tasks/adaptor.py
+++ b/eval_tasks/adaptor.py
@@ -27,6 +27,8 @@ import inspect
 from lm_eval import tasks 
 from lm_eval.utils import chunks
 
+# TODO: add data parallel
+
 class EvalHarnessAdaptor(GPT2LM):
 
     def __init__(self, model, forward_step_fn, neox_args, batch_size=None):
@@ -82,7 +84,6 @@ class EvalHarnessAdaptor(GPT2LM):
         return reord.get_original(res)
 
     def _loglikelihood_tokens(self, requests, disable_tqdm=False):
-        # TODO: implement some kind of efficient-request-middleware that lumps together requests with the same context
         disable_tqdm = disable_tqdm if self.is_main else True
         res = []
         res_len = 0  # storing the result length for later

--- a/eval_tasks/adaptor.py
+++ b/eval_tasks/adaptor.py
@@ -1,3 +1,14 @@
+import best_download
+
+# patch best_download (eval harness downloader) to only happen on the first rank
+fn = best_download.download_file
+
+def _download_file(*args, **kwargs):
+    if is_local_main():
+        fn(*args, **kwargs)
+
+best_download.download_file = _download_file
+
 import os
 import sys
 from functools import partial
@@ -15,17 +26,6 @@ import inspect
 from lm_eval import tasks 
 from lm_eval.utils import chunks
 from megatron.utils import is_local_main 
-import best_download
-
-# patch Task.download to only happen on the first rank
-download_original = best_download.download_file
-
-def _download_file(*args, **kwargs):
-    print('HELLO WORLD!')
-    if is_local_main():
-        download_original(*args, **kwargs)
-
-best_download.download_file = _download_file
 
 
 GENERATION_TASKS = []

--- a/eval_tasks/run.py
+++ b/eval_tasks/run.py
@@ -38,7 +38,7 @@ if __name__ == "__main__":
     results = run_eval_harness(model, forward_step, neox_args, eval_tasks=neox_args.eval_tasks)
     if neox_args.rank == 0:
         pprint(dict(results['results']))
-        results_path = f'eval_results{datetime.now().strftime("%m-%d-%Y-%H-%M-%S")}.json'
+        results_path = f'eval_results_{datetime.now().strftime("%m-%d-%Y-%H-%M-%S")}.json'
         if neox_args.eval_results_prefix:
             results_path = f"{neox_args.eval_results_prefix}_{results_path}"
         with open(results_path, 'w') as f:

--- a/eval_tasks/run.py
+++ b/eval_tasks/run.py
@@ -37,9 +37,9 @@ if __name__ == "__main__":
     model, neox_args = setup_for_inference_or_eval(inference=False, get_key_value=False)
     results = run_eval_harness(model, forward_step, neox_args, eval_tasks=neox_args.eval_tasks)
     if neox_args.rank == 0:
-        pprint(dict(results['results']))
+        pprint(results)
         results_path = f'eval_results_{datetime.now().strftime("%m-%d-%Y-%H-%M-%S")}.json'
         if neox_args.eval_results_prefix:
             results_path = f"{neox_args.eval_results_prefix}_{results_path}"
         with open(results_path, 'w') as f:
-            json.dump(dict(results['results']), f, indent=4)
+            json.dump(results, f, indent=4)

--- a/eval_tasks/run.py
+++ b/eval_tasks/run.py
@@ -26,11 +26,20 @@ from megatron.training import forward_step
 from megatron.utils import setup_for_inference_or_eval
 from adaptor import run_eval_harness
 from pprint import pprint
+from datetime import datetime
+
+import json 
+
 
 # TO RUN: ./deepy.py eval_tasks/run.py configs/your_config.yml
 
 if __name__ == "__main__":
     model, neox_args = setup_for_inference_or_eval(inference=False, get_key_value=False)
-    results = run_eval_harness(model, forward_step, neox_args)
+    results = run_eval_harness(model, forward_step, neox_args, eval_tasks=neox_args.eval_tasks)
     if neox_args.rank == 0:
         pprint(dict(results['results']))
+        results_path = f'eval_results{datetime.now().strftime("%m-%d-%Y-%H-%M-%S")}.json'
+        if neox_args.eval_results_prefix:
+            results_path = f"{neox_args.eval_results_prefix}_{results_path}"
+        with open(results_path, 'w') as f:
+            json.dump(dict(results['results']), f, indent=4)

--- a/megatron/model/gpt2_model.py
+++ b/megatron/model/gpt2_model.py
@@ -22,7 +22,7 @@ import torch
 from collections import defaultdict
 
 from functools import partial
-from megatron.model.utils import Lambda, SequentialWrapper
+from megatron.model.utils import Lambda, SequentialWrapper, _set_get_key_value
 from megatron.model.norms import get_norm
 from megatron.model.init_functions import get_init_methods
 
@@ -64,6 +64,41 @@ def cross_entropy(output, labels, _fp16=False):
     return loss
 
 
+def _pre_transformer_block(args):
+    # used instead of a lambda layer to pass outputs of the word embedding to the transformer block
+    # using a custom function means we don't have to have this _inference mode which makes everything tricky
+    in_inference = len(args) == 3
+    in_train = len(args) == 2
+    # data format change for hidden_states to avoid explicit tranposes : [b s h] --> [s b h]
+    if in_inference:
+        # we need to add a container to cache `presents` from each layer's forward pass
+        # inputs/outputs are now (hidden_states, layer_past, presents, attention_mask)
+        fn = lambda x: (x[0].transpose(0, 1).contiguous(), x[1], torch.Tensor(), *x[2:])
+    elif in_train:
+        fn = lambda x: (x[0].transpose(0, 1).contiguous(), *x[1:])
+    else:
+        raise ValueError('Incorrect number of args in `_pre_transformer_block`')
+    return fn(args)
+
+
+def _post_transformer_block(args):
+    # used instead of a lambda layer to pass outputs of the transformer block to the final layer
+    # using a custom function means we don't have to have this _inference mode which makes everything tricky
+    in_inference = len(args) == 4
+    in_train = len(args) == 2
+    if in_inference:
+        # we can get rid of the mask / pasts now
+        # from (hidden_states, layer_past, presents, attention_mask)
+        # to (hidden_states.T, presents)
+        fn = lambda x: (x[0].transpose(0, 1).contiguous(), x[2])
+    elif in_train:
+        # Undo data format change and drop mask
+        fn = lambda x: x[0].transpose(0, 1).contiguous()
+    else:
+        raise ValueError('Incorrect number of args in `_post_transformer_block`')
+    return fn(args)
+
+
 class GPT2ModelPipe(PipelineModule, torch.nn.Module):
     """GPT2Model adapted for pipeline parallelism.
 
@@ -71,7 +106,8 @@ class GPT2ModelPipe(PipelineModule, torch.nn.Module):
     sequence of layers including embedding, transformer layers, and output.
     """
 
-    def __init__(self, neox_args, num_tokentypes=0, parallel_output=True, topology=None, inference=False, get_key_value=True):
+    def __init__(self, neox_args, num_tokentypes=0, parallel_output=True, topology=None, inference=False,
+                 get_key_value=True):
         self.neox_args = neox_args
 
         self._inference = inference
@@ -98,7 +134,8 @@ class GPT2ModelPipe(PipelineModule, torch.nn.Module):
     def init_specs(self):
         weight_tying = not self.neox_args.no_weight_tying
         if self.embedding_type == 'rpe':
-            rpe_emb = ParallelRelativePositionBias(neox_args=self.neox_args, causal=True, num_buckets=self.neox_args.rpe_num_buckets,
+            rpe_emb = ParallelRelativePositionBias(neox_args=self.neox_args, causal=True,
+                                                   num_buckets=self.neox_args.rpe_num_buckets,
                                                    max_distance=self.neox_args.rpe_max_distance,
                                                    heads=self.neox_args.num_attention_heads)
         self.specs = []
@@ -130,17 +167,10 @@ class GPT2ModelPipe(PipelineModule, torch.nn.Module):
         # one stage to the next, because deepspeed is hacks on top of hacks.
         #
         # outputs are now
-        #           Train: (hidden_states, ((maybe) rotary_pos_emb), attention_mask)
-        #           Inference: (hidden_states, layer_past, ((maybe) rotary_pos_emb), attention_mask)
-        # 
-        # data format change for hidden_states to avoid explicit tranposes : [b s h] --> [s b h]
+        #           Train: (hidden_states,  attention_mask)
+        #           Inference: (hidden_states, layer_past, attention_mask)
 
-        if self._inference:
-            # we need to add a container to cache `presents` from each layer's forward pass
-            # inputs/outputs are now (hidden_states, layer_past, presents, attention_mask)
-            self.specs.append(lambda x: (x[0].transpose(0, 1).contiguous(), x[1], torch.Tensor(), *x[2:]))
-        else:
-            self.specs.append(lambda x: (x[0].transpose(0, 1).contiguous(), *x[1:]))
+        self.specs.append(_pre_transformer_block)
 
         # Transformer layers
         for i in range(self.neox_args.num_layers):
@@ -168,17 +198,10 @@ class GPT2ModelPipe(PipelineModule, torch.nn.Module):
                         rpe=rpe_emb if self.neox_args.pos_emb == 'rpe' else None,
                         rotary=self.neox_args.pos_emb == 'rotary',
                         get_key_value=self.get_key_value
-                        )
                     )
+                )
 
-        if self._inference:
-            # we can get rid of the mask / pasts now
-            # from (hidden_states, layer_past, presents, attention_mask)
-            # to (hidden_states.T, presents)
-            self.specs.append(lambda x: (x[0].transpose(0, 1).contiguous(), x[2]))
-        else:
-            # Undo data format change and drop mask
-            self.specs.append(lambda x: x[0].transpose(0, 1).contiguous())
+        self.specs.append(_post_transformer_block)
 
         # Final layernorm after transformer layers
         # NormPipe is a helper class to pass presents through to the output when doing inference
@@ -192,9 +215,6 @@ class GPT2ModelPipe(PipelineModule, torch.nn.Module):
         # outputs are now
         #           Train: hidden_states
         #           Inference: (hidden_states, presents)
-
-        # XXX forward_method_parallel_output is assumed to be None, but we're not in a
-        # fwd method to assert
 
         def _logits_helper(embedding, lm_output):
             """Just a wrapper to massage inputs/outputs from pipeline. """
@@ -238,6 +258,12 @@ class GPT2ModelPipe(PipelineModule, torch.nn.Module):
         # output in training should just be logits
         # in inference it will be (logits, presents) (assuming get_key_value) is true
 
+    def inference_mode(self, cache=True):
+        _set_get_key_value(self.forward_funcs, cache)
+
+    def train_mode(self):
+        _set_get_key_value(self.forward_funcs, False)
+
     def to_sequential(self):
         """
         Transforms the PipelineModule to a plain nn.Sequential module
@@ -267,4 +293,3 @@ class GPT2ModelPipe(PipelineModule, torch.nn.Module):
                                   self.activation_checkpoint_func,
                                   parent_class_name=self.__class__.__name__)
         return model
-

--- a/megatron/model/positional_embeddings.py
+++ b/megatron/model/positional_embeddings.py
@@ -1,6 +1,5 @@
 import torch
 
-
 class SinusoidalPositionalEmbedding(torch.nn.Module):
 
     def __init__(self, dim, base=10000):
@@ -45,6 +44,6 @@ def rotate_half(x):
     return torch.cat((-x2, x1), dim=x1.ndim - 1) # dim=-1 triggers a bug in earlier torch versions
 
 @torch.jit.script
-def apply_rotary_pos_emb(q, k, cos, sin, offset=None):
+def apply_rotary_pos_emb(q, k, cos, sin, offset: int = 0):
     cos, sin = cos[offset:q.shape[0]+offset, ...], sin[offset:q.shape[0]+offset, ...]
     return (q * cos) + (rotate_half(q) * sin), (k * cos) + (rotate_half(k) * sin)

--- a/megatron/model/positional_embeddings.py
+++ b/megatron/model/positional_embeddings.py
@@ -25,11 +25,12 @@ class RotaryEmbedding(torch.nn.Module):
         self.cos_cached = None
         self.sin_cached = None
 
-    def forward(self, x, seq_dim=1):
-        seq_len = x.shape[seq_dim]
+    def forward(self, x, seq_dim=1, seq_len=None):
+        if seq_len is None:
+            seq_len = x.shape[seq_dim]
         if seq_len != self.seq_len_cached:
             self.seq_len_cached = seq_len
-            t = torch.arange(x.shape[seq_dim], device=x.device).type_as(self.inv_freq)
+            t = torch.arange(seq_len, device=x.device).type_as(self.inv_freq)
             freqs = torch.einsum('i,j->ij', t, self.inv_freq)
             emb = torch.cat((freqs, freqs), dim=-1).to(x.device)
             self.cos_cached = emb.cos()[:, None, None, :]
@@ -44,5 +45,6 @@ def rotate_half(x):
     return torch.cat((-x2, x1), dim=x1.ndim - 1) # dim=-1 triggers a bug in earlier torch versions
 
 @torch.jit.script
-def apply_rotary_pos_emb(q, k, cos, sin):
+def apply_rotary_pos_emb(q, k, cos, sin, offset=None):
+    cos, sin = cos[offset:q.shape[0]+offset, ...], sin[offset:q.shape[0]+offset, ...]
     return (q * cos) + (rotate_half(q) * sin), (k * cos) + (rotate_half(k) * sin)

--- a/megatron/model/utils.py
+++ b/megatron/model/utils.py
@@ -21,9 +21,11 @@
 import math
 
 import torch
-from deepspeed.ops.sparse_attention import SparseSelfAttention, VariableSparsityConfig, FixedSparsityConfig, BigBirdSparsityConfig, BSLongformerSparsityConfig
+from deepspeed.ops.sparse_attention import SparseSelfAttention, VariableSparsityConfig, FixedSparsityConfig, \
+    BigBirdSparsityConfig, BSLongformerSparsityConfig
 from deepspeed.ops.sparse_attention.sparsity_config import LocalSlidingWindowSparsityConfig
 from megatron.model.norms import LayerNorm, RMSNorm, ScaleNorm
+
 
 def get_params_for_weight_decay_optimization(module, neox_args):
     """Divide params into with-weight-decay and without-weight-decay groups.
@@ -85,6 +87,12 @@ class SequentialWrapper(torch.nn.Module):
         params = [f.parameters() for f in funcs if isinstance(f, torch.nn.Module)]
         return any(len(list(p)) > 0 for p in params)
 
+    def inference_mode(self):
+        _set_get_key_value(self.sequential, True)
+
+    def train_mode(self):
+        _set_get_key_value(self.sequential, False)
+
     def forward(self, forward_input):
 
         def exec_range_func(start, end):
@@ -128,6 +136,18 @@ class SequentialWrapper(torch.nn.Module):
         return x
 
 
+def _set_get_key_value(base, value):
+    # utility used to recursively set the get key attribute value to true/false
+    # (i.e switch between inference and train mode)
+
+    assert isinstance(value, bool)
+    for m in base:
+        if hasattr(m, 'get_key_value'):
+            m.get_key_value = value
+        if hasattr(m, 'children'):
+            _set_get_key_value(m.children(), value)
+
+
 def configure_sparse_attention(neox_args, attention_type, num_attention_heads, mpu):
     if attention_type == "sparse_fixed":
         # you can think of local window size as `block_size` * `num_local_blocks`.
@@ -156,7 +176,8 @@ def configure_sparse_attention(neox_args, attention_type, num_attention_heads, m
         )
     elif attention_type == "local":
         # can configure with `num_local_blocks` or `num_sliding_window_blocks`
-        num_local_blocks = neox_args.sparsity_config.get("num_local_blocks", neox_args.sparsity_config.get("num_sliding_window_blocks", 4))
+        num_local_blocks = neox_args.sparsity_config.get("num_local_blocks",
+                                                         neox_args.sparsity_config.get("num_sliding_window_blocks", 4))
         sparsity_config = LocalSlidingWindowSparsityConfig(
             num_heads=num_attention_heads,
             block=neox_args.sparsity_config.get("block", 16),

--- a/megatron/neox_arguments/neox_args.py
+++ b/megatron/neox_arguments/neox_args.py
@@ -846,3 +846,13 @@ class NeoXArgsTextgen(NeoXArgsTemplate):
     During generation recompute all attention instead of using previously computed keys/values.
     Should be set to true for sparse attention models
     """
+
+    eval_results_prefix: str = ""
+    """
+    prefix to which to save evaluation results - final fp will be {eval_results_prefix}_eval_results_yy-mm-dd-HH-MM.json
+    """
+
+    eval_tasks: list = None
+    """
+    Tasks to evaluate on using lm_eval_harness
+    """

--- a/megatron/text_generation_utils.py
+++ b/megatron/text_generation_utils.py
@@ -29,7 +29,7 @@ import torch.nn.functional as F
 from megatron import print_rank_0
 from megatron import mpu
 from megatron.utils import get_ltor_masks_and_position_ids, is_mp_rank_0
-
+from megatron.utils import ddb 
 
 def get_batch(neox_args, context_tokens: torch.Tensor):
     """
@@ -148,8 +148,21 @@ def broadcast_terminate_signal(terminate_runs: int):
                                 group=mpu.get_model_parallel_group())
     return terminate_runs_tensor[0].item()
 
+def stop_tokens_in_completion(stop_tokens, context_tokens, batch_index, current_index):
+    if stop_tokens is None:
+        return False
+    res = []
+    for token_group in stop_tokens:
+        context = context_tokens[batch_index, :current_index + 1]
+        context = context[-len(token_group):]
+        if context.shape[0] == token_group.shape[0]:
+            res.append(all(token_group == context))
+        else:
+            res.append(False)
+    return any(res)
+
 def stream_tokens(neox_args, model, context_tokens: List[List[int]], eos_token_id: int = None, 
-                    maximum_tokens: int = None, recompute: bool = False, temperature: float = 0.0, top_k: int = 0, top_p: float = 0.0):
+                    maximum_tokens: int = None, recompute: bool = False, temperature: float = 0.0, top_k: int = 0, top_p: float = 0.0, stop_tokens=None):
     """
     iterator producing text completions
 
@@ -193,6 +206,11 @@ def stream_tokens(neox_args, model, context_tokens: List[List[int]], eos_token_i
 
     # convert to tensor and broadcast
     context_tokens = torch.cuda.LongTensor(context_tokens)
+    if stop_tokens:
+        stop_tokens = torch.cuda.LongTensor(stop_tokens)
+        if stop_tokens.ndim == 1:
+            stop_tokens = stop_tokens.unsqueeze(0)
+
     token_generation_start_index = torch.cuda.LongTensor(context_lengths)
 
     torch.distributed.broadcast(context_tokens,
@@ -203,7 +221,7 @@ def stream_tokens(neox_args, model, context_tokens: List[List[int]], eos_token_i
                                 group=mpu.get_model_parallel_group())
     
     # produce batch relevant attention_mask and position_ids
-    tokens, attention_mask, position_ids = get_batch(neox_args, context_tokens)
+    context_tokens, attention_mask, position_ids = get_batch(neox_args, context_tokens)
 
     # determine the smallest context length at which first output is produced
     context_length = token_generation_start_index.min().item()
@@ -248,14 +266,14 @@ def stream_tokens(neox_args, model, context_tokens: List[List[int]], eos_token_i
                 # not choosing recompute assumes that any number of tokens can be forwarded
                 # this is not the case for sparse attention
                 if token_index_to_generate == first_token_index_to_generate:
-                    tokens_to_use = tokens[:, :token_index_to_generate]
+                    tokens_to_use = context_tokens[:, :token_index_to_generate]
                     positions_to_use = position_ids[:, :token_index_to_generate]
                 else:
-                    tokens_to_use = tokens[:, token_index_to_generate - 1].view(
+                    tokens_to_use = context_tokens[:, token_index_to_generate - 1].view(
                         batch_size, -1)
                     positions_to_use = position_ids[:, token_index_to_generate - 1].view(
                         batch_size, -1)
-                # we have to use neox_args instead of kwargs here because deepspeed :|
+                    # we have to use neox_args instead of kwargs here because deepspeed :|
                 model_inputs = (tokens_to_use,  # input_ids
                                 positions_to_use,  # position_ids
                                 attention_mask,  # attention_mask
@@ -283,16 +301,26 @@ def stream_tokens(neox_args, model, context_tokens: List[List[int]], eos_token_i
                 next_token_log_probs = F.softmax(generated_token_logits, dim=-1)
                 generated_tokens = torch.multinomial(next_token_log_probs, num_samples=1).view(-1)
 
-        	# determine state for each batch item
+
+            # determine if state has started for eahc batch item
             state_started = token_generation_start_index <= token_index_to_generate # check which batch items have been started
-            state_done = (generated_tokens == eos_token_id).byte() & state_started.byte() # check which batch items produce an eos_token in the current iteration
-            state_just_finished = (state_done & ~state_is_done).bool()
-            state_is_done = state_is_done | state_done
-            token_generation_end_index[(state_started.byte() & ~state_is_done).bool()] = token_index_to_generate
+
 
             # switch out only padding tokens (the batch items that have been started)
             context_tokens[:, token_index_to_generate] = switch(context_tokens[:, token_index_to_generate].view(-1), generated_tokens, state_started) 
-            
+
+
+            # determine if state has finished for each batch item
+            state_done = (generated_tokens == eos_token_id).byte() & state_started.byte() # check which batch items produce an eos_token in the current iteration
+            state_just_finished = (state_done & ~state_is_done).bool()
+            state_is_done = state_is_done | state_done
+            stop_tokens_produced = torch.zeros_like(state_is_done)
+            for batch_idx, ctx in enumerate(context_tokens):
+                stop_tokens_produced[batch_idx] = stop_tokens_in_completion(stop_tokens, context_tokens, batch_idx, token_index_to_generate)
+            state_is_done = state_is_done | stop_tokens_produced
+
+            token_generation_end_index[(state_started.byte() & ~state_is_done).bool()] = token_index_to_generate
+
             token_index_to_generate += 1
             
             
@@ -300,7 +328,7 @@ def stream_tokens(neox_args, model, context_tokens: List[List[int]], eos_token_i
             if torch.all(state_is_done): break
 
 def generate_samples_from_prompt(neox_args, model, text: Union[List[str], str], eos_token_id: int = None, 
-                                    maximum_tokens: int = 64, recompute: bool = False, temperature: float = 0.0, top_k: int = 0, top_p: float = 0.0):
+                                    maximum_tokens: int = 64, recompute: bool = False, temperature: float = 0.0, top_k: int = 0, top_p: float = 0.0, stop_tokens=None):
     """
     Generates samples from raw text and returns them in a dictionary.
 
@@ -380,7 +408,8 @@ def generate_samples_from_prompt(neox_args, model, text: Union[List[str], str], 
             recompute=recompute,
             temperature=temperature,
             top_k=top_k,
-            top_p=top_p
+            top_p=top_p,
+            stop_tokens=stop_tokens
             ):
             pass # finish generation and use all results below
 

--- a/megatron/text_generation_utils.py
+++ b/megatron/text_generation_utils.py
@@ -390,7 +390,7 @@ def generate_samples_from_prompt(neox_args, model, text: Union[List[str], str], 
                 if context_length >= (neox_args.seq_length // 2):
                     print_rank_0("\nWarning! Context length", context_length,
                                  "\nPlease give smaller context (e.g. half of the "
-                                 "max sequence length)!", flush=True)
+                                 "max sequence length)!")
         else:
             context_tokens = neox_args.tokenizer.tokenize("EMPTY TEXT")
             context_length = len(context_tokens)

--- a/megatron/text_generation_utils.py
+++ b/megatron/text_generation_utils.py
@@ -29,7 +29,7 @@ import torch.nn.functional as F
 from megatron import print_rank_0
 from megatron import mpu
 from megatron.utils import get_ltor_masks_and_position_ids, is_mp_rank_0
-from megatron.utils import ddb 
+
 
 def get_batch(neox_args, context_tokens: torch.Tensor):
     """

--- a/megatron/utils.py
+++ b/megatron/utils.py
@@ -372,17 +372,20 @@ def get_total_params(model):
     total_n_parameters = total_n_parameters.item()
     return total_n_parameters
 
-def setup_for_inference_or_eval(inference=True, get_key_value=True):
+def setup_for_inference_or_eval(inference=True, get_key_value=True, overwrite_values=None):
 
     from megatron.neox_arguments import NeoXArgs
     from megatron.initialize import initialize_megatron
     from megatron.training import setup_model_and_optimizer
 
-    neox_args = NeoXArgs.consume_neox_args(overwrite_values={
+    _overwrite_values = {
         "checkpoint_activations": False,
         "partition_activations": False,
         "no_load_optim": True,
-    })
+    }
+    if overwrite_values:
+        _overwrite_values.update(overwrite_values)
+    neox_args = NeoXArgs.consume_neox_args(overwrite_values=_overwrite_values)
     neox_args.configure_distributed_args()
     neox_args.build_tokenizer()
     


### PR DESCRIPTION
- Adds generation tasks to lm_eval_harness adaptor
- Adds task parameters in neox args (`eval_tasks` - a list of tasks to evaluate on, & `eval_results_prefix` a prefix to the path where eval results will be saved)
- Makes it easier to switch between inference and train mode with neox model
- Adds stop tokens to text generation
- Fixes bug with rotary where caching would decrease generation quality
