### PR TITLE
Run eval harness during training

### DIFF
--- a/eval_tasks/__init__.py
+++ b/eval_tasks/__init__.py
@@ -1,0 +1,1 @@
+from .adaptor import EvalHarnessAdaptor, run_eval_harness

--- a/eval_tasks/adaptor.py
+++ b/eval_tasks/adaptor.py
@@ -1,4 +1,4 @@
-from megatron.utils import is_local_main
+from megatron.utils import is_local_main, print_rank_0
 import best_download
 
 # patch best_download (eval harness downloader) to only happen on the first rank
@@ -18,17 +18,14 @@ from functools import partial
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__),
                                              os.path.pardir)))
-from megatron.utils import print_rank_0
 from tqdm import tqdm
 import torch
+import torch.nn.functional as F
+
 from lm_eval.base import CacheHook
 from lm_eval.models.gpt2 import GPT2LM
 from lm_eval import tasks, evaluator, utils
-import torch.nn.functional as F
 from megatron.text_generation_utils import generate_samples_from_prompt
-import inspect
-from lm_eval import tasks
-from lm_eval.utils import chunks
 
 
 # TODO: add data parallel

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -27,30 +27,20 @@ import math
 import sys
 
 import torch
-
-from megatron.utils import Timers, init_wandb
-from megatron import print_rank_0
-
-from megatron import mpu
-
-from megatron.model import GPT2ModelPipe
-from megatron.checkpointing import load_checkpoint, save_checkpoint
-from megatron.data.data_utils import build_train_valid_test_data_iterators
-
-from megatron.initialize import initialize_megatron
-from megatron.learning_rates import AnnealingLR
-from megatron.model import get_params_for_weight_decay_optimization
-from megatron.logging import tb_wandb_log
-from megatron.utils import OverflowMonitor, get_noise_scale_logger
-from megatron.utils import get_total_params
-from megatron.logging import training_log
-
-from megatron.model.gpt2_model import cross_entropy
-from megatron.utils import get_ltor_masks_and_position_ids
-from megatron.utils import reduce_losses
-from eval_tasks import run_eval_harness
 import deepspeed
 import numpy as np
+
+from megatron.utils import Timers, init_wandb, get_ltor_masks_and_position_ids, reduce_losses
+from megatron import print_rank_0, mpu
+from megatron.model import GPT2ModelPipe, get_params_for_weight_decay_optimization
+from megatron.checkpointing import load_checkpoint, save_checkpoint
+from megatron.data.data_utils import build_train_valid_test_data_iterators
+from megatron.initialize import initialize_megatron
+from megatron.learning_rates import AnnealingLR
+from megatron.logging import tb_wandb_log, training_log
+from megatron.utils import OverflowMonitor, get_noise_scale_logger, get_total_params
+from megatron.model.gpt2_model import cross_entropy
+from eval_tasks import run_eval_harness
 
 
 def pretrain(neox_args):
@@ -554,7 +544,7 @@ def evaluate_and_print_results(neox_args, prefix, forward_step_func, data_iterat
     """Helper function to evaluate and dump results on screen."""
     total_loss_dict = evaluate(neox_args=neox_args, forward_step_fn=forward_step_func, data_iterator=data_iterator,
                                model=model, verbose=verbose, timers=timers)
-    string = f' validation loss at {prefix} | '
+    string = f' validation results at {prefix} | '
     for k, v in total_loss_dict.items():
         if isinstance(v, dict):
             for k2, v2 in v.items():

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -556,14 +556,17 @@ def evaluate_and_print_results(neox_args, prefix, forward_step_func, data_iterat
                                model=model, verbose=verbose, timers=timers)
     string = f' validation loss at {prefix} | '
     for k, v in total_loss_dict.items():
-        string += f'{k} value: {v:.6E} | '
         if isinstance(v, dict):
             for k2, v2 in v.items():
                 k3 = "_".join([k, k2])
+                string += f'{k3} value: {v2:.6E} | '
                 tb_wandb_log(f"validation/{k3}", v2, iteration, use_wandb=neox_args.use_wandb,
                              tensorboard_writer=neox_args.tensorboard_writer)
         else:
-            tb_wandb_log(f"validation/{k}", v, iteration, use_wandb=neox_args.use_wandb, tensorboard_writer=neox_args.tensorboard_writer)
+            string += f'{k} value: {v:.6E} | '
+            tb_wandb_log(f"validation/{k}", v, iteration, use_wandb=neox_args.use_wandb,
+                         tensorboard_writer=neox_args.tensorboard_writer)
+
     length = len(string) + 1
     print_rank_0('-' * length)
     print_rank_0(string)


### PR DESCRIPTION
addresses https://github.com/EleutherAI/gpt-neox/issues/366

The generation tasks aren't that fast - so best to stick to the log likelihood tasks (you can add them to the yaml with the "eval_tasks" parameter.

e.g

```yaml
"eval_tasks": ["lambada", "wikitext", "piqa"],
```