### PR TITLE
Add soft prompt tuning

### DIFF
--- a/megatron/model/__init__.py
+++ b/megatron/model/__init__.py
@@ -18,3 +18,4 @@
 
 from .gpt2_model import GPT2ModelPipe
 from .utils import get_params_for_weight_decay_optimization
+from .word_embeddings import SoftEmbedding

--- a/megatron/model/word_embeddings.py
+++ b/megatron/model/word_embeddings.py
@@ -1,4 +1,5 @@
 import torch
+import math
 from torch.nn.parameter import Parameter
 
 from megatron import mpu
@@ -141,18 +142,24 @@ class SoftEmbedding(torch.nn.Module):
                 wte,
                 n_tokens: int = 10, 
                 init_range: float = 0.5,
-                initialize_from_vocab: bool = True):
+                init_string: str = ''):
         super(SoftEmbedding, self).__init__()
         self.n_tokens = n_tokens
         self.neox_args = neox_args
         self.init_range = init_range
-        self.initialize_from_vocab = initialize_from_vocab
+        self.init_string = init_string
         self.soft_embedding_weight = torch.nn.parameter.Parameter(self.initialize_embedding(wte))
 
     def initialize_embedding(self, 
                              wte: torch.nn.Embedding):
-        if self.initialize_from_vocab:
-            return wte.weight[:self.n_tokens].clone().detach()
+        if self.init_string:
+            embeds = torch.LongTensor(self.neox_args.tokenizer.tokenize(self.init_string)).to(wte.weight.device)
+            embeds = wte(embeds)
+            if embeds.shape[0] >= self.n_tokens:
+                embeds = embeds[:self.n_tokens, :] # slice
+            else:
+                embeds = embeds.repeat(math.ceil(self.n_tokens / embeds.shape[0]), 1)[:self.n_tokens, :] # pad up to n_tokens
+            return embeds
         return torch.Tensor(n_tokens, neox_args.hidden_size).uniform_(-self.random_range, self.random_range)
             
     def forward(self, args: tuple):

--- a/megatron/model/word_embeddings.py
+++ b/megatron/model/word_embeddings.py
@@ -1,8 +1,9 @@
 import torch
+from torch.nn.parameter import Parameter
 
 from megatron import mpu
 from megatron.model.positional_embeddings import SinusoidalPositionalEmbedding
-
+from megatron.model.init_functions import get_init_methods
 
 class Embedding(torch.nn.Module):
     """Language model embeddings.
@@ -133,3 +134,44 @@ class EmbeddingPipe(Embedding):
         else:
             return embeddings, attention_mask
 
+class SoftEmbedding(torch.nn.Module):
+
+    def __init__(self, 
+                neox_args,
+                wte,
+                n_tokens: int = 10, 
+                init_range: float = 0.5,
+                initialize_from_vocab: bool = True):
+        super(SoftEmbedding, self).__init__()
+        self.n_tokens = n_tokens
+        self.neox_args = neox_args
+        self.init_range = init_range
+        self.initialize_from_vocab = initialize_from_vocab
+        self.soft_embedding_weight = torch.nn.parameter.Parameter(self.initialize_embedding(wte))
+
+    def initialize_embedding(self, 
+                             wte: torch.nn.Embedding):
+        if self.initialize_from_vocab:
+            return wte.weight[:self.n_tokens].clone().detach()
+        return torch.Tensor(n_tokens, neox_args.hidden_size).uniform_(-self.random_range, self.random_range)
+            
+    def forward(self, args: tuple):
+        in_inference = len(args) == 3  # embeddings, layer_past, attention_mask
+        in_train = len(args) == 2 # embeddings, attention_mask
+        if in_train:
+            embedding, attention_mask = args
+        else:
+            embedding, layer_past, attention_mask = args 
+        soft_embedding = self.soft_embedding_weight.repeat(embedding.shape[0], 1, 1) # repeat batch_size times
+        if in_train:
+            # append soft embedding at the beginning in training
+            embedding = torch.cat((soft_embedding, embedding), dim=1)
+            embedding = embedding[:, :self.neox_args.seq_length, ...]
+            return embedding, attention_mask
+        else:
+            if not (exists(layer_past) and layer_past.numel() > 0):
+                # if in inference, on the first forward pass, we want to do the same as in training (append soft embedding)
+                embedding = torch.cat((soft_embedding, embedding), dim=1)
+                embedding = embedding[:, :self.neox_args.seq_length, ...]
+            # otherwise, we're in incremental mode, and just want to forward the single embedding (since the soft prompt has already been cached)
+            return embedding, layer_past, attention_mask

--- a/megatron/neox_arguments/neox_args.py
+++ b/megatron/neox_arguments/neox_args.py
@@ -268,8 +268,8 @@ class NeoXArgsModel(NeoXArgsTemplate):
     parameters in the dict are:
         'enabled': bool = True # enables soft prompting
         'num_tokens': int = 10 # length of the soft prompt in tokens
-        # below are all still TODO:
-        'init_method': Literal["vocab", "random"] # init method of the soft prompt, either initializes from the model's vocab, or randomly
+        'init_string': str = '' # if provided, initialize the soft prompt with the word embeddings of this string
+        'init_range': float = 0.5 # if no init string is provided, initialize the soft prompt with a uniform distribution between -init_range and init_rang
     """
 
 

--- a/megatron/neox_arguments/neox_args.py
+++ b/megatron/neox_arguments/neox_args.py
@@ -261,6 +261,17 @@ class NeoXArgsModel(NeoXArgsTemplate):
     If None - gmlp model doesn't use attention.
     """
 
+    soft_prompt_tuning: dict = None
+    """
+    Dictionary configuring the soft prompt tuning parameters. 
+    If enabled, will train *only* the soft prompt, and freezes the rest of the model.
+    parameters in the dict are:
+        'enabled': bool = True # enables soft prompting
+        'num_tokens': int = 10 # length of the soft prompt in tokens
+        # below are all still TODO:
+        'init_method': Literal["vocab", "random"] # init method of the soft prompt, either initializes from the model's vocab, or randomly
+    """
+
 
 @dataclass
 class NeoXArgsOptimizer(NeoXArgsTemplate):

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -212,7 +212,7 @@ def get_model(neox_args, inference=False, get_key_value=True):
         soft_prompt = SoftEmbedding(neox_args, 
                                     wte = getattr(model, '0').word_embeddings,
                                     n_tokens=neox_args.soft_prompt_tuning.get("n_tokens", 10),
-                                    initialize_from_vocab=neox_args.soft_prompt_tuning.get("initialize_from_vocab", True),
+                                    init_string=neox_args.soft_prompt_tuning.get("init_string", ""),
                                     init_range=neox_args.soft_prompt_tuning.get("init_range", 0.5))
         model.insert_layers(layers=soft_prompt, idx=1) # insert the soft prompt layer directly after the word embeddings
         


### PR DESCRIPTION
- Adds a generalized `insert_layer` function to insert arbitrary layers in the model
- Uses it to add soft prompt tuning, but also could be used for other stuff (I'm thinking multimodal few shot training)

Should work in inference but haven't yet tested it.

We should be wary that soft prompt tuning / fine tuning will work better if we pad sequences up to max length, rather than packing them (which we do for pretraining).

I'll start working on a PR to simplify data loading + add an option to pad sequences, instead of pack.