### PR TITLE
fix launcher args being passed in and resource inclusion

### DIFF
--- a/deepy.py
+++ b/deepy.py
@@ -27,11 +27,6 @@ from megatron.utils import get_wandb_api_key
 
 
 neox_args = NeoXArgs.consume_deepy_args()
-if neox_args.wandb_group is not None:
-    # concat the wandb group name with a uid to make sure it's unique
-    import wandb
-    neox_args.wandb_group += "_" + wandb.util.generate_id()
-neox_args.print()
 deepspeed_main_args = neox_args.get_deepspeed_main_args()
 
 # Extract wandb API key and inject into worker environments

--- a/megatron/neox_arguments/arguments.py
+++ b/megatron/neox_arguments/arguments.py
@@ -263,7 +263,7 @@ class NeoXArgs(*BASE_CLASSES):
             import wandb
             neox_args.wandb_group += "_" + wandb.util.generate_id()
         neox_args.print()
-        
+
         return neox_args
 
     @classmethod
@@ -505,7 +505,7 @@ class NeoXArgs(*BASE_CLASSES):
 
         assert train_batch == micro_batch * grad_acc * dp_world_size, \
             (f'Check batch related parameters. train_batch_size is not equal'
-             ' to micro_batch_per_gpu * gradient_acc_step * world_size'
+             ' to micro_batch_per_gpu * gradient_acc_step * world_size \n'
              f'{train_batch} != {micro_batch} * {grad_acc} * {dp_world_size}')
 
     def calculate_derived(self):
@@ -521,20 +521,22 @@ class NeoXArgs(*BASE_CLASSES):
 
         # number of gpus
         # Get number of GPUs param or hostfile to determine train_batch_size
-        num_gpus = self.num_gpus
-        if num_gpus is None:
-            num_gpus = -1  # set -1 for backwards compatibility to old default value
-        if num_gpus < 1:
+        global_num_gpus = getattr(self, "global_num_gpus", None)
+        if global_num_gpus is None:
             if self.hostfile is not None or os.path.exists(DLTS_HOSTFILE):
                 hostfile_path = self.hostfile or DLTS_HOSTFILE
                 resources = obtain_resource_pool(hostfile_path, self.include or "", self.exclude or "")
-                num_gpus = sum(map(len, resources.values()))
+                if self.num_nodes is not None and self.num_nodes > 0:
+                    resources = {k:resources[k] for k in list(resources.keys())[:self.num_nodes]}
+                global_num_gpus = sum(map(len, resources.values()))
+                if self.num_gpus is not None and self.num_gpus > 0:
+                    global_num_gpus = self.num_gpus * len(resources)
             else:
-                num_gpus = torch.cuda.device_count()
-        self.update_value("num_gpus", num_gpus)
+                global_num_gpus = torch.cuda.device_count()
+            self.update_value("global_num_gpus", global_num_gpus)
 
         logging.info(
-            self.__class__.__name__ + ".calculate_derived() " + f"Total number of GPUs determined to be: {num_gpus}")
+            self.__class__.__name__ + ".calculate_derived() " + f"Total number of GPUs determined to be: {global_num_gpus}")
 
         # get world size in the model/pipe parallel case, the actual `world size` deepspeed uses is the size of the
         # data-parallel group, or (num_gpus / mp_size) / pp_size
@@ -545,13 +547,13 @@ class NeoXArgs(*BASE_CLASSES):
         self.update_value("model_parallel_size", mp_size)
 
         # pp_size and mp_size are only used here to compute dp world size and nowhere else.
-        dp_world_size = ((num_gpus / pp_size) / mp_size)
+        dp_world_size = ((global_num_gpus / pp_size) / mp_size)
         if not (dp_world_size % 1 == 0):
-            error_message = self.__class__.__name__ + ".calculate_derived() " + f"(num_gpus / pp_size) / mp_size [({num_gpus} / {pp_size}) / {mp_size}] must be a whole number"
+            error_message = self.__class__.__name__ + ".calculate_derived() " + f"(global_num_gpus / pp_size) / mp_size [({global_num_gpus} / {pp_size}) / {mp_size}] must be a whole number"
             logging.error(error_message)
             raise AssertionError(error_message)
 
-        # Automatically derive train_batch_size = train_micro_batch_size_per_gpu*num_gpus*gradient_accumulation_steps
+        # Automatically derive train_batch_size = train_micro_batch_size_per_gpu*global_num_gpus*gradient_accumulation_steps
         train_batch_size, train_micro_batch_size_per_gpu, gradient_accumulation_steps = self.calculate_batch_parameters(
             dp_world_size=dp_world_size,
             train_batch=self.train_batch_size,

--- a/megatron/neox_arguments/arguments.py
+++ b/megatron/neox_arguments/arguments.py
@@ -257,7 +257,13 @@ class NeoXArgs(*BASE_CLASSES):
             for conf_file_name, conf_data in conf_files_memory.items():
                 with open(os.path.join(configs_directory, conf_file_name), "w") as f:
                     f.write(conf_data)
-            
+
+        if neox_args.wandb_group is not None:
+            # concat the wandb group name with a uid to make sure it's unique
+            import wandb
+            neox_args.wandb_group += "_" + wandb.util.generate_id()
+        neox_args.print()
+        
         return neox_args
 
     @classmethod
@@ -297,14 +303,22 @@ class NeoXArgs(*BASE_CLASSES):
 
         args_list = list()
 
-        # add user script
-        args_list.append(self.user_script)
-
         # get deepspeed runner args, and only pass them in to deepspeed launcher if they differ from defaults
         for key, default_value in NeoXArgsDeepspeedRunner().defaults():
             configured_value = getattr(self, key)
             if configured_value != default_value:
                 args_list.extend(self.convert_key_value_to_command_line_arg(key, configured_value))
+
+        if ('--include' in args_list or '--exclude' in args_list) and '--num_gpus' in args_list:
+            print('WARNING: both --include/--exclude and num_gpus were specified simultaneously - overriding num_gpus with --include/--exclude')
+            # cannot specify these both simultaneously, remove num_gpus from list
+            idx = args_list.index('--num_gpus')
+            # pop twice, once for the arg, once for its value
+            args_list.pop(idx)
+            args_list.pop(idx)
+
+        # add user script
+        args_list.append(self.user_script)
 
         # get deepspeed_config
         args_list.append("--deepspeed_config")
@@ -479,6 +493,7 @@ class NeoXArgs(*BASE_CLASSES):
 
     @staticmethod
     def check_batch_parameters(dp_world_size, train_batch, micro_batch, grad_acc):
+
         assert train_batch > 0, \
             f'Train batch size: {train_batch} has to be greater than 0'
 
@@ -519,7 +534,7 @@ class NeoXArgs(*BASE_CLASSES):
         self.update_value("num_gpus", num_gpus)
 
         logging.info(
-            self.__class__.__name__ + ".calculate_derived() " + f"Total number of GPUs determined to be: {self.num_gpus}")
+            self.__class__.__name__ + ".calculate_derived() " + f"Total number of GPUs determined to be: {num_gpus}")
 
         # get world size in the model/pipe parallel case, the actual `world size` deepspeed uses is the size of the
         # data-parallel group, or (num_gpus / mp_size) / pp_size

--- a/megatron/neox_arguments/neox_args.py
+++ b/megatron/neox_arguments/neox_args.py
@@ -570,6 +570,11 @@ class NeoXArgsOther(NeoXArgsTemplate):
     Set during training
     """
 
+    global_num_gpus: int = None
+    """
+    Set during launching
+    """
+
 
 @dataclass
 class NeoXArgsTokenizer(NeoXArgsTemplate):
@@ -861,6 +866,11 @@ class NeoXArgsTraining(NeoXArgsTemplate):
     Minimum loss scale for dynamic loss scale.
     """
 
+    char_level_ppl: bool = False
+    """
+    Whether to calculate character level perplexity as well as token level perplexity. (may incur a time cost)
+    """
+
 
 @dataclass
 class NeoXArgsTextgen(NeoXArgsTemplate):
@@ -923,9 +933,4 @@ class NeoXArgsTextgen(NeoXArgsTemplate):
     eval_tasks: list = None
     """
     Tasks to evaluate on using lm_eval_harness
-    """
-
-    char_level_ppl: bool = False
-    """
-    Whether to calculate character level perplexity as well as token level perplexity. (may incur a time cost)
     """

--- a/megatron/neox_arguments/template.py
+++ b/megatron/neox_arguments/template.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+import logging 
 
 @dataclass
 class NeoXArgsTemplate:

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,7 +2,7 @@ pybind11==2.6.2
 six
 regex
 numpy==1.20.2
-git+git://github.com/EleutherAI/DeeperSpeed.git@c45ec1c0ac05803c02763d7e43be67919e475a2c#egg=deepspeed
+git+git://github.com/EleutherAI/DeeperSpeed.git@eb7f5cff36678625d23db8a8fe78b4a93e5d2c75#egg=deepspeed
 mpi4py==3.0.3
 wandb==0.10.28
 einops==0.3.0
@@ -10,4 +10,4 @@ transformers==4.5.0
 tokenizers==0.10.2
 lm_dataformat==0.0.19
 ftfy==6.0.1
-git+https://github.com/EleutherAI/lm-evaluation-harness.git@142ee24fa3c66d595b803641d9fed51ab96a3e91
+git+https://github.com/EleutherAI/lm-evaluation-harness.git@dc937d4b70af819c5695e09d94e59e4cdb1e40ad


### PR DESCRIPTION
The deepspeed launcher args weren't being passed in in the right position. (launcher args should come before user script / args)

Also, using the --include / --exclude flags wasn't working properly (you can't specify those and num_gpus at the same time, weird stuff was happening with batch size calculations...) 