### PR TITLE
Make interactive mode use maximum_tokens

### DIFF
--- a/text_gen_gpt2.py
+++ b/text_gen_gpt2.py
@@ -61,6 +61,7 @@ def main():
             model=model,
             recompute = neox_args.recompute, 
             temperature = neox_args.temperature,
+            maximum_tokens = neox_args.maximum_tokens, 
             top_k = neox_args.top_k, 
             top_p = neox_args.top_p
         )


### PR DESCRIPTION
This parameter was previously not passed, leading to a default of 64 tokens generated.