### PR TITLE
Eval harness fix

### DIFF
--- a/eval_tasks/__init__.py
+++ b/eval_tasks/__init__.py
@@ -1,1 +1,1 @@
-from .adaptor import EvalHarnessAdaptor, run_eval_harness
+from .eval_adapter import EvalHarnessAdapter, run_eval_harness

--- a/eval_tasks/eval_adapter.py
+++ b/eval_tasks/eval_adapter.py
@@ -204,5 +204,5 @@ class EvalHarnessAdapter(GPT2LM):
 
 def run_eval_harness(model, forward_step_fn, neox_args, batch_size=None, eval_tasks=None):
     print_rank_0('Running evaluation harness...')
-    adaptor = EvalHarnessAdaptor(model, forward_step_fn, neox_args, batch_size)
-    return adaptor.run_eval(eval_tasks=eval_tasks)
+    adapter = EvalHarnessAdapter(model, forward_step_fn, neox_args, batch_size)
+    return adapter.run_eval(eval_tasks=eval_tasks)

--- a/evaluate.py
+++ b/evaluate.py
@@ -24,11 +24,10 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__),
                                              os.path.pardir)))
 from megatron.training import forward_step
 from megatron.utils import setup_for_inference_or_eval
-from eval_tasks.adaptor import run_eval_harness
+from eval_tasks import run_eval_harness
 from pprint import pprint
 from datetime import datetime
-
-import json 
+import json
 
 def main():
     model, neox_args = setup_for_inference_or_eval(inference=False, get_key_value=False)

--- a/megatron/model/gpt2_model.py
+++ b/megatron/model/gpt2_model.py
@@ -285,9 +285,7 @@ class GPT2ModelPipe(PipelineModule, torch.nn.Module):
         # sets the parallel output value of the final layer to value
         final_layer = list(self.forward_funcs)[-1]
         if isinstance(final_layer, (ParallelLinearPipe, ParallelLinear)):
-            print('BEFORE: ', not final_layer.final_linear.gather_output)
             final_layer.final_linear.set_parallel_output(value)
-            print('AFTER: ', not final_layer.final_linear.gather_output)
 
     def inference_mode(self, cache=True):
         # first set caching to true if specified

--- a/megatron/model/gpt2_model.py
+++ b/megatron/model/gpt2_model.py
@@ -23,13 +23,13 @@ import torch.nn as nn
 from collections import defaultdict
 
 from functools import partial
-from megatron.model.utils import Lambda, SequentialWrapper, _set_get_key_value
+from megatron.model.utils import Lambda, SequentialWrapper, recursive_setattr
 from megatron.model.norms import get_norm
 from megatron.model.init_functions import get_init_methods
 
 from megatron import mpu
 from megatron.mpu import ParallelRelativePositionBias
-from megatron.model.transformer import ParallelTransformerLayerPipe, NormPipe, ParallelLinearPipe, parallel_lm_logits
+from megatron.model.transformer import ParallelTransformerLayerPipe, NormPipe, ParallelLinearPipe, parallel_lm_logits, ParallelLinear
 from megatron.model.gmlp import GMLPBlock
 from megatron.model.word_embeddings import EmbeddingPipe, SoftEmbedding
 
@@ -281,11 +281,27 @@ class GPT2ModelPipe(PipelineModule, torch.nn.Module):
         # output in training should just be logits
         # in inference it will be (logits, presents) (assuming get_key_value) is true
 
-    def inference_mode(self, cache=True):
-        _set_get_key_value(self.forward_funcs, cache)
+    def _set_parallel_output(self, value):
+        # sets the parallel output value of the final layer to value
+        final_layer = list(self.forward_funcs)[-1]
+        if isinstance(final_layer, (ParallelLinearPipe, ParallelLinear)):
+            print('BEFORE: ', not final_layer.final_linear.gather_output)
+            final_layer.final_linear.set_parallel_output(value)
+            print('AFTER: ', not final_layer.final_linear.gather_output)
 
+    def inference_mode(self, cache=True):
+        # first set caching to true if specified
+        recursive_setattr(self.forward_funcs, "get_key_value", cache, assert_type=bool)
+        # then set parallel output of the final layer to false so we don't have to gather the output manually
+        self._set_parallel_output(False)
+
+    
     def train_mode(self):
-        _set_get_key_value(self.forward_funcs, False)
+        # set caching to false
+        recursive_setattr(self.forward_funcs, "get_key_value", False)
+        # then set parallel output to true (more efficient training)
+        self._set_parallel_output(True)
+
 
     def to_sequential(self):
         """

--- a/megatron/mpu/layers.py
+++ b/megatron/mpu/layers.py
@@ -331,6 +331,10 @@ class ColumnParallelLinear(torch.nn.Module):
         else:
             self.register_parameter('bias', None)
 
+    def set_parallel_output(self, value: bool):
+        assert isinstance(value, bool)
+        self.gather_output = not value # if gather_output is True, parallel output is False, so we set the opposite
+
     def forward(self, input_):
         # Set up backprop all-reduce.
         input_parallel = copy_to_model_parallel_region(input_)
@@ -426,6 +430,10 @@ class RowParallelLinear(torch.nn.Module):
                 self.bias.zero_()
         else:
             self.register_parameter('bias', None)
+
+    def set_parallel_output(self, parallel_output: bool):
+        assert isinstance(parallel_output, bool)
+        self.parallel_output = parallel_output
 
     def forward(self, input_):
         # Set up backprop all-reduce.

--- a/megatron/neox_arguments/arguments.py
+++ b/megatron/neox_arguments/arguments.py
@@ -204,6 +204,7 @@ class NeoXArgs(*BASE_CLASSES):
                            help='Weights and Biases group name - used to group together "runs".')
         group.add_argument('--wandb_team', type=str, default=None,
                            help='Team name for Weights and Biases.')
+        group.add_argument('--eval_tasks', type=str, nargs='+', default=None, help='Optionally overwrite eval tasks to run for evaluate.py')
 
         args_parsed = parser.parse_args()
 
@@ -226,6 +227,8 @@ class NeoXArgs(*BASE_CLASSES):
             overwrite_values["wandb_team"] = args_parsed.wandb_team
         if args_parsed.user_script is not None:
             overwrite_values["user_script"] = args_parsed.user_script
+        if args_parsed.eval_tasks is not None:
+            overwrite_values["eval_tasks"] = args_parsed.eval_tasks
 
         # load args
         neox_args = cls.from_ymls(paths_to_yml_files=conf_files, overwrite_values=overwrite_values)

--- a/megatron/utils.py
+++ b/megatron/utils.py
@@ -387,6 +387,16 @@ def get_total_params(model):
 def setup_for_inference_or_eval(
     inference=True, get_key_value=True, overwrite_values=None
 ):
+    """
+    Initializes the model for evaluation or inference (doesn't load optimizer states, etc.) from command line args.
+
+    inference: bool
+        Whether to initialize in inference mode
+    get_key_value: bool
+        Whether to use key value caching in inference.
+    overwrite_values: dict
+        Optional Values to overwrite in the model config.
+    """
 
     from megatron.neox_arguments import NeoXArgs
     from megatron.initialize import initialize_megatron
@@ -396,6 +406,7 @@ def setup_for_inference_or_eval(
         "checkpoint_activations": False,
         "partition_activations": False,
         "no_load_optim": True,
+        'zero_optimization': None, # disable zero optimization (won't be used in inference, and loading zero optimizer can cause errors)
     }
     if overwrite_values:
         _overwrite_values.update(overwrite_values)


### PR DESCRIPTION
This fixes some problems relating to eval harness & model parallel models.
To summarize:

- logits weren't being gathered automatically, so with a model parallel size of 2, each machine only had vocab_size / 2 logits, which resulted in indexing errors.
- There was no straightforward way to toggle whether the logits were gathered or not, now there is (`model._set_parallel_output(value)`)
- When zero optimization was being used in a config, it would break at inference time. Fixed this by overriding the zero config when setting up for inference (https://github.com/EleutherAI/gpt-neox/compare/eval_harness_fix?expand=1#diff-b6ee2c1db780b46787ab3a576020f9a12695f3f5cb38ba8badcd5501960e5d22R409)
- There was no way to specify which tasks to run on the command line at runtime, you would have to specify them in the yaml config. Now you can do `./deepy.py evaluate.py -d configs 20B --eval_tasks lambada wikitext hellaswag`
- Fixes some minor spelling errors (adaptor vs. adapter)