### PR TITLE
Fix checkpoint / config file management

### DIFF
--- a/megatron/checkpointing.py
+++ b/megatron/checkpointing.py
@@ -152,10 +152,7 @@ def save_ds_checkpoint(iteration, model, neox_args):
         logits = do_forward_pass(neox_args=neox_args, model=model)
         sd['checkpoint_validation_logits'] = logits
     
-    # Derive tag 
-    # The tag is usually automatically derived in the same way in deepspeed
-    # As the save_checkpoint function does not return such derived tag, we 
-    # do it manually in order to use the subdirectory to save config files
+    # checkpoint folder name
     tag = f"global_step{iteration}"
 
     # save checkpoint

--- a/megatron/checkpointing.py
+++ b/megatron/checkpointing.py
@@ -152,7 +152,22 @@ def save_ds_checkpoint(iteration, model, neox_args):
         logits = do_forward_pass(neox_args=neox_args, model=model)
         sd['checkpoint_validation_logits'] = logits
     
-    model.save_checkpoint(neox_args.save, client_state=sd)
+    # Derive tag 
+    # The tag is usually automatically derived in the same way in deepspeed
+    # As the save_checkpoint function does not return such derived tag, we 
+    # do it manually in order to use the subdirectory to save config files
+    tag = f"global_step{iteration}"
+
+    # save checkpoint
+    model.save_checkpoint(neox_args.save, tag=tag, client_state=sd)
+
+    # save config files
+    if  torch.distributed.get_rank() == 0 and neox_args.config_files is not None:
+        configs_directory = os.path.join(neox_args.save, tag, "configs")
+        os.makedirs(configs_directory)
+        for config_filename, config_data in neox_args.config_files.items():
+            with open(os.path.join(configs_directory, config_filename), "w") as f:
+                f.write(config_data)
 
 def save_checkpoint(neox_args, iteration, model, optimizer, lr_scheduler):
     """Save a model checkpoint."""

--- a/megatron/neox_arguments/neox_args.py
+++ b/megatron/neox_arguments/neox_args.py
@@ -709,6 +709,11 @@ class NeoXArgsTraining(NeoXArgsTemplate):
     Output directory to save checkpoints to.
     """
 
+    config_files: dict = None
+    """
+    Store of original config files mapping config filename to file contents
+    """
+
     load: str = None
     """
     Directory containing a model checkpoint.


### PR DESCRIPTION
Saves config files in the global step directory instead of the neox_args.save directory. Discussion here: https://github.com/EleutherAI/gpt-neox/issues/459

Tested on small config with:
- mp 1, pp 1
- mp 2, pp 1
- mp1, pp 2

Question is how to get the config files from the load in deepy to the single processes. I opted for the hand-trough via neox args. Any other idea?