### PR TITLE
Improve Eval Harness

### DIFF
--- a/eval_tasks/eval_adapter.py
+++ b/eval_tasks/eval_adapter.py
@@ -165,7 +165,6 @@ class EvalHarnessAdapter(GPT2LM):
         return reord.get_original(res)
 
     def _model_call(self, inps):
-        print(inps.shape)
         ######## DATA PARALLEL STUFF ########
         world_size = mpu.get_data_parallel_world_size()
         assert inps.shape[0] % world_size == 0, f"batch size ({inps.shape[0]}) must be divisible by world size ({world_size})"

--- a/eval_tasks/eval_adapter.py
+++ b/eval_tasks/eval_adapter.py
@@ -1,7 +1,7 @@
 from megatron.utils import is_local_main, print_rank_0
 import best_download
 
-# patch best_download (eval harness downloader) to only happen on the first rank
+# patch best_download (eval harness downloader) to only happen on the first local rank
 fn = best_download.download_file
 
 
@@ -16,8 +16,9 @@ import os
 import sys
 from functools import partial
 
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__),
-                                             os.path.pardir)))
+sys.path.append(
+    os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir))
+)
 from tqdm import tqdm
 import torch
 import torch.nn.functional as F
@@ -26,38 +27,75 @@ from lm_eval.base import CacheHook
 from lm_eval.models.gpt2 import GPT2LM
 from lm_eval import tasks, evaluator, utils
 from megatron.text_generation_utils import generate_samples_from_prompt
-from megatron.mpu.mappings import gather_from_model_parallel_region
-from megatron import mpu 
+from megatron import mpu
 
-# TODO: add data parallel
 
 class EvalHarnessAdapter(GPT2LM):
+    """
+    An adapter to run NeoX models on LM Evaluation Harness (https://github.com/EleutherAI/lm-evaluation-harness) tasks.
 
+    Args:
+        model: A NeoX Model
+        forward_step_fn: A function that runs a forward pass through the model, returning `tuple(loss, logits)`.
+        neox_args: a NeoXArgs object containing the model configuration.
+        batch_size (optional): An argument to override the batch size, which defaults to batch size per gpu * dp world size.
+    """
     def __init__(self, model, forward_step_fn, neox_args, batch_size=None):
-        self.device = torch.device(f'cuda:{neox_args.local_rank}')
+
+        self.device = torch.device(f"cuda:{neox_args.local_rank}")
         self.VOCAB_SIZE = neox_args.padded_vocab_size
         self.tokenizer = neox_args.tokenizer
         self.EOT_TOKEN_ID = neox_args.tokenizer.eod_id
         self.model = model
-        self._forward_step_fn = partial(forward_step_fn, neox_args=neox_args, timers=None, return_logits=True)
-        self.max_length = neox_args.max_position_embeddings // 2
-        self.max_gen_toks = 128
-        self.tokenizer.encode = self.tokenizer.tokenize  # patch tokenizer encode + decode methods
-        self.tokenizer.decode = self.tokenizer.detokenize
-        self.batch_size = batch_size or neox_args.batch_size
         self.neox_args = neox_args
         self.cache_hook = CacheHook(None)
+        self.max_length = neox_args.max_position_embeddings // 2
+        self.max_gen_toks = 128
+
+        # parallelism args:
         self.is_main = neox_args.rank == 0
         self.is_local_main = neox_args.local_rank == 0
         self.is_model_parallel = neox_args.model_parallel_size > 1
         self.is_pipe_parallel = self.model.is_pipe_parallel
         self.is_data_parallel = self.model.is_data_parallel
-        self.is_last_stage = True if not self.is_pipe_parallel else model.is_last_stage()  # only the last stage of the pipeline model will receive the logits
-        self.generate = partial(generate_samples_from_prompt, neox_args=neox_args, model=model,
-                                maximum_tokens=self.max_gen_toks)
+        self.is_last_stage = (
+            True if not self.is_pipe_parallel else model.is_last_stage()
+        )  # only the last stage of the pipeline model will receive the logits
+        self.dp_world_size = mpu.get_data_parallel_world_size()
+        self.dp_rank = mpu.get_data_parallel_rank()
+        self.dp_group = mpu.get_data_parallel_group()
+        self.is_mp_rank_0 = mpu.get_model_parallel_rank() == 0
+
+        self.batch_size = batch_size or (neox_args.batch_size * self.dp_world_size) # default batch size to bs per gpu * dp size
+
+        # some utility functions:
+        # we need to patch tokenizer methods, because lm_eval uses them internally:
+        self.tokenizer.encode = self.tokenizer.tokenize
+        self.tokenizer.decode = self.tokenizer.detokenize
+        self._forward_step_fn = partial(
+            forward_step_fn, neox_args=neox_args, timers=None, return_logits=True
+        )
+        self.generate = partial(
+            generate_samples_from_prompt,
+            neox_args=neox_args,
+            model=model,
+            maximum_tokens=self.max_gen_toks,
+            temperature=0.0,
+            broadcast_generated_tokens=True,
+        )
 
     def greedy_until(self, requests):
-        self.model.module.inference_mode(cache=True) # tell model to cache kv pairs
+        """
+        Greedy until is lm_eval harness' way to say "do greedy generation" - necessary for some tasks.
+        the eval harness dispatches requests to the model, and the model does argmax generation, the results of which
+        are returned to the eval harness to evaluate.
+
+        TODO: batched / data parallel generation
+
+        :param requests: Dictionary of requests containing the context (prompt) and 'until' - a token or
+                         list of stop tokens.
+        """
+        self.model.module.inference_mode(cache=True)  # tell model to cache kv pairs
         res = []
 
         def _collate(x):
@@ -65,15 +103,19 @@ class EvalHarnessAdapter(GPT2LM):
             return (len(toks), x[0])
 
         reord = utils.Reorderer(requests, _collate)
-        for context, until in tqdm(reord.get_reordered()):
+        for context, until in tqdm(reord.get_reordered(), "Running greedy generation"):
             if isinstance(until, str):
                 until = [until]
             stop_tokens = [self.tokenizer.encode(i) for i in until]
-            cont = self.generate(text=context,
-                                 stop_tokens=stop_tokens,
-                                 recompute=self.neox_args.recompute)
-
-            s = cont[0]['text'] or ''
+            cont = self.generate(
+                text=context,
+                stop_tokens=stop_tokens,
+                recompute=self.neox_args.recompute,
+            )
+            if cont:
+                s = cont[0]["text"] or ""
+            else:
+                s = ""
 
             for term in until:
                 s = s.split(term)[0]
@@ -83,11 +125,20 @@ class EvalHarnessAdapter(GPT2LM):
 
             res.append(s)
 
-        self.model.module.train_mode() # set back to train mode
+        self.model.module.train_mode()  # set back to train mode
         return reord.get_original(res)
 
-    def _loglikelihood_tokens(self, requests, disable_tqdm=False):  
-        self.model.module.inference_mode(cache=False) # tell model to gather parallel outputs, but not cache
+    def _loglikelihood_tokens(self, requests, disable_tqdm=False):
+        """
+        In this method, the model doesn't do any generation, but just returns log likelihoods
+        for the next token, which eval harness uses to evaluate.
+
+        :param requests: Dictionary of requests containing the context and the expected continuation.
+        :param disable_tqdm: If True, disable tqdm progress bar.
+        """
+        self.model.module.inference_mode(
+            cache=False
+        )  # tell model to gather parallel outputs, but not cache key-value pairs
 
         disable_tqdm = disable_tqdm if self.is_main else True
         res = []
@@ -99,25 +150,35 @@ class EvalHarnessAdapter(GPT2LM):
                 return (-len(toks), tuple(toks))
 
             reord = utils.Reorderer(requests, _collate)
-            for chunk in utils.chunks(tqdm(reord.get_reordered(), disable=disable_tqdm), self.batch_size):
+            for chunk in utils.chunks(
+                tqdm(reord.get_reordered(), disable=disable_tqdm), self.batch_size
+            ):
                 inps, contlens, inplens, padding_length = [], [], [], None
                 for _, context_enc, continuation_enc in chunk:
                     # when too long to fit in context, truncate from the left
                     inp = torch.tensor(
-                        (context_enc + continuation_enc)[-(self.max_length + 1):][:-1]
-                        , dtype=torch.long).to(self.device)
-                    inplen, = inp.shape
+                        (context_enc + continuation_enc)[-(self.max_length + 1) :][:-1],
+                        dtype=torch.long,
+                    ).to(self.device)
+                    (inplen,) = inp.shape
 
                     cont = continuation_enc
 
                     # since in _collate we make sure length is descending, the longest is always the first one.
-                    padding_length = padding_length if padding_length is not None else inplen
+                    padding_length = (
+                        padding_length if padding_length is not None else inplen
+                    )
 
                     # pad to length
-                    inp = torch.cat([
-                        inp,  # [seq]
-                        torch.zeros(padding_length - inplen, dtype=torch.long).to(inp.device)  # [padding_length - seq]
-                    ], dim=0)
+                    inp = torch.cat(
+                        [
+                            inp,  # [seq]
+                            torch.zeros(padding_length - inplen, dtype=torch.long).to(
+                                inp.device
+                            ),  # [padding_length - seq]
+                        ],
+                        dim=0,
+                    )
 
                     inps.append(inp.unsqueeze(0))
                     contlens.append(cont)
@@ -128,77 +189,137 @@ class EvalHarnessAdapter(GPT2LM):
 
                 if logits is not None:
                     multi_logits = F.log_softmax(logits, dim=-1)  # [batch, seq, vocab]
-                    for (cache_key, _, _), logits, inp, inplen, cont_toks in zip(chunk, multi_logits, inps, inplens,
-                                                                                 contlens):
+                    for (cache_key, _, _), logits, inp, inplen, cont_toks in zip(
+                        chunk, multi_logits, inps, inplens, contlens
+                    ):
                         contlen = len(cont_toks)
-                        logits = logits[inplen - contlen:inplen].unsqueeze(0)  # [1, seq, vocab]
+                        logits = logits[inplen - contlen : inplen].unsqueeze(
+                            0
+                        )  # [1, seq, vocab]
                         greedy_tokens = logits.argmax(dim=-1)
                         # cont_toks :: [1, seq]
-                        cont_toks = torch.tensor(cont_toks, dtype=torch.long).unsqueeze(0).to(multi_logits.device)
+                        cont_toks = (
+                            torch.tensor(cont_toks, dtype=torch.long)
+                            .unsqueeze(0)
+                            .to(multi_logits.device)
+                        )
                         max_equal = (greedy_tokens == cont_toks).all()
-                        logits = torch.gather(logits, 2, cont_toks.unsqueeze(-1)).squeeze(-1)  # [1, seq]
+                        logits = torch.gather(
+                            logits, 2, cont_toks.unsqueeze(-1)
+                        ).squeeze(
+                            -1
+                        )  # [1, seq]
                         answer = (float(logits.sum()), bool(max_equal))
 
                         # partial caching
                         if cache_key is not None:
-                            self.cache_hook.add_partial("loglikelihood", cache_key, answer)
+                            self.cache_hook.add_partial(
+                                "loglikelihood", cache_key, answer
+                            )
 
                         res.append(answer)
 
-        # broadcast results to all ranks
-        if self.is_pipe_parallel:
-            src_rank = self.model.grid.stage_to_global(self.model.num_stages - 1)
-            if res:
-                logits_sums, max_equals = list(zip(*res))
-                logits_sums = torch.FloatTensor(logits_sums).cuda()
-                max_equals = torch.LongTensor(max_equals).cuda()
-            else:
-                logits_sums = torch.zeros(res_len, dtype=torch.float32).cuda()
-                max_equals = torch.zeros(res_len, dtype=torch.int64).cuda()
-            torch.distributed.broadcast(tensor=logits_sums, src=src_rank)
-            torch.distributed.broadcast(tensor=max_equals, src=src_rank)
-            max_equals = [bool(i) for i in max_equals.tolist()]
-            logits_sums = logits_sums.tolist()
-            res = list(zip(logits_sums, max_equals))
+            # broadcast results to all ranks
+            if self.is_pipe_parallel:
+                src_rank = self.model.grid.stage_to_global(self.model.num_stages - 1)
+                if res:
+                    logits_sums, max_equals = list(zip(*res))
+                    logits_sums = torch.FloatTensor(logits_sums).cuda()
+                    max_equals = torch.LongTensor(max_equals).cuda()
+                else:
+                    logits_sums = torch.zeros(res_len, dtype=torch.float32).cuda()
+                    max_equals = torch.zeros(res_len, dtype=torch.int64).cuda()
+                torch.distributed.broadcast(tensor=logits_sums, src=src_rank)
+                torch.distributed.broadcast(tensor=max_equals, src=src_rank)
+                max_equals = [bool(i) for i in max_equals.tolist()]
+                logits_sums = logits_sums.tolist()
+                res = list(zip(logits_sums, max_equals))
 
-        self.model.module.train_mode() # set back to train mode
+        self.model.module.train_mode()  # set back to train mode
         return reord.get_original(res)
 
-    def _model_call(self, inps):
-        ######## DATA PARALLEL STUFF ########
-        world_size = mpu.get_data_parallel_world_size()
-        assert inps.shape[0] % world_size == 0, f"batch size ({inps.shape[0]}) must be divisible by world size ({world_size})"
-        # get a chunk for each data parallel rank
-        chunk_size = inps.shape[0] // world_size
-        rank = mpu.get_data_parallel_rank()
-        inps = inps[rank * chunk_size:(rank + 1) * chunk_size]
-        #####################################
+    def _dp_scatter(self, inps):
+        """
+        Scatters the inputs to all data parallel ranks.
+        """
 
+        batch_size = inps.shape[0]
+        padded = False
+        if batch_size % self.dp_world_size != 0:
+            # The last batch could potentially not fill the full batch size (if the dataset size is not divisible by batch size)
+            # In this case we pad the batch
+            padded_size = self.dp_world_size - (batch_size % self.dp_world_size)
+
+            print_rank_0(f'WARNING: Batch size ({batch_size}) must be divisible by dp world size ({self.dp_world_size}). Padding inputs to {padded_size}.')
+            
+            inps = torch.cat([inps] + [ inps[0:1, ...] for _ in range(padded_size) ], dim=0) # pad with first inp item
+            padded = True
+
+        assert (
+            inps.shape[0] % self.dp_world_size == 0
+        ), f"batch size ({inps.shape[0]}) must be divisible by dp world size ({self.dp_world_size})"
+
+        # get a chunk for each data parallel rank
+        chunk_size = inps.shape[0] // self.dp_world_size
+        inps = inps[self.dp_rank * chunk_size : (self.dp_rank + 1) * chunk_size]
         # make a dummy dataloader / iterator to pass to model
-        data_wrapped = iter([{'text': F.pad(inps, pad=(0, 1))}]) 
+        # we need to do this because deepspeed pipe parallel only takes an iterator
+        # in this format
+        return iter([{"text": F.pad(inps, pad=(0, 1))}]), padded
+
+    def _dp_gather(self, logits):
+        """
+        Gather logits from all data parallel ranks
+        """
+        if logits is not None:
+            tensor_list = [torch.zeros_like(logits) for _ in range(self.dp_world_size)]
+            torch.distributed.all_gather(
+                tensor_list, logits, group=mpu.get_data_parallel_group()
+            )
+            logits = torch.cat(tensor_list, dim=0)
+            return logits 
+
+    def _model_call(self, inps):
+        batch_size = inps.shape[0]
+
+        # scatter inputs to all dp ranks:
+        inps, padded = self._dp_scatter(inps)
+
         if self.neox_args.is_pipe_parallel:
-            # need these flags to stop deepspeed from hanging
+            # need these flags to stop deepspeed pipe parallel from hanging
             self.model.first_output_send = True
             self.model.pipe_recv_buf = None
-        _, logits = self._forward_step_fn(model=self.model, data_iterator=data_wrapped)
 
-        ######## DATA PARALLEL STUFF ########
-        # gather logits from all ranks
-        if logits is not None:
-            tensor_list = [torch.zeros_like(logits) for _ in range(world_size)]
-            torch.distributed.all_gather(tensor_list, logits, group=mpu.get_data_parallel_group())
-            logits = torch.cat(tensor_list, dim=0)
+        _, logits = self._forward_step_fn(model=self.model, data_iterator=inps)
 
+        # gather outputs from all dp ranks:
+        logits = self._dp_gather(logits)
+
+        # if logits have been padded (normally just last item where batch size is unequal)
+        # restore to original shape
+        if padded and logits is not None:
+            logits = logits[:batch_size, ...]
         return logits
 
-    def run_eval(self, eval_tasks=None):
+    @torch.no_grad()
+    def run_eval(self, eval_tasks=None, num_fewshot=0):
         was_training = self.model.training
         self.model.eval()
-        in_micro_batches = self.model.micro_batches  # store input microbatches - we need to set to 1 during eval
+        in_micro_batches = (
+            self.model.micro_batches
+        )  # store input microbatches - we need to set to 1 during eval, but want to return to its original value after
         self.model.micro_batches = 1
         if eval_tasks is None:
-            eval_tasks = ["lambada", "piqa", "hellaswag", "winogrande", "mathqa", "pubmedqa"]
-            
+            eval_tasks = [
+                "lambada",
+                "piqa",
+                "hellaswag",
+                "winogrande",
+                "mathqa",
+                "pubmedqa",
+            ]
+
+        # **HACK INCOMING**:
         # first get task dict on local main rank
         # the tasks are downloaded *as they are initialized*, and the downloads don't like multithreading.
         # so we download them once on the local main rank, wait, and then initialize them on all other ranks, which *should* load from the cache.
@@ -209,19 +330,24 @@ class EvalHarnessAdapter(GPT2LM):
             torch.distributed.barrier()
         task_dict = tasks.get_task_dict(eval_tasks)
 
-        results = evaluator.evaluate(lm=self,
-                                     task_dict=tasks.get_task_dict(eval_tasks),
-                                     provide_description=False,
-                                     num_fewshot=0,
-                                     limit=None,
-                                     bootstrap_iters=2).get('results')
+        results = evaluator.evaluate(
+            lm=self,
+            task_dict=tasks.get_task_dict(eval_tasks),
+            provide_description=False,
+            num_fewshot=num_fewshot,
+            limit=None,
+            bootstrap_iters=2,
+        ).get("results")
+
         if was_training:
             self.model.train()
         self.model.micro_batches = in_micro_batches
         return results
 
 
-def run_eval_harness(model, forward_step_fn, neox_args, batch_size=None, eval_tasks=None):
-    print_rank_0('Running evaluation harness...')
+def run_eval_harness(
+    model, forward_step_fn, neox_args, batch_size=None, eval_tasks=None, num_fewshot=0,
+):
+    print_rank_0("Running evaluation harness...")
     adapter = EvalHarnessAdapter(model, forward_step_fn, neox_args, batch_size)
-    return adapter.run_eval(eval_tasks=eval_tasks)
+    return adapter.run_eval(eval_tasks=eval_tasks, num_fewshot=num_fewshot)

--- a/eval_tasks/eval_adapter.py
+++ b/eval_tasks/eval_adapter.py
@@ -187,7 +187,7 @@ class EvalHarnessAdapter(GPT2LM):
         # gather logits from all ranks
         if logits is not None:
             tensor_list = [torch.zeros_like(logits) for _ in range(world_size)]
-            torch.distributed.all_gather(tensor_list, logits)
+            torch.distributed.all_gather(tensor_list, logits, group=mpu.get_data_parallel_group())
             logits = torch.cat(tensor_list, dim=0)
 
         return logits

--- a/megatron/checkpointing.py
+++ b/megatron/checkpointing.py
@@ -207,7 +207,7 @@ def load_checkpoint(
     neox_args, model, optimizer, lr_scheduler, inference=False, iteration=None
 ):
     """Load a model checkpoint and return the iteration."""
-
+    print("ITER IN LOAD CHKPT: ", iteration)
     if neox_args.deepspeed:
         load_optim_and_scheduler = (
             not neox_args.no_load_optim

--- a/megatron/checkpointing.py
+++ b/megatron/checkpointing.py
@@ -232,11 +232,11 @@ def load_checkpoint(
             # continuing silently, since we are trying to load a specific checkpoint
             if iteration is not None:
                 available_checkpoints = [
-                    str(i).replace("global_step", "")
+                    i.name.replace("global_step", "")
                     for i in Path(neox_args.load).glob("global_step*")
                 ]
                 raise ValueError(
-                    f"Unable to load checkpoint for iteration {iteration}. \nAvailable checkpoints: {pformat(available_checkpoints)}"
+                    f"Unable to load checkpoint for iteration {iteration}. \nAvailable iterations: {pformat(available_checkpoints)}"
                 )
             if mpu.get_data_parallel_rank() == 0:
                 print("Unable to load checkpoint.")

--- a/megatron/checkpointing.py
+++ b/megatron/checkpointing.py
@@ -33,6 +33,7 @@ from megatron import print_rank_0
 from megatron.utils import natural_sort
 from megatron.text_generation_utils import get_batch, forward_model
 
+
 def check_checkpoint_args(neox_args, checkpoint_args):
     """Ensure fixed arguments for a model are the same for the input
     arguments and the one retreived frm checkpoint."""
@@ -40,33 +41,43 @@ def check_checkpoint_args(neox_args, checkpoint_args):
     assert isinstance(checkpoint_args, dict), "args stored in checkpoint is a dict"
     for checkpoint_arg_name, checkpoint_arg_value in checkpoint_args.items():
         args_value = getattr(neox_args, checkpoint_arg_name)
-        error_message = '{} value from checkpoint ({}) is not equal to the currently set argument value ({}).'.format(checkpoint_arg_name, checkpoint_arg_value, args_value)
+        error_message = "{} value from checkpoint ({}) is not equal to the currently set argument value ({}).".format(
+            checkpoint_arg_name, checkpoint_arg_value, args_value
+        )
         assert checkpoint_arg_value == args_value, error_message
 
+
 def do_forward_pass(neox_args, model, inference=False):
-    
+
     # set to eval mode
     model_was_in_train = model.training
     model.eval()
-    
+
     # get context tokens
     # always forward full batch size
-    context_tokens_tensor = torch.arange(2049).repeat((neox_args.train_micro_batch_size_per_gpu, 1)).cuda()
+    context_tokens_tensor = (
+        torch.arange(2049).repeat((neox_args.train_micro_batch_size_per_gpu, 1)).cuda()
+    )
 
     # forward
     if inference:
-        tokens, attention_mask, position_ids = get_batch(neox_args, context_tokens_tensor[:, :2048])
-        model_inputs = (tokens,
-                        position_ids,
-                        attention_mask,
-                        torch.Tensor(),
-                        )
+        tokens, attention_mask, position_ids = get_batch(
+            neox_args, context_tokens_tensor[:, :2048]
+        )
+        model_inputs = (
+            tokens,
+            position_ids,
+            attention_mask,
+            torch.Tensor(),
+        )
         logits, _ = forward_model(neox_args, model, model_inputs)
     elif neox_args.is_pipe_parallel:
         data_iterator = iter([{"text": context_tokens_tensor}])
         _, logits = model.eval_batch(data_iter=data_iterator, return_logits=True)
     else:
-        tokens, attention_mask, position_ids = get_batch(neox_args, context_tokens_tensor[:, :2048])
+        tokens, attention_mask, position_ids = get_batch(
+            neox_args, context_tokens_tensor[:, :2048]
+        )
         logits = model((tokens, position_ids, attention_mask))
 
     # reset to train mode, if model was in training before
@@ -74,20 +85,30 @@ def do_forward_pass(neox_args, model, inference=False):
         model.train()
 
     if logits is not None:
-        logits = logits.detach().cpu()[0] # just return first batch item (they are all equal)
+        logits = logits.detach().cpu()[
+            0
+        ]  # just return first batch item (they are all equal)
 
     return logits
+
 
 def check_forward_pass(neox_args, model, checkpoint_logits, inference):
     # do forward pass with loaded checkpoint
     logits = do_forward_pass(neox_args=neox_args, model=model, inference=inference)
 
     # check
-    if logits is not None and checkpoint_logits is not None: # this could be the case for non-final pipeline stages
+    if (
+        logits is not None and checkpoint_logits is not None
+    ):  # this could be the case for non-final pipeline stages
         if not (logits == checkpoint_logits).all().item():
             if mpu.get_data_parallel_rank() == 0:
-                    print(" > WARNING: validate_checkpoint_forward() forward after load of checkpoint does not yield exactly same result")
-            assert torch.isclose(logits, checkpoint_logits).all().item(), "validate_checkpoint_forward() forward after load of checkpoint does not yield a close result"
+                print(
+                    " > WARNING: validate_checkpoint_forward() forward after load of checkpoint does not yield exactly same result"
+                )
+            assert (
+                torch.isclose(logits, checkpoint_logits).all().item()
+            ), "validate_checkpoint_forward() forward after load of checkpoint does not yield a close result"
+
 
 def ensure_directory_exists(filename):
     """Build filename's path if it does not already exists."""
@@ -95,26 +116,35 @@ def ensure_directory_exists(filename):
     if not os.path.exists(dirname):
         os.makedirs(dirname)
 
-def get_checkpoint_name(checkpoints_path, iteration,
-                        release=False, mp_rank=None):
+
+def get_checkpoint_name(checkpoints_path, iteration, release=False, mp_rank=None):
     """A unified checkpoint name."""
     if release:
-        directory = 'release'
+        directory = "release"
     else:
-        directory = 'iter_{:07d}'.format(iteration)
-    return os.path.join(checkpoints_path, directory,
-                        'mp_rank_{:02d}'.format(
-                            mpu.get_model_parallel_rank() if mp_rank is None
-                            else mp_rank),
-                        'model_optim_rng.pt')
+        directory = "iter_{:07d}".format(iteration)
+    return os.path.join(
+        checkpoints_path,
+        directory,
+        "mp_rank_{:02d}".format(
+            mpu.get_model_parallel_rank() if mp_rank is None else mp_rank
+        ),
+        "model_optim_rng.pt",
+    )
+
 
 def delete_old_checkpoints(save_dir, n_to_keep):
     if torch.distributed.get_rank() == 0:
-        ckpt_dir_regex = r'global_step[\d]*'
-        if save_dir.endswith('/'):
-            save_dir = save_dir.strip('/')
-        all_ckpts = natural_sort([i for i in glob(f'{save_dir}/*') if os.path.isdir(i)
-                                  and re.search(ckpt_dir_regex, i)])
+        ckpt_dir_regex = r"global_step[\d]*"
+        if save_dir.endswith("/"):
+            save_dir = save_dir.strip("/")
+        all_ckpts = natural_sort(
+            [
+                i
+                for i in glob(f"{save_dir}/*")
+                if os.path.isdir(i) and re.search(ckpt_dir_regex, i)
+            ]
+        )
         n_to_delete = len(all_ckpts) - n_to_keep
         if n_to_delete > 0:
             to_delete = all_ckpts[:n_to_delete]
@@ -125,34 +155,36 @@ def delete_old_checkpoints(save_dir, n_to_keep):
                 except FileNotFoundError:
                     pass
 
+
 def save_ds_checkpoint(iteration, model, neox_args):
     """Save a model checkpoint."""
     sd = {
-        'iteration': iteration,
-        'args': {
-            'num_layers': neox_args.num_layers,
-            'hidden_size': neox_args.hidden_size,
-            'num_attention_heads': neox_args.num_attention_heads,
-            'max_position_embeddings': neox_args.max_position_embeddings,
-            'make_vocab_size_divisible_by': neox_args.make_vocab_size_divisible_by,
-            'padded_vocab_size': neox_args.padded_vocab_size,
-            'tokenizer_type': neox_args.tokenizer_type,
-            'model_parallel_size': neox_args.model_parallel_size
-            }
-        }
+        "iteration": iteration,
+        "args": {
+            "num_layers": neox_args.num_layers,
+            "hidden_size": neox_args.hidden_size,
+            "num_attention_heads": neox_args.num_attention_heads,
+            "max_position_embeddings": neox_args.max_position_embeddings,
+            "make_vocab_size_divisible_by": neox_args.make_vocab_size_divisible_by,
+            "padded_vocab_size": neox_args.padded_vocab_size,
+            "tokenizer_type": neox_args.tokenizer_type,
+            "model_parallel_size": neox_args.model_parallel_size,
+        },
+    }
     # rng states.
     if not neox_args.no_save_rng:
-        sd['random_rng_state'] = random.getstate()
-        sd['np_rng_state'] = np.random.get_state()
-        sd['torch_rng_state'] = torch.get_rng_state()
-        sd['cuda_rng_state'] = torch.cuda.get_rng_state()
-        sd['rng_tracker_states'] = mpu.get_cuda_rng_tracker().get_states()
-    
+        sd["random_rng_state"] = random.getstate()
+        sd["np_rng_state"] = np.random.get_state()
+        sd["torch_rng_state"] = torch.get_rng_state()
+        sd["cuda_rng_state"] = torch.cuda.get_rng_state()
+        sd["rng_tracker_states"] = mpu.get_cuda_rng_tracker().get_states()
+
     if neox_args.checkpoint_validation_with_forward_pass:
         logits = do_forward_pass(neox_args=neox_args, model=model)
-        sd['checkpoint_validation_logits'] = logits
-    
+        sd["checkpoint_validation_logits"] = logits
+
     model.save_checkpoint(neox_args.save, client_state=sd)
+
 
 def save_checkpoint(neox_args, iteration, model, optimizer, lr_scheduler):
     """Save a model checkpoint."""
@@ -160,7 +192,7 @@ def save_checkpoint(neox_args, iteration, model, optimizer, lr_scheduler):
     if neox_args.deepspeed:
         save_ds_checkpoint(iteration, model, neox_args)
     else:
-        raise ValueError('Must be using deepspeed to use neox')
+        raise ValueError("Must be using deepspeed to use neox")
 
     # Wait so everyone is done (necessary)
     torch.distributed.barrier()
@@ -170,72 +202,95 @@ def save_checkpoint(neox_args, iteration, model, optimizer, lr_scheduler):
     # Wait so everyone is done (not necessary)
     torch.distributed.barrier()
 
-def load_checkpoint(neox_args, model, optimizer, lr_scheduler, inference=False):
+
+def load_checkpoint(
+    neox_args, model, optimizer, lr_scheduler, inference=False, iteration=None
+):
     """Load a model checkpoint and return the iteration."""
 
     if neox_args.deepspeed:
-        load_optim_and_scheduler = not neox_args.no_load_optim  # TODO: These should be configured by separate args
+        load_optim_and_scheduler = (
+            not neox_args.no_load_optim
+        )  # TODO: These should be configured by separate args
         if neox_args.finetune:
             load_optim_and_scheduler = False
-        checkpoint_name, state_dict = model.load_checkpoint(neox_args.load,
-                                                            load_optimizer_states=load_optim_and_scheduler,
-                                                            load_lr_scheduler_states=load_optim_and_scheduler)
+        if iteration is not None:
+            tag = f"global_step{iteration}"
+        else:
+            tag = None
+        checkpoint_name, state_dict = model.load_checkpoint(
+            neox_args.load,
+            load_optimizer_states=load_optim_and_scheduler,
+            load_lr_scheduler_states=load_optim_and_scheduler,
+            tag=tag,
+        )
 
         if checkpoint_name is None:
             if mpu.get_data_parallel_rank() == 0:
                 print("Unable to load checkpoint.")
-            return 0 # iteration 0, if not checkpoint loaded
+            return 0  # iteration 0, if not checkpoint loaded
     else:
-        raise ValueError('Must be using deepspeed to use neox')
+        raise ValueError("Must be using deepspeed to use neox")
 
     # Set iteration.
     if neox_args.finetune:
         iteration = 0
     else:
-        iteration = state_dict.get('iteration') or state_dict.get("total_iters") # total_iters backward compatible with older checkpoints
+        iteration = state_dict.get("iteration") or state_dict.get(
+            "total_iters"
+        )  # total_iters backward compatible with older checkpoints
         if iteration is None:
-            raise ValueError(f'Unable to load iteration from checkpoint {checkpoint_name} with keys {state_dict.keys()}, exiting')
+            raise ValueError(
+                f"Unable to load iteration from checkpoint {checkpoint_name} with keys {state_dict.keys()}, exiting"
+            )
 
     # Check arguments.
-    if 'args' in state_dict:
-        checkpoint_args = state_dict['args']
+    if "args" in state_dict:
+        checkpoint_args = state_dict["args"]
         check_checkpoint_args(neox_args=neox_args, checkpoint_args=checkpoint_args)
-        print_rank_0(' > validated currently set args with arguments in the checkpoint ...')
+        print_rank_0(
+            " > validated currently set args with arguments in the checkpoint ..."
+        )
     else:
-        print_rank_0(' > could not find arguments in the checkpoint for validation...')
+        print_rank_0(" > could not find arguments in the checkpoint for validation...")
 
     # Check loaded checkpoint with forward pass
     if neox_args.checkpoint_validation_with_forward_pass:
         if "checkpoint_validation_logits" in state_dict:
             check_forward_pass(
-                neox_args=neox_args, 
-                model=model, 
+                neox_args=neox_args,
+                model=model,
                 checkpoint_logits=state_dict["checkpoint_validation_logits"],
-                inference=inference
-                )
-            print_rank_0(' > validated loaded checkpoint with forward pass ...')
+                inference=inference,
+            )
+            print_rank_0(" > validated loaded checkpoint with forward pass ...")
         else:
             if mpu.get_data_parallel_rank() == 0:
-                print(' > WARNING: checkpoint_validation_with_forward_pass is configured but no checkpoint validation data available in checkpoint {}'.format(checkpoint_name))
+                print(
+                    " > WARNING: checkpoint_validation_with_forward_pass is configured but no checkpoint validation data available in checkpoint {}".format(
+                        checkpoint_name
+                    )
+                )
 
     # rng states.
     if not neox_args.finetune and not neox_args.no_load_rng:
         try:
-            random.setstate(state_dict['random_rng_state'])
-            np.random.set_state(state_dict['np_rng_state'])
-            torch.set_rng_state(state_dict['torch_rng_state'])
-            torch.cuda.set_rng_state(state_dict['cuda_rng_state'])
-            mpu.get_cuda_rng_tracker().set_states(
-                state_dict['rng_tracker_states'])
+            random.setstate(state_dict["random_rng_state"])
+            np.random.set_state(state_dict["np_rng_state"])
+            torch.set_rng_state(state_dict["torch_rng_state"])
+            torch.cuda.set_rng_state(state_dict["cuda_rng_state"])
+            mpu.get_cuda_rng_tracker().set_states(state_dict["rng_tracker_states"])
         except KeyError:
-            print_rank_0('Unable to load optimizer from checkpoint {}. '
-                         'Specify --no-load-rng or --finetune to prevent '
-                         'attempting to load the optimizer state, '
-                         'exiting ...'.format(checkpoint_name))
+            print_rank_0(
+                "Unable to load optimizer from checkpoint {}. "
+                "Specify --no-load-rng or --finetune to prevent "
+                "attempting to load the optimizer state, "
+                "exiting ...".format(checkpoint_name)
+            )
             sys.exit()
 
     torch.distributed.barrier()
     if mpu.get_data_parallel_rank() == 0:
-        print('  successfully loaded {}'.format(checkpoint_name))
+        print("  successfully loaded {}".format(checkpoint_name))
 
     return iteration

--- a/megatron/checkpointing.py
+++ b/megatron/checkpointing.py
@@ -232,7 +232,7 @@ def load_checkpoint(
             # continuing silently, since we are trying to load a specific checkpoint
             if iteration is not None:
                 available_checkpoints = [
-                    i.replace("global_step", "")
+                    str(i).replace("global_step", "")
                     for i in Path(neox_args.load).glob("global_step*")
                 ]
                 raise ValueError(

--- a/megatron/checkpointing.py
+++ b/megatron/checkpointing.py
@@ -209,7 +209,6 @@ def load_checkpoint(
     neox_args, model, optimizer, lr_scheduler, inference=False, iteration=None
 ):
     """Load a model checkpoint and return the iteration."""
-    print("ITER IN LOAD CHKPT: ", iteration)
     if neox_args.deepspeed:
         load_optim_and_scheduler = (
             not neox_args.no_load_optim
@@ -231,10 +230,12 @@ def load_checkpoint(
             # if an iteration is specified, we want to raise an error here rather than
             # continuing silently, since we are trying to load a specific checkpoint
             if iteration is not None:
-                available_checkpoints = [
-                    i.name.replace("global_step", "")
-                    for i in Path(neox_args.load).glob("global_step*")
-                ]
+                available_checkpoints = sorted(
+                    [
+                        int(i.name.replace("global_step", ""))
+                        for i in Path(neox_args.load).glob("global_step*")
+                    ]
+                )
                 raise ValueError(
                     f"Unable to load checkpoint for iteration {iteration}. \nAvailable iterations: {pformat(available_checkpoints)}"
                 )

--- a/megatron/neox_arguments/arguments.py
+++ b/megatron/neox_arguments/arguments.py
@@ -247,6 +247,9 @@ class NeoXArgs(*BASE_CLASSES):
             default=None,
             help="Team name for Weights and Biases.",
         )
+
+        group = parser.add_argument_group(title="Misc. args")
+
         group.add_argument(
             "--eval_tasks",
             type=str,
@@ -277,15 +280,10 @@ class NeoXArgs(*BASE_CLASSES):
 
         # determine overwrite values
         overwrite_values = dict()
-        if args_parsed.wandb_group is not None:
-            overwrite_values["wandb_group"] = args_parsed.wandb_group
-        if args_parsed.wandb_team is not None:
-            overwrite_values["wandb_team"] = args_parsed.wandb_team
-        if args_parsed.user_script is not None:
-            overwrite_values["user_script"] = args_parsed.user_script
-        if args_parsed.eval_tasks is not None:
-            overwrite_values["eval_tasks"] = args_parsed.eval_tasks
-
+        for k, v in vars(args_parsed).items():
+            if k not in ["user_script", "conf_dir", "conf_file"] and v is not None:
+                overwrite_values[k] = v
+                
         # load args
         neox_args = cls.from_ymls(
             paths_to_yml_files=conf_files, overwrite_values=overwrite_values

--- a/megatron/neox_arguments/arguments.py
+++ b/megatron/neox_arguments/arguments.py
@@ -281,9 +281,9 @@ class NeoXArgs(*BASE_CLASSES):
         # determine overwrite values
         overwrite_values = dict()
         for k, v in vars(args_parsed).items():
-            if k not in ["user_script", "conf_dir", "conf_file"] and v is not None:
+            if k not in ["conf_dir", "conf_file"] and v is not None:
                 overwrite_values[k] = v
-                
+
         # load args
         neox_args = cls.from_ymls(
             paths_to_yml_files=conf_files, overwrite_values=overwrite_values

--- a/megatron/neox_arguments/arguments.py
+++ b/megatron/neox_arguments/arguments.py
@@ -248,7 +248,7 @@ class NeoXArgs(*BASE_CLASSES):
             help="Team name for Weights and Biases.",
         )
 
-        group = parser.add_argument_group(title="Misc. args")
+        group = parser.add_argument_group(title="Eval args")
 
         group.add_argument(
             "--eval_tasks",
@@ -262,6 +262,12 @@ class NeoXArgs(*BASE_CLASSES):
             type=int,
             default=None,
             help="Iteration to load checkpoint from in evaluate.py / generate.py. If None is provided, uses the latest iteration.",
+        )
+        group.add_argument(
+            "--eval_results_prefix",
+            type=str,
+            default=None,
+            help="prefix to append to eval results file",
         )
         args_parsed = parser.parse_args()
 

--- a/megatron/neox_arguments/arguments.py
+++ b/megatron/neox_arguments/arguments.py
@@ -11,6 +11,7 @@ import shutil
 from dataclasses import dataclass
 from typing import List, Dict
 from socket import gethostname
+
 try:
     from typing import Literal
 except ImportError:
@@ -20,8 +21,18 @@ from megatron.logging import Tee
 from megatron.tokenizer import build_tokenizer
 from megatron.utils import obtain_resource_pool, expand_attention_types
 from .deepspeed_args import NeoXArgsDeepspeedConfig, NeoXArgsDeepspeedRunner
-from .neox_args import NeoXArgsModel, NeoXArgsTokenizer, NeoXArgsTraining, NeoXArgsParallelism, \
-    NeoXArgsLogging, NeoXArgsOther, NeoXArgsTextgen, NeoXArgsOptimizer, NeoXArgsLRScheduler, ATTENTION_TYPE_CHOICES
+from .neox_args import (
+    NeoXArgsModel,
+    NeoXArgsTokenizer,
+    NeoXArgsTraining,
+    NeoXArgsParallelism,
+    NeoXArgsLogging,
+    NeoXArgsOther,
+    NeoXArgsTextgen,
+    NeoXArgsOptimizer,
+    NeoXArgsLRScheduler,
+    ATTENTION_TYPE_CHOICES,
+)
 
 # ZERO defaults by deespeed
 # These values should not be changed unless defaults in deepspeed are changed
@@ -34,22 +45,19 @@ ZERO_DEFAULTS = {
     "reduce_scatter": True,
     "reduce_bucket_size": int(5e8),
     "contiguous_gradients": False,
-    "cpu_offload": False
+    "cpu_offload": False,
 }
 
 # NeoX optimizer defaults
 OPT_DEFAULT = "Adam"
 OPT_PARAMS_DEFAULTS = {
     "lr": 0.001,
-    "betas": [
-        0.9,
-        0.999
-    ],
+    "betas": [0.9, 0.999],
     "eps": 1.0e-8,
     "weight_decay": 0,
     "freeze_step": 400,
     "momentum": 0.0,
-    "cuda_aware": False
+    "cuda_aware": False,
 }
 
 BASE_CLASSES = [
@@ -63,7 +71,7 @@ BASE_CLASSES = [
     NeoXArgsParallelism,
     NeoXArgsLogging,
     NeoXArgsTextgen,
-    NeoXArgsOther
+    NeoXArgsOther,
 ]
 
 DEEPSPEED_ARG_CLASSES = [NeoXArgsDeepspeedRunner, NeoXArgsDeepspeedConfig]
@@ -83,22 +91,31 @@ class NeoXArgs(*BASE_CLASSES):
 
     def __post_init__(self):
         """
-        after initialization of default or loaded values 
-        a number of functions are performed in order to 
+        after initialization of default or loaded values
+        a number of functions are performed in order to
         calculate values, assert consistency and do typechecking.
         """
         if not NeoXArgs.validate_keys():
-            raise ValueError(self.__class__.__name__ + ".__post_init__() NeoXArgs keys cannot be validated")
+            raise ValueError(
+                self.__class__.__name__
+                + ".__post_init__() NeoXArgs keys cannot be validated"
+            )
 
         self.enable_logging()
 
         self.calculate_derived()
 
         if not self.validate_types():
-            raise ValueError(self.__class__.__name__ + ".__post_init__() NeoXArgs types cannot be validated")
+            raise ValueError(
+                self.__class__.__name__
+                + ".__post_init__() NeoXArgs types cannot be validated"
+            )
 
         if not self.validate_values():
-            raise ValueError(self.__class__.__name__ + ".__post_init__() NeoXArgs values cannot be validated")
+            raise ValueError(
+                self.__class__.__name__
+                + ".__post_init__() NeoXArgs values cannot be validated"
+            )
 
     def build_tokenizer(self):
         self.tokenizer = build_tokenizer(self)
@@ -107,12 +124,16 @@ class NeoXArgs(*BASE_CLASSES):
         if self.tensorboard_dir and self.rank == 0:
             try:
                 from torch.utils.tensorboard import SummaryWriter
-                print('> setting tensorboard ...')
+
+                print("> setting tensorboard ...")
                 self.tensorboard_writer = SummaryWriter(log_dir=self.tensorboard_dir)
             except (ModuleNotFoundError, ImportError):
-                print('WARNING: TensorBoard writing requested but is not '
-                    'available (are you using PyTorch 1.1.0 or later and do you have tensorboard installed?), '
-                    'no TensorBoard logs will be written.', flush=True)
+                print(
+                    "WARNING: TensorBoard writing requested but is not "
+                    "available (are you using PyTorch 1.1.0 or later and do you have tensorboard installed?), "
+                    "no TensorBoard logs will be written.",
+                    flush=True,
+                )
 
     @classmethod
     def from_ymls(cls, paths_to_yml_files: List[str], overwrite_values: Dict = None):
@@ -140,17 +161,24 @@ class NeoXArgs(*BASE_CLASSES):
             for conf_key, conf_value in conf.items():
                 if conf_key in config:
                     raise ValueError(
-                        f'Conf file {conf_file_name} has the following duplicate keys with previously loaded file: {conf_key}')
+                        f"Conf file {conf_file_name} has the following duplicate keys with previously loaded file: {conf_key}"
+                    )
 
-                conf_key_converted = conf_key.replace("-", "_")  # TODO remove replace and update configuration files?
+                conf_key_converted = conf_key.replace(
+                    "-", "_"
+                )  # TODO remove replace and update configuration files?
                 config[conf_key_converted] = conf_value
 
         # Configuration parameters not specified
-        params_not_in_config = sorted(list(set(cls.__dataclass_fields__.keys()) - set(config.keys())))
+        params_not_in_config = sorted(
+            list(set(cls.__dataclass_fields__.keys()) - set(config.keys()))
+        )
         if len(params_not_in_config) > 0:
             logging.debug(
-                cls.__name__ + ".from_ymls() Configuration parameters not specified (using defaults): " + ", ".join(
-                    params_not_in_config))
+                cls.__name__
+                + ".from_ymls() Configuration parameters not specified (using defaults): "
+                + ", ".join(params_not_in_config)
+            )
 
         if overwrite_values is not None:
             for k, v in overwrite_values.items():
@@ -174,42 +202,70 @@ class NeoXArgs(*BASE_CLASSES):
     def consume_deepy_args(cls):
         """
         entry point for deepy.py configuring and consuming command line arguments.
-        
+
         We can use `--wandb_group` / `--wandb_team` to overwrite those args from the command line, otherwise the value from the config is taken.
         """
 
-        parser = argparse.ArgumentParser(description='GPT-NeoX Configuration',
-                                         allow_abbrev=False)
+        parser = argparse.ArgumentParser(
+            description="GPT-NeoX Configuration", allow_abbrev=False
+        )
 
-        group = parser.add_argument_group(title='Training Configuration')
+        group = parser.add_argument_group(title="Training Configuration")
 
-        group.add_argument("user_script",
-                           type=str,
-                           help="User script to launch, followed by any required "
-                                "arguments.")
+        group.add_argument(
+            "user_script",
+            type=str,
+            help="User script to launch, followed by any required " "arguments.",
+        )
 
-        group.add_argument("--conf_dir", '-d',
-                           type=str,
-                           default=None,
-                           help="Directory to prefix to all configuration file paths")
+        group.add_argument(
+            "--conf_dir",
+            "-d",
+            type=str,
+            default=None,
+            help="Directory to prefix to all configuration file paths",
+        )
 
-        group.add_argument("conf_file",
-                           type=str,
-                           nargs='+',
-                           help="Configuration file path. Multiple files can be provided and will be merged.")
+        group.add_argument(
+            "conf_file",
+            type=str,
+            nargs="+",
+            help="Configuration file path. Multiple files can be provided and will be merged.",
+        )
 
-        group = parser.add_argument_group(title='Weights and Biases monitoring args')
+        group = parser.add_argument_group(title="Weights and Biases monitoring args")
 
-        group.add_argument('--wandb_group', type=str, default=None,
-                           help='Weights and Biases group name - used to group together "runs".')
-        group.add_argument('--wandb_team', type=str, default=None,
-                           help='Team name for Weights and Biases.')
-        group.add_argument('--eval_tasks', type=str, nargs='+', default=None, help='Optionally overwrite eval tasks to run for evaluate.py')
-
+        group.add_argument(
+            "--wandb_group",
+            type=str,
+            default=None,
+            help='Weights and Biases group name - used to group together "runs".',
+        )
+        group.add_argument(
+            "--wandb_team",
+            type=str,
+            default=None,
+            help="Team name for Weights and Biases.",
+        )
+        group.add_argument(
+            "--eval_tasks",
+            type=str,
+            nargs="+",
+            default=None,
+            help="Optionally overwrite eval tasks to run for evaluate.py",
+        )
+        group.add_argument(
+            "--iteration",
+            type=int,
+            default=None,
+            help="Iteration to load checkpoint from in evaluate.py / generate.py. If None is provided, uses the latest iteration.",
+        )
         args_parsed = parser.parse_args()
 
         # Validate user_script exists
-        assert os.path.exists(args_parsed.user_script), f"User script could not be found: {args_parsed.user_script}"
+        assert os.path.exists(
+            args_parsed.user_script
+        ), f"User script could not be found: {args_parsed.user_script}"
 
         # load config files
         conf_files = args_parsed.conf_file
@@ -217,7 +273,7 @@ class NeoXArgs(*BASE_CLASSES):
             conf_files = [os.path.join(args_parsed.conf_dir, f) for f in conf_files]
 
         # enables us to pass in `small` instead of `small.yml`
-        conf_files = [(cf if cf.endswith('.yml') else cf + ".yml") for cf in conf_files]
+        conf_files = [(cf if cf.endswith(".yml") else cf + ".yml") for cf in conf_files]
 
         # determine overwrite values
         overwrite_values = dict()
@@ -231,27 +287,30 @@ class NeoXArgs(*BASE_CLASSES):
             overwrite_values["eval_tasks"] = args_parsed.eval_tasks
 
         # load args
-        neox_args = cls.from_ymls(paths_to_yml_files=conf_files, overwrite_values=overwrite_values)
-
+        neox_args = cls.from_ymls(
+            paths_to_yml_files=conf_files, overwrite_values=overwrite_values
+        )
 
         # save a copy of yaml configs to the save directory
         if neox_args.save is not None:
             configs_directory = os.path.join(neox_args.save, "configs")
-            
+
             # If loading the conf files from the save directory
             # deleting the conf files in the following step would
             # naturally prevent the later copy. Therefore we are first
-            # loading the files into memory. 
+            # loading the files into memory.
             conf_files_memory = dict()
             for conf_file in conf_files:
-                conf_files_memory[os.path.basename(conf_file)] = open(conf_file, "r").read()
-            
+                conf_files_memory[os.path.basename(conf_file)] = open(
+                    conf_file, "r"
+                ).read()
+
             # Delete the configs subdirectory in save if it already exists.
             # Reason: only the latest version of the configs are stored
-            # All files are deleted because selecting a subset of configs 
+            # All files are deleted because selecting a subset of configs
             # is a valid option. We would like to prevent keeping files
             # which are not part of the latest config. If data is saved to
-            # a previously non-empty save directory. 
+            # a previously non-empty save directory.
             if os.path.isdir(configs_directory):
                 shutil.rmtree(configs_directory)
 
@@ -264,6 +323,7 @@ class NeoXArgs(*BASE_CLASSES):
         if neox_args.wandb_group is not None:
             # concat the wandb group name with a uid to make sure it's unique
             import wandb
+
             neox_args.wandb_group += "_" + wandb.util.generate_id()
         neox_args.print()
 
@@ -273,17 +333,22 @@ class NeoXArgs(*BASE_CLASSES):
     def consume_neox_args(cls, overwrite_values=None):
         """
         Deepspeed launcher needs to pass the arguments for `pretrain_gpt2.py` across to all machines.
-        
+
         In order not to have any problems with different configs being mismatched across machines, we instead read the .yaml configuration file from the main rank,
         then serialize the arguments to a dictionary, which the deepspeed launcher broadcasts to all machines (`--megatron_config`).
-        
+
         We then instantiate a new NeoXArgs from the dictionary (`.from_dict`). This should ensure args are never inconsistent across machines.
         """
 
-        parser = argparse.ArgumentParser(description='GPT-NeoX Configuration',
-                                         allow_abbrev=False)
-        parser.add_argument('--megatron_config', type=str, default=None,
-                            help='json dict dumped as string in NeoXArgs.get_deepspeed_main_args()')
+        parser = argparse.ArgumentParser(
+            description="GPT-NeoX Configuration", allow_abbrev=False
+        )
+        parser.add_argument(
+            "--megatron_config",
+            type=str,
+            default=None,
+            help="json dict dumped as string in NeoXArgs.get_deepspeed_main_args()",
+        )
 
         args_parsed, _ = parser.parse_known_args()
         megatron_config = json.loads(args_parsed.megatron_config)
@@ -295,12 +360,12 @@ class NeoXArgs(*BASE_CLASSES):
     def convert_key_value_to_command_line_arg(k, v):
         if isinstance(v, bool):
             if v:
-                return [f'--{k}']
+                return [f"--{k}"]
             else:
                 return []
         if v is None:
             return []
-        return [f'--{k}', str(v)]
+        return [f"--{k}", str(v)]
 
     def get_deepspeed_main_args(self):
 
@@ -310,12 +375,18 @@ class NeoXArgs(*BASE_CLASSES):
         for key, default_value in NeoXArgsDeepspeedRunner().defaults():
             configured_value = getattr(self, key)
             if configured_value != default_value:
-                args_list.extend(self.convert_key_value_to_command_line_arg(key, configured_value))
+                args_list.extend(
+                    self.convert_key_value_to_command_line_arg(key, configured_value)
+                )
 
-        if ('--include' in args_list or '--exclude' in args_list) and '--num_gpus' in args_list:
-            print('WARNING: both --include/--exclude and num_gpus were specified simultaneously - overriding num_gpus with --include/--exclude')
+        if (
+            "--include" in args_list or "--exclude" in args_list
+        ) and "--num_gpus" in args_list:
+            print(
+                "WARNING: both --include/--exclude and num_gpus were specified simultaneously - overriding num_gpus with --include/--exclude"
+            )
             # cannot specify these both simultaneously, remove num_gpus from list
-            idx = args_list.index('--num_gpus')
+            idx = args_list.index("--num_gpus")
             # pop twice, once for the arg, once for its value
             args_list.pop(idx)
             args_list.pop(idx)
@@ -329,7 +400,9 @@ class NeoXArgs(*BASE_CLASSES):
 
         # get all config values
         args_list.append("--megatron_config")
-        neox_args = self.get_parent_class_value_dict(*self.__class__.__bases__, only_non_defaults=True)
+        neox_args = self.get_parent_class_value_dict(
+            *self.__class__.__bases__, only_non_defaults=True
+        )
         args_list.append(json.dumps(neox_args))
 
         return args_list
@@ -342,7 +415,9 @@ class NeoXArgs(*BASE_CLASSES):
         """
         returns a dict containing variables within deepspeed config
         """
-        return self.get_parent_class_value_dict(NeoXArgsDeepspeedConfig, only_non_defaults=True)
+        return self.get_parent_class_value_dict(
+            NeoXArgsDeepspeedConfig, only_non_defaults=True
+        )
 
     @property
     def deepspeed_runner(self) -> dict:
@@ -365,7 +440,9 @@ class NeoXArgs(*BASE_CLASSES):
         """
         return self.get_parent_class_value_dict(*BASE_CLASSES)
 
-    def get_parent_class_value_dict(self, *parent_classes, only_non_defaults=False) -> dict:
+    def get_parent_class_value_dict(
+        self, *parent_classes, only_non_defaults=False
+    ) -> dict:
         """
         takes a sequence of parent classes and returns corresponding values (with defaults set)
         """
@@ -373,11 +450,12 @@ class NeoXArgs(*BASE_CLASSES):
         result = dict()
         for parent in parent_classes:
             for key, default_value in parent().defaults():
-                if key in ["tokenizer", "tensorboard_writer", "adlr_autoresume_object"]: 
+                if key in ["tokenizer", "tensorboard_writer", "adlr_autoresume_object"]:
                     continue
                 if only_non_defaults:
                     value = getattr(self, key)
-                    if value == default_value: continue
+                    if value == default_value:
+                        continue
                 result[key] = getattr(self, key)
         return result
 
@@ -404,33 +482,39 @@ class NeoXArgs(*BASE_CLASSES):
             os.makedirs(self.log_dir, exist_ok=True)
             hostname = gethostname()
             file_prefix = os.path.join(self.log_dir, hostname)
-            Tee(file_prefix + '_stdout.txt', err=False)
-            Tee(file_prefix + '_stderr.txt', err=True)
+            Tee(file_prefix + "_stdout.txt", err=False)
+            Tee(file_prefix + "_stderr.txt", err=True)
 
     def print(self):
         """Print arguments."""
         if self.rank == 0 or self.rank is None:
-            print('-------------------- arguments --------------------', flush=True)
+            print("-------------------- arguments --------------------", flush=True)
             str_list = []
             for arg in vars(self):
                 # add arg + value
-                dots = '.' * (32 - len(arg))
+                dots = "." * (32 - len(arg))
                 value = getattr(self, arg)
-                print_str = '  {} {} {}'.format(arg, dots, value)
+                print_str = "  {} {} {}".format(arg, dots, value)
 
                 # add info 'default or updated'
                 field_def = self.__dataclass_fields__.get(arg)
                 if field_def is not None:
-                    default_info = "default" if value == field_def.default else "updated"
+                    default_info = (
+                        "default" if value == field_def.default else "updated"
+                    )
                 else:
                     default_info = ""
-                dots = '.' * (64 - len(print_str))
-                print_str += dots 
+                dots = "." * (64 - len(print_str))
+                print_str += dots
                 str_list.append({"print_str": print_str, "default_info": default_info})
-            
-            for arg in sorted(sorted(str_list, key=lambda x: x["print_str"].lower()), key=lambda x: x["default_info"], reverse=True):
-                print(arg["print_str"]+arg["default_info"], flush=True)
-            print('---------------- end of arguments ----------------', flush=True)
+
+            for arg in sorted(
+                sorted(str_list, key=lambda x: x["print_str"].lower()),
+                key=lambda x: x["default_info"],
+                reverse=True,
+            ):
+                print(arg["print_str"] + arg["default_info"], flush=True)
+            print("---------------- end of arguments ----------------", flush=True)
 
     ############################################################################################################################
     # start of calculations and derived values
@@ -441,40 +525,42 @@ class NeoXArgs(*BASE_CLASSES):
         """
         if self.deepspeed_mpi:
             from deepspeed.utils.distributed import mpi_discovery
+
             mpi_discovery()
 
-        self.update_value("local_rank", int(os.getenv('LOCAL_RANK', '0')))
-        self.update_value("rank", int(os.getenv('RANK', '0')))
-        self.update_value("world_size", int(os.getenv("WORLD_SIZE", '1')))
-        
+        self.update_value("local_rank", int(os.getenv("LOCAL_RANK", "0")))
+        self.update_value("rank", int(os.getenv("RANK", "0")))
+        self.update_value("world_size", int(os.getenv("WORLD_SIZE", "1")))
+
         if self.rank == 0:
             print(
-                self.__class__.__name__ + ".configure_distributed_args() using world size: {} and model-parallel size: {} ".format(
-                    self.world_size, self.model_parallel_size), flush=True)
+                self.__class__.__name__
+                + ".configure_distributed_args() using world size: {} and model-parallel size: {} ".format(
+                    self.world_size, self.model_parallel_size
+                ),
+                flush=True,
+            )
 
     @staticmethod
-    def calculate_batch_parameters(dp_world_size, train_batch=None, micro_batch=None, grad_acc=None):
+    def calculate_batch_parameters(
+        dp_world_size, train_batch=None, micro_batch=None, grad_acc=None
+    ):
         # all values are provided nothing needs to be set
-        if train_batch is not None and \
-                micro_batch is not None and \
-                grad_acc is not None:
+        if train_batch is not None and micro_batch is not None and grad_acc is not None:
             return train_batch, micro_batch, grad_acc
 
         # gradient_accumulation_steps needs to be set
-        elif train_batch is not None and \
-                micro_batch is not None:
+        elif train_batch is not None and micro_batch is not None:
             grad_acc = train_batch // micro_batch
             grad_acc //= dp_world_size
 
         # micro_batch_per_gpu needs to be set
-        elif train_batch is not None and \
-                grad_acc is not None:
+        elif train_batch is not None and grad_acc is not None:
             micro_batch = train_batch // dp_world_size
             micro_batch //= grad_acc
 
         # train_batch_size needs to be set
-        elif micro_batch is not None and \
-                grad_acc is not None:
+        elif micro_batch is not None and grad_acc is not None:
             train_batch = micro_batch * grad_acc
             train_batch *= dp_world_size
 
@@ -490,26 +576,31 @@ class NeoXArgs(*BASE_CLASSES):
 
         # either none of the three parameters are provided or just gradient_accumulation_step is provided
         else:
-            assert False, \
-                'Either train_batch_size or micro_batch_per_gpu needs to be provided'
+            assert (
+                False
+            ), "Either train_batch_size or micro_batch_per_gpu needs to be provided"
         return int(train_batch), int(micro_batch), int(grad_acc)
 
     @staticmethod
     def check_batch_parameters(dp_world_size, train_batch, micro_batch, grad_acc):
 
-        assert train_batch > 0, \
-            f'Train batch size: {train_batch} has to be greater than 0'
+        assert (
+            train_batch > 0
+        ), f"Train batch size: {train_batch} has to be greater than 0"
 
-        assert micro_batch > 0, \
-            f'Micro batch size per gpu: {micro_batch} has to be greater than 0'
+        assert (
+            micro_batch > 0
+        ), f"Micro batch size per gpu: {micro_batch} has to be greater than 0"
 
-        assert grad_acc > 0, \
-            f'Gradient accumulation steps: {grad_acc} has to be greater than 0'
+        assert (
+            grad_acc > 0
+        ), f"Gradient accumulation steps: {grad_acc} has to be greater than 0"
 
-        assert train_batch == micro_batch * grad_acc * dp_world_size, \
-            (f'Check batch related parameters. train_batch_size is not equal'
-             ' to micro_batch_per_gpu * gradient_acc_step * world_size \n'
-             f'{train_batch} != {micro_batch} * {grad_acc} * {dp_world_size}')
+        assert train_batch == micro_batch * grad_acc * dp_world_size, (
+            f"Check batch related parameters. train_batch_size is not equal"
+            " to micro_batch_per_gpu * gradient_acc_step * world_size \n"
+            f"{train_batch} != {micro_batch} * {grad_acc} * {dp_world_size}"
+        )
 
     def calculate_derived(self):
         """
@@ -528,9 +619,14 @@ class NeoXArgs(*BASE_CLASSES):
         if global_num_gpus is None:
             if self.hostfile is not None or os.path.exists(DLTS_HOSTFILE):
                 hostfile_path = self.hostfile or DLTS_HOSTFILE
-                resources = obtain_resource_pool(hostfile_path, self.include or "", self.exclude or "")
+                resources = obtain_resource_pool(
+                    hostfile_path, self.include or "", self.exclude or ""
+                )
                 if self.num_nodes is not None and self.num_nodes > 0:
-                    resources = {k:resources[k] for k in list(resources.keys())[:self.num_nodes]}
+                    resources = {
+                        k: resources[k]
+                        for k in list(resources.keys())[: self.num_nodes]
+                    }
                 global_num_gpus = sum(map(len, resources.values()))
                 if self.num_gpus is not None and self.num_gpus > 0:
                     global_num_gpus = self.num_gpus * len(resources)
@@ -539,7 +635,10 @@ class NeoXArgs(*BASE_CLASSES):
             self.update_value("global_num_gpus", global_num_gpus)
 
         logging.info(
-            self.__class__.__name__ + ".calculate_derived() " + f"Total number of GPUs determined to be: {global_num_gpus}")
+            self.__class__.__name__
+            + ".calculate_derived() "
+            + f"Total number of GPUs determined to be: {global_num_gpus}"
+        )
 
         # get world size in the model/pipe parallel case, the actual `world size` deepspeed uses is the size of the
         # data-parallel group, or (num_gpus / mp_size) / pp_size
@@ -550,38 +649,46 @@ class NeoXArgs(*BASE_CLASSES):
         self.update_value("model_parallel_size", mp_size)
 
         # pp_size and mp_size are only used here to compute dp world size and nowhere else.
-        dp_world_size = ((global_num_gpus / pp_size) / mp_size)
+        dp_world_size = (global_num_gpus / pp_size) / mp_size
         if not (dp_world_size % 1 == 0):
-            error_message = self.__class__.__name__ + ".calculate_derived() " + f"(global_num_gpus / pp_size) / mp_size [({global_num_gpus} / {pp_size}) / {mp_size}] must be a whole number"
+            error_message = (
+                self.__class__.__name__
+                + ".calculate_derived() "
+                + f"(global_num_gpus / pp_size) / mp_size [({global_num_gpus} / {pp_size}) / {mp_size}] must be a whole number"
+            )
             logging.error(error_message)
             raise AssertionError(error_message)
 
         # Automatically derive train_batch_size = train_micro_batch_size_per_gpu*global_num_gpus*gradient_accumulation_steps
-        train_batch_size, train_micro_batch_size_per_gpu, gradient_accumulation_steps = self.calculate_batch_parameters(
+        (
+            train_batch_size,
+            train_micro_batch_size_per_gpu,
+            gradient_accumulation_steps,
+        ) = self.calculate_batch_parameters(
             dp_world_size=dp_world_size,
             train_batch=self.train_batch_size,
             micro_batch=self.train_micro_batch_size_per_gpu,
-            grad_acc=self.gradient_accumulation_steps
+            grad_acc=self.gradient_accumulation_steps,
         )
         self.check_batch_parameters(
             dp_world_size=dp_world_size,
             train_batch=train_batch_size,
             micro_batch=train_micro_batch_size_per_gpu,
-            grad_acc=gradient_accumulation_steps
+            grad_acc=gradient_accumulation_steps,
         )
-        self.update_values({
-            # batch size params
-            "train_batch_size": train_batch_size,
-            "train_micro_batch_size_per_gpu": train_micro_batch_size_per_gpu,
-            "gradient_accumulation_steps": gradient_accumulation_steps,
-            "batch_size": train_micro_batch_size_per_gpu,
+        self.update_values(
+            {
+                # batch size params
+                "train_batch_size": train_batch_size,
+                "train_micro_batch_size_per_gpu": train_micro_batch_size_per_gpu,
+                "gradient_accumulation_steps": gradient_accumulation_steps,
+                "batch_size": train_micro_batch_size_per_gpu,
+                # duplicate items
+                "gas": self.gradient_accumulation_steps,
+                "clip_grad": self.gradient_clipping,
+            }
+        )
 
-            # duplicate items
-            "gas": self.gradient_accumulation_steps,
-            "clip_grad": self.gradient_clipping,
-
-        })
-        
         # derive precision
         if (self.fp16 or {}).get("type", self.precision) == "bfloat16":
             self.update_value("precision", "bfloat16")
@@ -589,28 +696,43 @@ class NeoXArgs(*BASE_CLASSES):
             self.update_value("precision", "fp16")
         else:
             self.update_value("precision", "fp32")
-        
 
         # zero optimization
         if self.zero_optimization is None:
-            self.zero_optimization = copy.deepcopy(ZERO_DEFAULTS)  # a dict is overwritten and not updated key by key
-        self.update_values({
-            "zero_stage": self.zero_optimization.get('stage', ZERO_DEFAULTS['stage']),
-            "zero_reduce_scatter": self.zero_optimization.get('reduce_scatter', ZERO_DEFAULTS['reduce_scatter']),
-            "zero_contiguous_gradients": self.zero_optimization.get('contiguous_gradients',
-                                                                    ZERO_DEFAULTS['contiguous_gradients']),
-            "zero_reduce_bucket_size": self.zero_optimization.get('reduce_bucket_size',
-                                                                  ZERO_DEFAULTS['reduce_bucket_size']),
-            "zero_allgather_bucket_size": self.zero_optimization.get('allgather_bucket_size',
-                                                                     ZERO_DEFAULTS['allgather_bucket_size'])
-        })
+            self.zero_optimization = copy.deepcopy(
+                ZERO_DEFAULTS
+            )  # a dict is overwritten and not updated key by key
+        self.update_values(
+            {
+                "zero_stage": self.zero_optimization.get(
+                    "stage", ZERO_DEFAULTS["stage"]
+                ),
+                "zero_reduce_scatter": self.zero_optimization.get(
+                    "reduce_scatter", ZERO_DEFAULTS["reduce_scatter"]
+                ),
+                "zero_contiguous_gradients": self.zero_optimization.get(
+                    "contiguous_gradients", ZERO_DEFAULTS["contiguous_gradients"]
+                ),
+                "zero_reduce_bucket_size": self.zero_optimization.get(
+                    "reduce_bucket_size", ZERO_DEFAULTS["reduce_bucket_size"]
+                ),
+                "zero_allgather_bucket_size": self.zero_optimization.get(
+                    "allgather_bucket_size", ZERO_DEFAULTS["allgather_bucket_size"]
+                ),
+            }
+        )
 
         # optimizer and scheduler
-        opt_params = self.optimizer or {"type": OPT_DEFAULT, "params": OPT_PARAMS_DEFAULTS}
-        self.update_values({
-            "optimizer_type": opt_params.get('type', OPT_DEFAULT),
-            "lr": opt_params['params'].get('lr', OPT_PARAMS_DEFAULTS['lr'])
-        })
+        opt_params = self.optimizer or {
+            "type": OPT_DEFAULT,
+            "params": OPT_PARAMS_DEFAULTS,
+        }
+        self.update_values(
+            {
+                "optimizer_type": opt_params.get("type", OPT_DEFAULT),
+                "lr": opt_params["params"].get("lr", OPT_PARAMS_DEFAULTS["lr"]),
+            }
+        )
 
         if self.optimizer_type.lower() == "onebitadam":
             # onebitadam needs to instantiated by deepspeed, and so we need to pass deepspeed scheduler args
@@ -621,8 +743,9 @@ class NeoXArgs(*BASE_CLASSES):
                     "warmup_min_lr": 0,
                     "warmup_max_lr": self.lr,
                     "warmup_num_steps": int(self.train_iters * self.warmup),
-                    "total_num_steps": self.lr_decay_iters or self.train_iters
-                }}
+                    "total_num_steps": self.lr_decay_iters or self.train_iters,
+                },
+            }
 
         # Fp16 loss scaling.
         self.update_value("dynamic_loss_scale", self.loss_scale is None)
@@ -635,12 +758,21 @@ class NeoXArgs(*BASE_CLASSES):
         # Attention config
         if self.attention_config is None:
             self.update_value("attention_config", [[["global"], self.num_layers]])
-        self.update_value("attention_config", expand_attention_types(self.attention_config, self.num_layers))
-        assert len(self.attention_config) == self.num_layers, "Length of attention config list must equal num_layers"
+        self.update_value(
+            "attention_config",
+            expand_attention_types(self.attention_config, self.num_layers),
+        )
+        assert (
+            len(self.attention_config) == self.num_layers
+        ), "Length of attention config list must equal num_layers"
         for item in self.attention_config:
-            assert item in ATTENTION_TYPE_CHOICES, f"Attention type {item} not recognized"
+            assert (
+                item in ATTENTION_TYPE_CHOICES
+            ), f"Attention type {item} not recognized"
         if "gmlp" in self.attention_config or "amlp" in self.attention_config:
-            assert not self.partition_activations, "GMLP Blocks are not compatible with partition activations"
+            assert (
+                not self.partition_activations
+            ), "GMLP Blocks are not compatible with partition activations"
 
         # Sparsity config
         if self.sparsity_config is None:
@@ -649,11 +781,11 @@ class NeoXArgs(*BASE_CLASSES):
 
         # Adding equal dataset weights if none are provided
         if self.train_data_paths and (self.train_data_weights is None):
-            self.train_data_weights = [1.] * len(self.train_data_paths)
+            self.train_data_weights = [1.0] * len(self.train_data_paths)
         if self.valid_data_paths and (self.valid_data_weights is None):
-            self.valid_data_weights = [1.] * len(self.valid_data_paths)
+            self.valid_data_weights = [1.0] * len(self.valid_data_paths)
         if self.test_data_paths and (self.test_data_weights is None):
-            self.test_data_weights = [1.] * len(self.test_data_paths)
+            self.test_data_weights = [1.0] * len(self.test_data_paths)
 
     ############################################################################################################################
     # start of validation functions
@@ -671,7 +803,8 @@ class NeoXArgs(*BASE_CLASSES):
             for item in source_vars:
                 if item in defined_properties.keys():
                     logging.error(
-                        f'({cls.__name__}) duplicate of item: {item}, in class {source_class.__name__} and {defined_properties[item]}')
+                        f"({cls.__name__}) duplicate of item: {item}, in class {source_class.__name__} and {defined_properties[item]}"
+                    )
                     return False
                 else:
                     defined_properties[item] = source_class.__name__
@@ -690,36 +823,58 @@ class NeoXArgs(*BASE_CLASSES):
             return False
 
         # required arguments
-        required_args = ['num_layers', 'hidden_size', 'num_attention_heads', 'max_position_embeddings']
+        required_args = [
+            "num_layers",
+            "hidden_size",
+            "num_attention_heads",
+            "max_position_embeddings",
+        ]
         for req_arg in required_args:
             if getattr(self, req_arg) is None:
-                error_message = self.__class__.__name__ + ".validate_values() " + req_arg + " is None."
+                error_message = (
+                    self.__class__.__name__
+                    + ".validate_values() "
+                    + req_arg
+                    + " is None."
+                )
                 logging.error(error_message)
                 raise ValueError(error_message)
                 return False
 
         # Checks.
         if self.hidden_size % self.num_attention_heads != 0:
-            error_message = self.__class__.__name__ + ".validate_values() hidden_size must be divisable by num_attention_heads"
+            error_message = (
+                self.__class__.__name__
+                + ".validate_values() hidden_size must be divisable by num_attention_heads"
+            )
             logging.error(error_message)
             raise ValueError(error_message)
             return False
 
         if self.seq_length is not None:
             if not (self.max_position_embeddings >= self.seq_length):
-                error_message = self.__class__.__name__ + ".validate_values() max_position_embeddings must be bigger or equal seq_length"
+                error_message = (
+                    self.__class__.__name__
+                    + ".validate_values() max_position_embeddings must be bigger or equal seq_length"
+                )
                 logging.error(error_message)
                 raise ValueError(error_message)
                 return False
 
         if not (self.min_lr <= self.lr):
-            error_message = self.__class__.__name__ + ".validate_values() min_lr must be smaller or equal lr"
+            error_message = (
+                self.__class__.__name__
+                + ".validate_values() min_lr must be smaller or equal lr"
+            )
             logging.error(error_message)
             raise ValueError(error_message)
             return False
 
         if self.save is not None and self.save_interval is None:
-            error_message = self.__class__.__name__ + ".validate_values() save_interval must be defined if save is defined"
+            error_message = (
+                self.__class__.__name__
+                + ".validate_values() save_interval must be defined if save is defined"
+            )
             logging.error(error_message)
             raise ValueError(error_message)
             return False
@@ -728,37 +883,61 @@ class NeoXArgs(*BASE_CLASSES):
         if (self.num_unique_layers is not None) and (self.num_layers is not None):
 
             if not (self.num_unique_layers <= self.num_layers):
-                error_message = self.__class__.__name__ + ".validate_values() num-unique-layers must be smaller or equal num_layers"
+                error_message = (
+                    self.__class__.__name__
+                    + ".validate_values() num-unique-layers must be smaller or equal num_layers"
+                )
                 logging.error(error_message)
                 raise ValueError(error_message)
                 return False
 
             if not (self.num_layers % self.num_unique_layers == 0):
-                error_message = self.__class__.__name__ + ".validate_values() num-layers should be divisible by num-unique-layers"
+                error_message = (
+                    self.__class__.__name__
+                    + ".validate_values() num-layers should be divisible by num-unique-layers"
+                )
                 logging.error(error_message)
                 raise ValueError(error_message)
                 return False
 
         if self.fp16_lm_cross_entropy and self.precision != "fp16":
-            error_message = self.__class__.__name__ + ".validate_values() lm cross entropy in fp16 only support in fp16 mode."
+            error_message = (
+                self.__class__.__name__
+                + ".validate_values() lm cross entropy in fp16 only support in fp16 mode."
+            )
             logging.error(error_message)
             raise ValueError(error_message)
             return False
 
         # assert that if one of train/test/valid_data_path are provided, data_path should not be
-        has_separate_path = [data_path is not None for data_path in [self.train_data_paths,
-                                                                     self.valid_data_paths,
-                                                                     self.test_data_paths]]
+        has_separate_path = [
+            data_path is not None
+            for data_path in [
+                self.train_data_paths,
+                self.valid_data_paths,
+                self.test_data_paths,
+            ]
+        ]
         if all(has_separate_path):
-            assert self.data_path is None, "Please provide *either* `data_path` or `train/valid/test_data_path` " \
-                                                "in args "
+            assert self.data_path is None, (
+                "Please provide *either* `data_path` or `train/valid/test_data_path` "
+                "in args "
+            )
 
         # assert that if one of train/test/valid_data_path are provided, all should be
-        assert_error_mess = "One or more of train/valid/test data_path are not provided:\n\t"
+        assert_error_mess = (
+            "One or more of train/valid/test data_path are not provided:\n\t"
+        )
         assert_error_mess += "\n\t".join(
-            [f"{name} data paths: {data_path}," for name, data_path in [['train', self.train_data_paths],
-                                                                        ['valid', self.valid_data_paths],
-                                                                        ['test', self.test_data_paths]]])
+            [
+                f"{name} data paths: {data_path},"
+                for name, data_path in [
+                    ["train", self.train_data_paths],
+                    ["valid", self.valid_data_paths],
+                    ["test", self.test_data_paths],
+                ]
+            ]
+        )
         assert any(has_separate_path) == all(has_separate_path), assert_error_mess
 
         # assert that if train / valid / test data path(s) and weights are provided, that the paths and the weights should be equal length
@@ -783,7 +962,9 @@ class NeoXArgs(*BASE_CLASSES):
 
             actual_type = type(actual_value)
             if actual_type != field_def.type:
-                if actual_type == int and field_def.type == float:  # floats should be able to be configured as ints
+                if (
+                    actual_type == int and field_def.type == float
+                ):  # floats should be able to be configured as ints
                     continue
 
                 # for typing.Literal (i.e a list of choices) - checks that actual value is in accepted values
@@ -793,45 +974,71 @@ class NeoXArgs(*BASE_CLASSES):
                         continue
                     elif type(actual_value) == str:
                         # case insensitive checking
-                        lowercase_accepted_values = [i.lower() for i in accepted_values if isinstance(i, str)]
+                        lowercase_accepted_values = [
+                            i.lower() for i in accepted_values if isinstance(i, str)
+                        ]
                         if actual_value.lower() in lowercase_accepted_values:
                             continue
                     logging.error(
-                        self.__class__.__name__ + ".validate_types() " + f"{field_name}: '{actual_value}' Not in accepted values: '{accepted_values}'")
+                        self.__class__.__name__
+                        + ".validate_types() "
+                        + f"{field_name}: '{actual_value}' Not in accepted values: '{accepted_values}'"
+                    )
                     return False
 
                 logging.error(
-                    self.__class__.__name__ + ".validate_types() " + f"{field_name}: '{actual_type}' instead of '{field_def.type}'")
+                    self.__class__.__name__
+                    + ".validate_types() "
+                    + f"{field_name}: '{actual_type}' instead of '{field_def.type}'"
+                )
                 return False
 
         # validate deepspeed dicts
         for field_name in ["optimizer", "scheduler"]:
             value = getattr(self, field_name)
-            if isinstance(value, dict):  # dict is checked above, only fields are checked here
+            if isinstance(
+                value, dict
+            ):  # dict is checked above, only fields are checked here
                 if "type" in value:
                     if not isinstance(value["type"], str):
                         logging.error(
-                            self.__class__.__name__ + ".validate_types() " + f"{field_name}: key 'type' must be a string")
+                            self.__class__.__name__
+                            + ".validate_types() "
+                            + f"{field_name}: key 'type' must be a string"
+                        )
                         return False
                 else:
                     logging.error(
-                        self.__class__.__name__ + ".validate_types() " + f"{field_name}: must contain key 'type'")
+                        self.__class__.__name__
+                        + ".validate_types() "
+                        + f"{field_name}: must contain key 'type'"
+                    )
                     return False
                 if "params" in value:
                     if not isinstance(value["params"], dict):
                         logging.error(
-                            self.__class__.__name__ + ".validate_types() " + f"{field_name}: key 'params' must be a dict")
+                            self.__class__.__name__
+                            + ".validate_types() "
+                            + f"{field_name}: key 'params' must be a dict"
+                        )
                         return False
                 else:
                     logging.error(
-                        self.__class__.__name__ + ".validate_types() " + f"{field_name}: must contain key 'params'")
+                        self.__class__.__name__
+                        + ".validate_types() "
+                        + f"{field_name}: must contain key 'params'"
+                    )
                     return False
 
         for field_name in ["fp16", "amp", "flops_profiler"]:
             value = getattr(self, field_name)
             if isinstance(value, dict):
                 if not "enabled" in value:
-                    error_message = self.__class__.__name__ + ".validate_types() " + f"{field_name}: must contain key 'enabled'"
+                    error_message = (
+                        self.__class__.__name__
+                        + ".validate_types() "
+                        + f"{field_name}: must contain key 'enabled'"
+                    )
                     logging.error(error_message)
                     return False
 

--- a/megatron/neox_arguments/neox_args.py
+++ b/megatron/neox_arguments/neox_args.py
@@ -957,3 +957,5 @@ class NeoXArgsTextgen(NeoXArgsTemplate):
     """
     Tasks to evaluate on using lm_eval_harness
     """
+
+    

--- a/megatron/text_generation_utils.py
+++ b/megatron/text_generation_utils.py
@@ -34,21 +34,21 @@ from megatron.utils import get_ltor_masks_and_position_ids, is_mp_rank_0
 def get_batch(neox_args, context_tokens: torch.Tensor):
     """
     Generate batch from context tokens. Attention mask and position ids are created. Returned tensors will be on CUDA.
-    
+
     neox_args: NeoXArgs.
     context_tokens: torch tensor with dimensions [batch, context_size]
 
     returns: tuple of torch tensors (tokens, attention_mask, position_ids) on CUDA
     """
- 
+
     # Move to GPU.
     tokens = context_tokens.contiguous().cuda()
     # Get the attention mask and postition ids.
     attention_mask, _, position_ids = get_ltor_masks_and_position_ids(
-        tokens,
-        neox_args.tokenizer.eod,
-        neox_args.eod_mask_loss)
+        tokens, neox_args.tokenizer.eod, neox_args.eod_mask_loss
+    )
     return tokens, attention_mask, position_ids
+
 
 def pad_batch(context_tokens: List[List[int]], pad_id: int, pad_len: int):
     """
@@ -72,7 +72,8 @@ def pad_batch(context_tokens: List[List[int]], pad_id: int, pad_len: int):
         context_lengths.append(context_length)
     return context_tokens, context_lengths
 
-def filter_logits(logits, top_k=0, top_p=0.0, filter_value=-float('Inf')):
+
+def filter_logits(logits, top_k=0, top_p=0.0, filter_value=-float("Inf")):
     """
     Filters the logits using top_k / top_p, filling any filtered vocab items with filter_value (defaults to -inf).
 
@@ -108,12 +109,14 @@ def filter_logits(logits, top_k=0, top_p=0.0, filter_value=-float('Inf')):
 
     return logits
 
+
 def switch(val1, val2, boolean):
     """
     replaces items in val1 with items in val2 where boolean = True
     """
     boolean = boolean.type_as(val1)
     return (1 - boolean) * val1 + boolean * val2
+
 
 def forward_model(neox_args, model, model_inputs):
     """
@@ -134,33 +137,49 @@ def forward_model(neox_args, model, model_inputs):
         return model.module(model_inputs)
     else:
         data_iterator = iter(
-            [[model_inputs, torch.Tensor(1)]])  # we need to feed in fake labels bc deepspeed is only built for training
+            [[model_inputs, torch.Tensor(1)]]
+        )  # we need to feed in fake labels bc deepspeed is only built for training
         x = model.inference_batch(data_iterator)
         return x
+
 
 def broadcast_terminate_signal(terminate_runs: int):
     """Send signal to all workers to terminate if we've finished the process"""
     terminate_runs_tensor = torch.cuda.LongTensor([terminate_runs])
-    torch.distributed.broadcast(terminate_runs_tensor,
-                                mpu.get_model_parallel_src_rank(),
-                                group=mpu.get_model_parallel_group())
+    torch.distributed.broadcast(
+        terminate_runs_tensor,
+        mpu.get_model_parallel_src_rank(),
+        group=mpu.get_model_parallel_group(),
+    )
     return terminate_runs_tensor[0].item()
+
 
 def stop_tokens_in_completion(stop_tokens, context_tokens, batch_index, current_index):
     if stop_tokens is None:
         return False
     res = []
     for token_group in stop_tokens:
-        context = context_tokens[batch_index, :current_index + 1]
-        context = context[-len(token_group):]
+        context = context_tokens[batch_index, : current_index + 1]
+        context = context[-len(token_group) :]
         if context.shape[0] == token_group.shape[0]:
             res.append(all(token_group == context))
         else:
             res.append(False)
     return any(res)
 
-def stream_tokens(neox_args, model, context_tokens: List[List[int]], eos_token_id: int = None, 
-                    maximum_tokens: int = None, recompute: bool = False, temperature: float = 0.0, top_k: int = 0, top_p: float = 0.0, stop_tokens=None):
+
+def stream_tokens(
+    neox_args,
+    model,
+    context_tokens: List[List[int]],
+    eos_token_id: int = None,
+    maximum_tokens: int = None,
+    recompute: bool = False,
+    temperature: float = 0.0,
+    top_k: int = 0,
+    top_p: float = 0.0,
+    stop_tokens=None,
+):
     """
     iterator producing text completions
 
@@ -173,7 +192,7 @@ def stream_tokens(neox_args, model, context_tokens: List[List[int]], eos_token_i
     position_ids: position ids for positional encoding.
 
     eos_token_id: end of text token at which completion is terminated, even if max_tokes count has not been reached
-    maximum_tokens: maximum number of tokens to be generated; careful! if a batch input is provided maximum_tokens specifies the maximum number of forwards. 
+    maximum_tokens: maximum number of tokens to be generated; careful! if a batch input is provided maximum_tokens specifies the maximum number of forwards.
                     longer batch items get less generated tokens.
 
     recompute: flag indicating whether a cache is used for already forwarded tokens (true) or whether all tokens are recomputed at every iteration (false)
@@ -181,12 +200,12 @@ def stream_tokens(neox_args, model, context_tokens: List[List[int]], eos_token_i
     temperature (default 0.0): exponential scaling output distribution ("higher == more risk")
     top_k (default 0): integer -> integer between 0 and the models vocab size. Filters out any logits with a probability less than that of the top_kth token.
     top_p (default 0.0): float -> Top-p (nucleus) sampling chooses from the smallest possible set of tokens whose cumulative probability exceeds the probability top_p.
-    
+
     note: greedy decoding is used if temperature is 0.0, top_k is 0 and top_p is 0.0
 
     yields: (
-                tokens (completions from model), 
-                token_generation_start_index (token index per batch item for the first generated token), 
+                tokens (completions from model),
+                token_generation_start_index (token index per batch item for the first generated token),
                 token_generation_end_index (token index per batch item for the last generated token),
                 logits (logits which are so far computed, zeros otherwise),
                 is_done (flag for each bach item indicating whether an eod token was generated)
@@ -200,7 +219,11 @@ def stream_tokens(neox_args, model, context_tokens: List[List[int]], eos_token_i
     model.eval()
 
     # pad batch in order to allow conversion to tensor
-    context_tokens, context_lengths = pad_batch(copy.deepcopy(context_tokens), pad_id=neox_args.tokenizer.eod, pad_len=neox_args.seq_length) 
+    context_tokens, context_lengths = pad_batch(
+        copy.deepcopy(context_tokens),
+        pad_id=neox_args.tokenizer.eod,
+        pad_len=neox_args.seq_length,
+    )
 
     # convert to tensor and broadcast
     context_tokens = torch.cuda.LongTensor(context_tokens)
@@ -211,13 +234,17 @@ def stream_tokens(neox_args, model, context_tokens: List[List[int]], eos_token_i
 
     token_generation_start_index = torch.cuda.LongTensor(context_lengths)
 
-    torch.distributed.broadcast(context_tokens,
-                                mpu.get_model_parallel_src_rank(),
-                                group=mpu.get_model_parallel_group())
-    torch.distributed.broadcast(token_generation_start_index,
-                                mpu.get_model_parallel_src_rank(),
-                                group=mpu.get_model_parallel_group())
-    
+    torch.distributed.broadcast(
+        context_tokens,
+        mpu.get_model_parallel_src_rank(),
+        group=mpu.get_model_parallel_group(),
+    )
+    torch.distributed.broadcast(
+        token_generation_start_index,
+        mpu.get_model_parallel_src_rank(),
+        group=mpu.get_model_parallel_group(),
+    )
+
     # produce batch relevant attention_mask and position_ids
     context_tokens, attention_mask, position_ids = get_batch(neox_args, context_tokens)
 
@@ -226,7 +253,9 @@ def stream_tokens(neox_args, model, context_tokens: List[List[int]], eos_token_i
 
     # set variables
     eos_token_id = eos_token_id or neox_args.tokenizer.eod
-    maximum_tokens = maximum_tokens or (neox_args.seq_length - token_generation_start_index.max().item() - 1)
+    maximum_tokens = maximum_tokens or (
+        neox_args.seq_length - token_generation_start_index.max().item() - 1
+    )
     batch_size = context_tokens.size(0)
 
     # get the context_index at which generation is to start
@@ -234,11 +263,14 @@ def stream_tokens(neox_args, model, context_tokens: List[List[int]], eos_token_i
     token_index_to_generate = token_generation_start_index.min().item()
     first_token_index_to_generate = token_index_to_generate
     last_token_index_to_generate = min(
-        neox_args.seq_length - 1, # never generate more than the model's sequence length
-        token_index_to_generate + maximum_tokens -1
+        neox_args.seq_length
+        - 1,  # never generate more than the model's sequence length
+        token_index_to_generate + maximum_tokens - 1,
     )
 
-    all_logits = torch.zeros((batch_size, neox_args.seq_length, neox_args.padded_vocab_size))
+    all_logits = torch.zeros(
+        (batch_size, neox_args.seq_length, neox_args.padded_vocab_size)
+    )
 
     with torch.no_grad():
         # initialize generation variables
@@ -252,11 +284,12 @@ def stream_tokens(neox_args, model, context_tokens: List[List[int]], eos_token_i
                 # because we can only forward multiples of the block size
                 # TODO The full padded context_tokens would not need to be forwarded, adjust to multiples of block size
                 # we need to use neox_args instead of kwargs here because deepspeed :|
-                model_inputs = (context_tokens,
-                                position_ids,
-                                attention_mask,
-                                torch.Tensor(),
-                                )
+                model_inputs = (
+                    context_tokens,
+                    position_ids,
+                    attention_mask,
+                    torch.Tensor(),
+                )
                 logits, _ = forward_model(neox_args, model, model_inputs)
                 generated_token_logits = logits[:, token_index_to_generate - 1, :]
                 all_logits = logits
@@ -268,25 +301,31 @@ def stream_tokens(neox_args, model, context_tokens: List[List[int]], eos_token_i
                     positions_to_use = position_ids[:, :token_index_to_generate]
                 else:
                     tokens_to_use = context_tokens[:, token_index_to_generate - 1].view(
-                        batch_size, -1)
-                    positions_to_use = position_ids[:, token_index_to_generate - 1].view(
-                        batch_size, -1)
+                        batch_size, -1
+                    )
+                    positions_to_use = position_ids[
+                        :, token_index_to_generate - 1
+                    ].view(batch_size, -1)
                     # we have to use neox_args instead of kwargs here because deepspeed :|
-                model_inputs = (tokens_to_use,  # input_ids
-                                positions_to_use,  # position_ids
-                                attention_mask,  # attention_mask
-                                layer_past,  # layer_past
-                                )
+                model_inputs = (
+                    tokens_to_use,  # input_ids
+                    positions_to_use,  # position_ids
+                    attention_mask,  # attention_mask
+                    layer_past,  # layer_past
+                )
 
                 logits, layer_past = forward_model(neox_args, model, model_inputs)
                 # TODO: we are replicating computation across all machines here, which is really unecessary,
-                #  we should probably just do it on one then communicate the results?
+                #  we should probably just do it on one rank then communicate the results?
                 generated_token_logits = logits[:, -1].view(batch_size, -1).contiguous()
-                
                 if token_index_to_generate == first_token_index_to_generate:
-                    all_logits[:, :token_index_to_generate, :] = logits[:, :token_index_to_generate, :]         
+                    all_logits[:, :token_index_to_generate, :] = logits[
+                        :, :token_index_to_generate, :
+                    ]
                 else:
-                    all_logits[:, token_index_to_generate - 1, :] = logits[:, 0, :] # only one token will is computed
+                    all_logits[:, token_index_to_generate - 1, :] = logits[
+                        :, 0, :
+                    ]  # only one token will be computed
 
             # sample token id of the to be generated token
             if temperature == 0.0 and top_k == 0 and top_p == 0.0:
@@ -295,38 +334,63 @@ def stream_tokens(neox_args, model, context_tokens: List[List[int]], eos_token_i
                 generated_token_logits = generated_token_logits.float()
                 if temperature > 0.0:
                     generated_token_logits /= temperature
-                generated_token_logits = filter_logits(generated_token_logits, top_k=top_k, top_p=top_p)
+                generated_token_logits = filter_logits(
+                    generated_token_logits, top_k=top_k, top_p=top_p
+                )
                 next_token_log_probs = F.softmax(generated_token_logits, dim=-1)
-                generated_tokens = torch.multinomial(next_token_log_probs, num_samples=1).view(-1)
+                generated_tokens = torch.multinomial(
+                    next_token_log_probs, num_samples=1
+                ).view(-1)
 
-
-            # determine if state has started for eahc batch item
-            state_started = token_generation_start_index <= token_index_to_generate # check which batch items have been started
-
+            # determine if state has started for each batch item
+            state_started = (
+                token_generation_start_index <= token_index_to_generate
+            )  # check which batch items have been started
 
             # switch out only padding tokens (the batch items that have been started)
-            context_tokens[:, token_index_to_generate] = switch(context_tokens[:, token_index_to_generate].view(-1), generated_tokens, state_started) 
-
+            context_tokens[:, token_index_to_generate] = switch(
+                context_tokens[:, token_index_to_generate].view(-1),
+                generated_tokens,
+                state_started,
+            )
 
             # determine if state has finished for each batch item
-            state_done = (generated_tokens == eos_token_id).byte() & state_started.byte() # check which batch items produce an eos_token in the current iteration
+            state_done = (
+                generated_tokens == eos_token_id
+            ).byte() & state_started.byte()  # check which batch items produce an eos_token in the current iteration
             state_just_finished = (state_done & ~state_is_done).bool()
             state_is_done = state_is_done | state_done
             stop_tokens_produced = torch.zeros_like(state_is_done)
             for batch_idx, ctx in enumerate(context_tokens):
-                stop_tokens_produced[batch_idx] = stop_tokens_in_completion(stop_tokens, context_tokens, batch_idx, token_index_to_generate)
+                stop_tokens_produced[batch_idx] = stop_tokens_in_completion(
+                    stop_tokens, context_tokens, batch_idx, token_index_to_generate
+                )
             state_is_done = state_is_done | stop_tokens_produced
 
-            token_generation_end_index[(state_started.byte() & ~state_is_done).bool()] = token_index_to_generate
+            token_generation_end_index[
+                (state_started.byte() & ~state_is_done).bool()
+            ] = token_index_to_generate
 
             token_index_to_generate += 1
-            
-            
-            yield context_tokens, token_generation_start_index, token_generation_end_index, all_logits, state_is_done.bool()
-            if torch.all(state_is_done): break
 
-def generate_samples_from_prompt(neox_args, model, text: Union[List[str], str], eos_token_id: int = None, 
-                                    maximum_tokens: int = 64, recompute: bool = False, temperature: float = 0.0, top_k: int = 0, top_p: float = 0.0, stop_tokens=None):
+            yield context_tokens, token_generation_start_index, token_generation_end_index, all_logits, state_is_done.bool()
+            if torch.all(state_is_done):
+                break
+
+
+def generate_samples_from_prompt(
+    neox_args,
+    model,
+    text: Union[List[str], str],
+    eos_token_id: int = None,
+    maximum_tokens: int = 64,
+    recompute: bool = False,
+    temperature: float = 0.0,
+    top_k: int = 0,
+    top_p: float = 0.0,
+    stop_tokens=None,
+    broadcast_generated_tokens=False,
+):
     """
     Generates samples from raw text and returns them in a dictionary.
 
@@ -342,63 +406,74 @@ def generate_samples_from_prompt(neox_args, model, text: Union[List[str], str], 
     temperature (default 0.0): exponential scaling output distribution ("higher == more risk")
     top_k (default 0): integer -> integer between 0 and the models vocab size. Filters out any logits with a probability less than that of the top_kth token.
     top_p (default 0.0): float -> Top-p (nucleus) sampling chooses from the smallest possible set of tokens whose cumulative probability exceeds the probability top_p.
-    
+    broadcast_generated_tokens: If true, broadcasts the generated tokens to all ranks (normally they would only be available on mp_rank == 0)
     note: greedy decoding is used if temperature is 0.0, top_k is 0 and top_p is 0.0
 
     returns: List[dict] -> a list of dicts containing the following fields:
         - 'context' (the input)
         - 'text' (the completion)
         - 'length' (the length of the completion in number of tokens)
-        - 'finished': 
+        - 'finished':
         - 'message': a messaged associated with the generation procedure, can be a warning or error
-        - 'duration_seconds': duration of the generation in seconds 
-        
+        - 'duration_seconds': duration of the generation in seconds
+
     """
     eos_token_id = eos_token_id or neox_args.tokenizer.eod
 
     # type check
-    assert any([isinstance(text, str), isinstance(text, list)]), "Text should be in string or list form"
+    assert any(
+        [isinstance(text, str), isinstance(text, list)]
+    ), "Text should be in string or list form"
     if isinstance(text, str):
         text = [text]
 
-    if is_mp_rank_0():
-        input_count = len(text)
-        input_pos = 0
+    input_count = len(text)
+    input_pos = 0
 
     # generate completions
     generated_texts = []
     while True:
-        
+
         start_time = time.time()
         # Tokenize text, and check whether we should terminate process
         terminate_runs = 0
-        if is_mp_rank_0():
-            if input_pos == input_count:
-                terminate_runs = 1
-            else:
-                raw_text = text[input_pos]
-                input_pos += 1
-
-                if raw_text == "":
-                    context_tokens = [eos_token_id]
-                else:
-                    context_tokens = neox_args.tokenizer.tokenize(raw_text)
-                context_length = len(context_tokens)
-
-                if context_length >= (neox_args.seq_length // 2):
-                    print_rank_0("\nWarning! Context length", context_length,
-                                 "\nPlease give smaller context (e.g. half of the "
-                                 "max sequence length)!")
+        if input_pos == input_count:
+            terminate_runs = 1
         else:
+            raw_text = text[input_pos]
+            input_pos += 1
+
+            if raw_text == "":
+                context_tokens = [eos_token_id]
+            else:
+                context_tokens = neox_args.tokenizer.tokenize(raw_text)
+            context_length = len(context_tokens)
+
+            if context_length >= (neox_args.seq_length // 2):
+                print_rank_0(
+                    "\nWarning! Context length",
+                    context_length,
+                    "\nPlease give smaller context (e.g. half of the "
+                    "max sequence length)!",
+                )
+        if not is_mp_rank_0():
             context_tokens = neox_args.tokenizer.tokenize("EMPTY TEXT")
             context_length = len(context_tokens)
+            terminate_runs = 0
+
 
         terminate_runs = broadcast_terminate_signal(terminate_runs)
         if terminate_runs == 1:
             return generated_texts
 
-        for batch_context_tokens, batch_token_generation_start_index, batch_token_generation_end_index, batch_logits, is_done in stream_tokens(
-            neox_args=neox_args, 
+        for (
+            batch_context_tokens,
+            batch_token_generation_start_index,
+            batch_token_generation_end_index,
+            batch_logits,
+            is_done,
+        ) in stream_tokens(
+            neox_args=neox_args,
             model=model,
             context_tokens=[context_tokens],
             eos_token_id=eos_token_id,
@@ -407,17 +482,37 @@ def generate_samples_from_prompt(neox_args, model, text: Union[List[str], str], 
             temperature=temperature,
             top_k=top_k,
             top_p=top_p,
-            stop_tokens=stop_tokens
-            ):
-            pass # finish generation and use all results below
+            stop_tokens=stop_tokens,
+        ):
+            pass  # finish generation and use all results below
 
         batch_context_tokens = batch_context_tokens.cpu().numpy().tolist()
-        batch_token_generation_start_index = batch_token_generation_start_index.cpu().numpy().tolist()
-        batch_token_generation_end_index = batch_token_generation_end_index.cpu().numpy().tolist()
+        batch_token_generation_start_index = (
+            batch_token_generation_start_index.cpu().numpy().tolist()
+        )
+        batch_token_generation_end_index = (
+            batch_token_generation_end_index.cpu().numpy().tolist()
+        )
         batch_is_done = is_done.cpu().numpy().tolist()
-        for tokens, start_index, end_index, is_done in zip(batch_context_tokens, batch_token_generation_start_index, batch_token_generation_end_index, batch_is_done):
+
+        for tokens, start_index, end_index, is_done in zip(
+            batch_context_tokens,
+            batch_token_generation_start_index,
+            batch_token_generation_end_index,
+            batch_is_done,
+        ):
+
             if end_index >= start_index:
-                generated_tokens = tokens[start_index:end_index + 1]
+                generated_tokens = tokens[start_index : end_index + 1]
+                if broadcast_generated_tokens:
+                    from copy import deepcopy
+                    generated_tokens = torch.tensor(generated_tokens).cuda()
+                    torch.distributed.broadcast(
+                        generated_tokens,
+                        mpu.get_model_parallel_src_rank(),
+                        group=mpu.get_model_parallel_group(),
+                    )
+                    generated_tokens = generated_tokens.cpu().numpy().tolist()
                 try:
                     generated_text = neox_args.tokenizer.detokenize(generated_tokens)
                     message = None
@@ -427,22 +522,34 @@ def generate_samples_from_prompt(neox_args, model, text: Union[List[str], str], 
             else:
                 generated_text = None
                 generated_tokens = []
-                message = "WARNING: text generation did not start; try different batching or adjust parameters"
-            if is_mp_rank_0():
+                # this will happen if the first generated token is a stop token or eos token
+                message = "WARNING: text generation did not start; try different batching or adjust parameters" 
+            if is_mp_rank_0() or broadcast_generated_tokens:
                 data = {
-                    'context': raw_text, 
-                    'text': generated_text, 
-                    'length': len(generated_tokens), 
-                    'finished': is_done, 
-                    'message': message, 
-                    'duration_seconds': float(time.time() - start_time)
-                    }
+                    "context": raw_text,
+                    "text": generated_text,
+                    "length": len(generated_tokens),
+                    "finished": is_done,
+                    "message": message,
+                    "duration_seconds": float(time.time() - start_time),
+                }
                 generated_texts.append(data)
-                
+
     return generated_texts
 
-def generate_samples_input_from_file(neox_args, model, input_file, output_file=None, eos_token_id: int = None, 
-                                        maximum_tokens: int = 64, recompute: bool = False, temperature: float = 0.0, top_k: int = 0, top_p: float = 0.0):
+
+def generate_samples_input_from_file(
+    neox_args,
+    model,
+    input_file,
+    output_file=None,
+    eos_token_id: int = None,
+    maximum_tokens: int = 64,
+    recompute: bool = False,
+    temperature: float = 0.0,
+    top_k: int = 0,
+    top_p: float = 0.0,
+):
     """
     Generates samples from an input file and writes them to an output file.
 
@@ -462,53 +569,72 @@ def generate_samples_input_from_file(neox_args, model, input_file, output_file=N
     temperature (default 0.0): exponential scaling output distribution ("higher == more risk")
     top_k (default 0): integer -> integer between 0 and the models vocab size. Filters out any logits with a probability less than that of the top_kth token.
     top_p (default 0.0): float -> Top-p (nucleus) sampling chooses from the smallest possible set of tokens whose cumulative probability exceeds the probability top_p.
-    
+
     note: greedy decoding is used if temperature is 0.0, top_k is 0 and top_p is 0.0
-    
-    
+
+
     returns: List[dict] -> a list of dicts containing the following fields:
         - 'context' (the input)
         - 'text' (the completion)
         - 'length' (the length of the completion in number of tokens)
-        - 'finished': 
+        - 'finished':
         - 'message': a messaged associated with the generation procedure, can be a warning or error
-        - 'duration_seconds': duration of the generation in seconds 
+        - 'duration_seconds': duration of the generation in seconds
     """
     # Read the sample file
-    print_rank_0('generate_samples_input_from_file() loading input from {}'.format(input_file))
+    print_rank_0(
+        "generate_samples_input_from_file() loading input from {}".format(input_file)
+    )
     with open(input_file, "r") as f:
         prompts = f.readlines()
     prompts = [p.strip() for p in prompts]
     prompts = [p for p in prompts if len(p) > 0]
-    print_rank_0('generate_samples_input_from_file() prompts loaded: {}'.format(len(prompts)))
-    
+    print_rank_0(
+        "generate_samples_input_from_file() prompts loaded: {}".format(len(prompts))
+    )
+
     if is_mp_rank_0():
         if output_file is None:
             output_file = str(input_file) + ".output.jsonl"
-            print_rank_0('generate_samples_input_from_file() setting default output file to {}'.format(output_file))
-        
-    print_rank_0('generate_samples_input_from_file() generating...')
+            print_rank_0(
+                "generate_samples_input_from_file() setting default output file to {}".format(
+                    output_file
+                )
+            )
+
+    print_rank_0("generate_samples_input_from_file() generating...")
     generated_texts = generate_samples_from_prompt(
-        neox_args=neox_args, 
-        model=model, 
-        text=prompts, 
-        eos_token_id=eos_token_id, 
+        neox_args=neox_args,
+        model=model,
+        text=prompts,
+        eos_token_id=eos_token_id,
         maximum_tokens=maximum_tokens,
-        recompute=recompute, 
-        temperature=temperature, 
-        top_k=top_k, 
-        top_p=top_p
-        )
-    
+        recompute=recompute,
+        temperature=temperature,
+        top_k=top_k,
+        top_p=top_p,
+    )
+
     if is_mp_rank_0():
         with open(output_file, "w") as f_out:
             for item in generated_texts:
-                f_out.write(json.dumps(item) + '\n')
-    print_rank_0('generate_samples_input_from_file() done')
+                f_out.write(json.dumps(item) + "\n")
+    print_rank_0("generate_samples_input_from_file() done")
     return generated_texts
 
-def generate_samples_unconditional(neox_args, model, number_of_samples: int = 10, output_file=None, eos_token_id: int = None, 
-                                        maximum_tokens: int = 64, recompute: bool = False, temperature: float = 0.0, top_k: int = 0, top_p: float = 0.0):
+
+def generate_samples_unconditional(
+    neox_args,
+    model,
+    number_of_samples: int = 10,
+    output_file=None,
+    eos_token_id: int = None,
+    maximum_tokens: int = 64,
+    recompute: bool = False,
+    temperature: float = 0.0,
+    top_k: int = 0,
+    top_p: float = 0.0,
+):
     """
     Generates samples unconditionially (no prompt) and yields them in a dictionary.
 
@@ -516,7 +642,7 @@ def generate_samples_unconditional(neox_args, model, number_of_samples: int = 10
     model: a Megatron model
 
     number_of_samples (default 10): number of unconditional samples to be generated
-    
+
     output_file: file where generation results are to be stored in jsonl format. no file will be stored if ommitted
 
     eos_token_id: end of text token at which completion is terminated, even if max_tokes count has not been reached
@@ -527,41 +653,50 @@ def generate_samples_unconditional(neox_args, model, number_of_samples: int = 10
     temperature (default 0.0): exponential scaling output distribution ("higher == more risk")
     top_k (default 0): integer -> integer between 0 and the models vocab size. Filters out any logits with a probability less than that of the top_kth token.
     top_p (default 0.0): float -> Top-p (nucleus) sampling chooses from the smallest possible set of tokens whose cumulative probability exceeds the probability top_p.
-    
+
     note: greedy decoding is used if temperature is 0.0, top_k is 0 and top_p is 0.0
 
     yields: dict containing the following fields:
         - 'context' (the input)
         - 'text' (the completion)
         - 'length' (the length of the completion in number of tokens)
-        - 'finished': 
+        - 'finished':
         - 'message': a messaged associated with the generation procedure, can be a warning or error
-        - 'duration_seconds': duration of the generation in seconds 
+        - 'duration_seconds': duration of the generation in seconds
     """
-   
-    print_rank_0('generate_samples_unconditional() generating...')
+
+    print_rank_0("generate_samples_unconditional() generating...")
     generated_texts = generate_samples_from_prompt(
-        neox_args=neox_args, 
-        model=model, 
-        text=["" for _ in range(number_of_samples)], 
-        eos_token_id=eos_token_id, 
-        maximum_tokens=maximum_tokens, 
-        recompute=recompute, 
-        temperature=temperature, 
-        top_k=top_k, 
-        top_p=top_p
-        )
-    
+        neox_args=neox_args,
+        model=model,
+        text=["" for _ in range(number_of_samples)],
+        eos_token_id=eos_token_id,
+        maximum_tokens=maximum_tokens,
+        recompute=recompute,
+        temperature=temperature,
+        top_k=top_k,
+        top_p=top_p,
+    )
+
     if is_mp_rank_0():
         if output_file is not None:
             with open(output_file, "w") as f_out:
                 for item in generated_texts:
-                    f_out.write(json.dumps(item) + '\n')
-    print_rank_0('generate_samples_unconditional() done')
+                    f_out.write(json.dumps(item) + "\n")
+    print_rank_0("generate_samples_unconditional() done")
     return generated_texts
 
-def generate_samples_interactive(neox_args, model, maximum_tokens: int = 64, eos_token_id: int = None, 
-                                    recompute: bool = False, temperature: float = 0.0, top_k: int = 0, top_p: float = 0.0):
+
+def generate_samples_interactive(
+    neox_args,
+    model,
+    maximum_tokens: int = 64,
+    eos_token_id: int = None,
+    recompute: bool = False,
+    temperature: float = 0.0,
+    top_k: int = 0,
+    top_p: float = 0.0,
+):
     """
     Generates samples unconditionially (no prompt) and yields them in a dictionary.
 
@@ -570,48 +705,57 @@ def generate_samples_interactive(neox_args, model, maximum_tokens: int = 64, eos
 
     maximum_tokens: maximum number of tokens to be generated
     eos_token_id: end of text token at which completion is terminated, even if max_tokes count has not been reached
-    
+
     recompute: flag indicating whether a cache is used for already forwarded tokens (true) or whether all tokens are recomputed at every iteration (false)
 
     temperature (default 0.0): exponential scaling output distribution ("higher == more risk")
     top_k (default 0): integer -> integer between 0 and the models vocab size. Filters out any logits with a probability less than that of the top_kth token.
     top_p (default 0.0): float -> Top-p (nucleus) sampling chooses from the smallest possible set of tokens whose cumulative probability exceeds the probability top_p.
-    
+
     note: greedy decoding is used if temperature is 0.0, top_k is 0 and top_p is 0.0
 
     yields: dict containing the following fields:
         - 'context' (the input)
         - 'text' (the completion)
         - 'length' (the length of the completion in number of tokens)
-        - 'finished': 
+        - 'finished':
         - 'message': a messaged associated with the generation procedure, can be a warning or error
-        - 'duration_seconds': duration of the generation in seconds 
+        - 'duration_seconds': duration of the generation in seconds
     """
-   
+
     while True:
         torch.distributed.barrier(group=mpu.get_model_parallel_group())
         terminate_runs = 0
 
-        if torch.distributed.is_initialized() and  torch.distributed.get_rank() == 0:
-            os.system('clear')
+        if torch.distributed.is_initialized() and torch.distributed.get_rank() == 0:
+            os.system("clear")
             raw_text = input("Context prompt >>> ")
             context_tokens = neox_args.tokenizer.tokenize(raw_text)
             if len(context_tokens) == 0:
                 context_tokens = [neox_args.tokenizer.eod]
             context_length = len(context_tokens)
             if context_length >= (neox_args.seq_length - 1):
-                print_rank_0("\nContext length"+str(context_length)+"\nReached max sequence length!")
+                print_rank_0(
+                    "\nContext length"
+                    + str(context_length)
+                    + "\nReached max sequence length!"
+                )
                 terminate_runs = 1
         else:
             context_tokens = neox_args.tokenizer.tokenize("EMPTY TEXT")
             context_length = len(context_tokens)
 
-        
         terminate_runs = broadcast_terminate_signal(terminate_runs)
         if terminate_runs == 1:
             return
-        for batch_context_tokens, batch_token_generation_start_index, batch_token_generation_end_index, batch_logits, is_done in stream_tokens(
-            neox_args=neox_args, 
+        for (
+            batch_context_tokens,
+            batch_token_generation_start_index,
+            batch_token_generation_end_index,
+            batch_logits,
+            is_done,
+        ) in stream_tokens(
+            neox_args=neox_args,
             model=model,
             context_tokens=[context_tokens],
             eos_token_id=eos_token_id,
@@ -619,14 +763,21 @@ def generate_samples_interactive(neox_args, model, maximum_tokens: int = 64, eos
             recompute=recompute,
             temperature=temperature,
             top_k=top_k,
-            top_p=top_p
-            ):
-             if mpu.get_model_parallel_rank() == 0:
-                generated_tokens = batch_context_tokens[0].cpu().numpy().tolist()[batch_token_generation_start_index[0].item():batch_token_generation_end_index[0].item()]
+            top_p=top_p,
+        ):
+            if mpu.get_model_parallel_rank() == 0:
+                generated_tokens = (
+                    batch_context_tokens[0]
+                    .cpu()
+                    .numpy()
+                    .tolist()[
+                        batch_token_generation_start_index[0]
+                        .item() : batch_token_generation_end_index[0]
+                        .item()
+                    ]
+                )
                 generated_text = neox_args.tokenizer.detokenize(generated_tokens)
-        
-        print_rank_0("Generated Text: "+generated_text)
-        if torch.distributed.is_initialized() and  torch.distributed.get_rank() == 0:
+
+        print_rank_0("Generated Text: " + generated_text)
+        if torch.distributed.is_initialized() and torch.distributed.get_rank() == 0:
             _ = input("\n<press enter to continue>")
-
-

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -39,7 +39,11 @@ from megatron.utils import (
 
 
 from megatron import print_rank_0, mpu
-from megatron.model import GPT2ModelPipe, SoftEmbedding, get_params_for_weight_decay_optimization
+from megatron.model import (
+    GPT2ModelPipe,
+    SoftEmbedding,
+    get_params_for_weight_decay_optimization,
+)
 from megatron.checkpointing import load_checkpoint, save_checkpoint
 from megatron.data.data_utils import build_train_valid_test_data_iterators
 from megatron.initialize import initialize_megatron
@@ -158,9 +162,8 @@ def _get_batch(neox_args, tokenizer, keys, data, datatype):
 
     # Get the masks and position ids.
     attention_mask, loss_mask, position_ids = get_ltor_masks_and_position_ids(
-        tokens,
-        tokenizer.eod,
-        neox_args.eod_mask_loss)
+        tokens, tokenizer.eod, neox_args.eod_mask_loss
+    )
 
     return tokens, labels, loss_mask, attention_mask, position_ids
 
@@ -228,23 +231,35 @@ def get_model(neox_args, inference=False, get_key_value=True):
     print_rank_0("building GPT2 model ...")
 
     # Build model on cpu.
-    model = GPT2ModelPipe(neox_args=neox_args, num_tokentypes=0, parallel_output=True, topology=mpu.get_topology(),
-                            inference=inference, get_key_value=get_key_value)
-    
+    model = GPT2ModelPipe(
+        neox_args=neox_args,
+        num_tokentypes=0,
+        parallel_output=True,
+        topology=mpu.get_topology(),
+        inference=inference,
+        get_key_value=get_key_value,
+    )
+
     ### soft prompt tuning stuff ###
-    if neox_args.soft_prompt_tuning is not None and neox_args.soft_prompt_tuning.get('enabled', False):
-        soft_prompt = SoftEmbedding(neox_args, 
-                                    wte = getattr(model, '0').word_embeddings,
-                                    n_tokens=neox_args.soft_prompt_tuning.get("n_tokens", 10),
-                                    init_string=neox_args.soft_prompt_tuning.get("init_string", ""),
-                                    init_range=neox_args.soft_prompt_tuning.get("init_range", 0.5))
-        model.insert_layers(layers=soft_prompt, idx=1) # insert the soft prompt layer directly after the word embeddings
-        
+    if neox_args.soft_prompt_tuning is not None and neox_args.soft_prompt_tuning.get(
+        "enabled", False
+    ):
+        soft_prompt = SoftEmbedding(
+            neox_args,
+            wte=getattr(model, "0").word_embeddings,
+            n_tokens=neox_args.soft_prompt_tuning.get("n_tokens", 10),
+            init_string=neox_args.soft_prompt_tuning.get("init_string", ""),
+            init_range=neox_args.soft_prompt_tuning.get("init_range", 0.5),
+        )
+        model.insert_layers(
+            layers=soft_prompt, idx=1
+        )  # insert the soft prompt layer directly after the word embeddings
+
         # freeze everything but the soft prompt
         for name, param in model.named_parameters():
-            if not 'soft_embedding' in name:
+            if not "soft_embedding" in name:
                 param.requires_grad = False
-        
+
     if not neox_args.is_pipe_parallel:
         # Export PipeParallel model to nn.Sequential model to avoid the overhead of deepspeed's pipe parallel training
         model = model.to_sequential()
@@ -266,7 +281,9 @@ def get_optimizer(model, neox_args):
         return None, None
     # Build parameter groups (weight decay and non-decay).
     param_groups = get_params_for_weight_decay_optimization(model, neox_args)
-    print_rank_0(f'Configuring Optimizer type: {neox_args.optimizer_type} with params: {neox_args.optimizer["params"]}')
+    print_rank_0(
+        f'Configuring Optimizer type: {neox_args.optimizer_type} with params: {neox_args.optimizer["params"]}'
+    )
 
     # Add model parallel attribute if it is not set.
     for param_group in param_groups:
@@ -277,8 +294,8 @@ def get_optimizer(model, neox_args):
     # Filter out params that don't require a grad (for soft prompt tuning, etc.)
     _param_groups = []
     for param_group in param_groups:
-        trainable_params = [p for p in param_group['params'] if p.requires_grad]
-        param_group['params'] = trainable_params
+        trainable_params = [p for p in param_group["params"] if p.requires_grad]
+        param_group["params"] = trainable_params
         _param_groups.append(param_group)
     param_groups = _param_groups
 
@@ -315,9 +332,12 @@ def get_optimizer(model, neox_args):
         if neox_args.use_bnb_optimizer:
             try:
                 import bitsandbytes as bnb
+
                 adam_optimizer = bnb.optim.Adam8bit
             except ModuleNotFoundError:
-                print("Please install bitsandbytes following https://github.com/facebookresearch/bitsandbytes.")
+                print(
+                    "Please install bitsandbytes following https://github.com/facebookresearch/bitsandbytes."
+                )
                 raise Exception
         else:
             try:
@@ -325,7 +345,9 @@ def get_optimizer(model, neox_args):
                 from apex.optimizers import FusedAdam as Adam
             except ImportError:
                 # if apex isn't installed, use deepspeed's FusedAdam
-                print("WARNING: APEX not installed - defaulting to deepspeed's fused adam")
+                print(
+                    "WARNING: APEX not installed - defaulting to deepspeed's fused adam"
+                )
                 from deepspeed.ops.adam import FusedAdam as Adam
             adam_optimizer = Adam
         optimizer = adam_optimizer(
@@ -378,7 +400,9 @@ def get_learning_rate_scheduler(optimizer, neox_args):
     return lr_scheduler
 
 
-def setup_model_and_optimizer(neox_args, inference=False, get_key_value=True):
+def setup_model_and_optimizer(
+    neox_args, inference=False, get_key_value=True, iteration=None
+):
     """Setup model and optimizer."""
     model = get_model(
         neox_args=neox_args, inference=inference, get_key_value=get_key_value
@@ -422,6 +446,7 @@ def setup_model_and_optimizer(neox_args, inference=False, get_key_value=True):
             optimizer=optimizer,
             lr_scheduler=lr_scheduler,
             inference=inference,
+            iteration=iteration,
         )
         print_rank_0(
             f"Loading checkpoint and starting from iteration {neox_args.iteration}"
@@ -563,10 +588,10 @@ def train(
         if neox_args.log_gradient_noise_scale:  # log noise scale if applicable
             noise_scale_logger.update()
 
-        # get learning rate (if present) - if doing soft prompt tuning + pipe parallel, you 
+        # get learning rate (if present) - if doing soft prompt tuning + pipe parallel, you
         # may have no tunable parameters on a specific rank
         if optimizer.param_groups:
-            lr = optimizer.param_groups[0].get('lr', 0)
+            lr = optimizer.param_groups[0].get("lr", 0)
         else:
             lr = 0
 
@@ -662,7 +687,11 @@ def evaluate(
             # although we're not accumulating gradients here, we count one iter as train_batch_size_per_gpu * g.a.s
             # to be consistent with deepspeed's pipe parallel engine
             # since pipe parallel already takes gas into account - default to 1 here if pipe parallel is true
-            for _ in range(1 if neox_args.is_pipe_parallel else neox_args.gradient_accumulation_steps):
+            for _ in range(
+                1
+                if neox_args.is_pipe_parallel
+                else neox_args.gradient_accumulation_steps
+            ):
                 # Forward evaluation
                 loss = forward_step_fn(
                     model=model,

--- a/megatron/utils.py
+++ b/megatron/utils.py
@@ -422,6 +422,10 @@ def setup_for_inference_or_eval(
     # initialize megatron
     initialize_megatron(neox_args)
 
+    print("NEOX ARGS ITERATION: ", neox_args.iteration)
+    import time
+
+    time.sleep(10)
     # set up model and load checkpoint.
     model, _, _ = setup_model_and_optimizer(
         neox_args=neox_args,

--- a/megatron/utils.py
+++ b/megatron/utils.py
@@ -387,7 +387,7 @@ def get_total_params(model):
 
 
 def setup_for_inference_or_eval(
-    inference=True, get_key_value=True, overwrite_values=None, iteration=None
+    inference=True, get_key_value=True, overwrite_values=None
 ):
     """
     Initializes the model for evaluation or inference (doesn't load optimizer states, etc.) from command line args.
@@ -427,7 +427,7 @@ def setup_for_inference_or_eval(
         neox_args=neox_args,
         inference=inference,
         get_key_value=get_key_value,
-        iteration=iteration,
+        iteration=neox_args.iteration,
     )  # we use setup_model_and_optimizer instead of get_model in order to initialize deepspeed
     print_rank_0("Finished loading model")
     return model, neox_args

--- a/megatron/utils.py
+++ b/megatron/utils.py
@@ -61,21 +61,21 @@ def report_memory(name):
     )
     print_rank_0(string)
 
+
 def get_attn_mask(seq_length, device):
     """
     Get triangular attention mask for a given sequence length / device.
     """
     # lower triangular attention mask
-    mask = torch.tril(torch.ones(
-        (1, seq_length, seq_length), device=device)).view(
-        1, 1, seq_length, seq_length)
-    
-    # convert to binary
-    return (mask < 0.5)
+    mask = torch.tril(torch.ones((1, seq_length, seq_length), device=device)).view(
+        1, 1, seq_length, seq_length
+    )
 
-def get_ltor_masks_and_position_ids(data,
-                                    eod_token,
-                                    eod_mask_loss=False):
+    # convert to binary
+    return mask < 0.5
+
+
+def get_ltor_masks_and_position_ids(data, eod_token, eod_mask_loss=False):
     """Build masks and position id for left to right model."""
 
     # Extract batch size and sequence length.
@@ -107,9 +107,11 @@ def local_rank():
         local_rank = 0
     return int(local_rank)
 
+
 def is_bnb_available():
     """ True if bitsandbytes optimizers are available """
     return importlib.util.find_spec("bitsandbytes") is not None
+
 
 def is_local_main():
     """ True if is the local main process """
@@ -385,7 +387,7 @@ def get_total_params(model):
 
 
 def setup_for_inference_or_eval(
-    inference=True, get_key_value=True, overwrite_values=None
+    inference=True, get_key_value=True, overwrite_values=None, iteration=None
 ):
     """
     Initializes the model for evaluation or inference (doesn't load optimizer states, etc.) from command line args.
@@ -406,7 +408,7 @@ def setup_for_inference_or_eval(
         "checkpoint_activations": False,
         "partition_activations": False,
         "no_load_optim": True,
-        'zero_optimization': None, # disable zero optimization (won't be used in inference, and loading zero optimizer can cause errors)
+        "zero_optimization": None,  # disable zero optimization (won't be used in inference, and loading zero optimizer can cause errors)
     }
     if overwrite_values:
         _overwrite_values.update(overwrite_values)
@@ -422,7 +424,10 @@ def setup_for_inference_or_eval(
 
     # set up model and load checkpoint.
     model, _, _ = setup_model_and_optimizer(
-        neox_args=neox_args, inference=inference, get_key_value=get_key_value
+        neox_args=neox_args,
+        inference=inference,
+        get_key_value=get_key_value,
+        iteration=iteration,
     )  # we use setup_model_and_optimizer instead of get_model in order to initialize deepspeed
     print_rank_0("Finished loading model")
     return model, neox_args

--- a/megatron/utils.py
+++ b/megatron/utils.py
@@ -422,10 +422,6 @@ def setup_for_inference_or_eval(
     # initialize megatron
     initialize_megatron(neox_args)
 
-    print("NEOX ARGS ITERATION: ", neox_args.iteration)
-    import time
-
-    time.sleep(10)
     # set up model and load checkpoint.
     model, _, _ = setup_model_and_optimizer(
         neox_args=neox_args,


### PR DESCRIPTION
Adds the following:

- Data Parallelism to Eval Harness (need to test this a bit more thoroughly before merge)
- Adds the ability to specify a checkpoint path to run evaluation on with a command line argument, e.g:
```python
./deepy.py evaluate.py configs/tmp.yml --eval_tasks lambada pubmedqa --iteration 26000 --eval_results_prefix iteration_26000
```
- Adds the ability to specify a results prefix to save results to with a command line arg (see above)

Apologies, autoformatter made a lot of cosmetic changes too