### PR TITLE
Hotfix to disallow generation with pipe + model parallel

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -18,56 +18,70 @@
 
 from megatron.utils import print_rank_0, setup_for_inference_or_eval
 
-from megatron.text_generation_utils import generate_samples_input_from_file, generate_samples_from_prompt, generate_samples_unconditional, generate_samples_interactive
+from megatron.text_generation_utils import (
+    generate_samples_input_from_file,
+    generate_samples_from_prompt,
+    generate_samples_unconditional,
+    generate_samples_interactive,
+)
+
 
 def main():
     """
     Generate text/sample model
     """
     model, neox_args = setup_for_inference_or_eval()
-    if neox_args.text_gen_type == 'unconditional':
-        print_rank_0('Generating samples unconditionally')
-        assert neox_args.sample_output_file is not None
+    assert (
+        neox_args.pipe_parallel_size <= 1
+    ), "Pipe parallel size must be <= 1 in generation"
+    if neox_args.text_gen_type == "unconditional":
+        print_rank_0(
+            f"Generating samples unconditionally and saving results to {neox_args.sample_output_file}"
+        )
         generate_samples_unconditional(
-            neox_args=neox_args, 
+            neox_args=neox_args,
             model=model,
             number_of_samples=neox_args.num_samples,
             output_file=neox_args.sample_output_file,
-            maximum_tokens = neox_args.maximum_tokens, 
-            recompute = neox_args.recompute, 
-            temperature = neox_args.temperature,
-            top_k = neox_args.top_k, 
-            top_p = neox_args.top_p
+            maximum_tokens=neox_args.maximum_tokens,
+            recompute=neox_args.recompute,
+            temperature=neox_args.temperature,
+            top_k=neox_args.top_k,
+            top_p=neox_args.top_p,
         )
 
-    elif neox_args.text_gen_type == 'input-file':
-        print_rank_0(f'Generating samples from input file {neox_args.sample_input_file}')
+    elif neox_args.text_gen_type == "input-file":
+        print_rank_0(
+            f"Generating samples from input file {neox_args.sample_input_file}"
+        )
         assert neox_args.sample_input_file is not None
         generate_samples_input_from_file(
-            neox_args=neox_args, 
+            neox_args=neox_args,
             model=model,
             input_file=neox_args.sample_input_file,
             output_file=neox_args.sample_output_file,
-            maximum_tokens = neox_args.maximum_tokens, 
-            recompute = neox_args.recompute, 
-            temperature = neox_args.temperature,
-            top_k = neox_args.top_k, 
-            top_p = neox_args.top_p
+            maximum_tokens=neox_args.maximum_tokens,
+            recompute=neox_args.recompute,
+            temperature=neox_args.temperature,
+            top_k=neox_args.top_k,
+            top_p=neox_args.top_p,
         )
 
-    elif neox_args.text_gen_type == 'interactive':
+    elif neox_args.text_gen_type == "interactive":
         generate_samples_interactive(
-            neox_args=neox_args, 
+            neox_args=neox_args,
             model=model,
-            recompute = neox_args.recompute, 
-            temperature = neox_args.temperature,
-            maximum_tokens = neox_args.maximum_tokens, 
-            top_k = neox_args.top_k, 
-            top_p = neox_args.top_p
+            recompute=neox_args.recompute,
+            temperature=neox_args.temperature,
+            maximum_tokens=neox_args.maximum_tokens,
+            top_k=neox_args.top_k,
+            top_p=neox_args.top_p,
         )
 
     else:
-        raise ValueError(f"`text-gen-type` either not specified or not recognised: {neox_args.text_gen_type}")
+        raise ValueError(
+            f"`text-gen-type` either not specified or not recognised: {neox_args.text_gen_type}"
+        )
 
 
 if __name__ == "__main__":

--- a/megatron/neox_arguments/neox_args.py
+++ b/megatron/neox_arguments/neox_args.py
@@ -24,7 +24,7 @@ ATTENTION_TYPE_CHOICES = [
 
 
 def get_git_commit_hash():
-    """ Gets the git commit hash of your current repo (if it exists) """
+    """Gets the git commit hash of your current repo (if it exists)"""
     try:
         git_hash = subprocess.check_output(["git", "describe", "--always"]).strip()
         git_hash = git_hash.decode()
@@ -906,7 +906,7 @@ class NeoXArgsTextgen(NeoXArgsTemplate):
     Text Generation arguments
     """
 
-    text_gen_type: str = None
+    text_gen_type: str = "unconditional"
     """
     How to generate text/sample the model.
     Options: `unconditional`, `input-file`, `interactive`
@@ -937,14 +937,14 @@ class NeoXArgsTextgen(NeoXArgsTemplate):
     Get input from file instead of interactive mode, each line is an input.
     """
 
-    sample_output_file: str = None
+    sample_output_file: str = "samples.txt"
     """
     Output file 
     """
 
-    num_samples: int = 0
+    num_samples: int = 1
     """
-    Number of samples to generate unconditionally, defaults to 0 and interactive conditional sampling
+    Number of samples to generate unconditionally, defaults to 1 and interactive conditional sampling
     """
 
     recompute: bool = False
@@ -962,5 +962,3 @@ class NeoXArgsTextgen(NeoXArgsTemplate):
     """
     Tasks to evaluate on using lm_eval_harness
     """
-
-    

--- a/megatron/text_generation_utils.py
+++ b/megatron/text_generation_utils.py
@@ -505,7 +505,6 @@ def generate_samples_from_prompt(
             if end_index >= start_index:
                 generated_tokens = tokens[start_index : end_index + 1]
                 if broadcast_generated_tokens:
-                    from copy import deepcopy
                     generated_tokens = torch.tensor(generated_tokens).cuda()
                     torch.distributed.broadcast(
                         generated_tokens,
@@ -523,7 +522,7 @@ def generate_samples_from_prompt(
                 generated_text = None
                 generated_tokens = []
                 # this will happen if the first generated token is a stop token or eos token
-                message = "WARNING: text generation did not start; try different batching or adjust parameters" 
+                message = "WARNING: text generation did not start; try different batching or adjust parameters"
             if is_mp_rank_0() or broadcast_generated_tokens:
                 data = {
                     "context": raw_text,
@@ -666,6 +665,7 @@ def generate_samples_unconditional(
     """
 
     print_rank_0("generate_samples_unconditional() generating...")
+    assert number_of_samples > 0, "number_of_samples must be > 0"
     generated_texts = generate_samples_from_prompt(
         neox_args=neox_args,
         model=model,


### PR DESCRIPTION
Generation with pipe + model parallel combined is currently broken due to the fact that deepspeed expects pipe parallel inputs to be broadcast from the zeroth model parallel rank, which is not yet implemented for layer pasts in particular. I'm working on a fix for that, but in the meantime, we should disallow this explicitly.