### PR TITLE
fixes the use of uninitialized variable

### DIFF
--- a/megatron/text_generation_utils.py
+++ b/megatron/text_generation_utils.py
@@ -759,6 +759,7 @@ def generate_samples_interactive(
             top_k=top_k,
             top_p=top_p,
         ):
+            generated_text = ""
             if mpu.get_model_parallel_rank() == 0:
                 generated_tokens = (
                     batch_context_tokens[0]


### PR DESCRIPTION
The variable  generated_text in line 776 must exist regardless of the result of the 'if' statement in line 763.
(fixes issue #538 on my machine).