### PR TITLE
Add links for *.torrent files, specify download sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The configuration file for the model is available [here](./configs/20B.yml), and
 
 ### Download Links
 
-[Slim weights](https://mystic.the-eye.eu/public/AI/models/GPT-NeoX-20B/slim_weights/) - (No optimizer states, for inference or finetuning)
+[Slim weights](https://mystic.the-eye.eu/public/AI/models/GPT-NeoX-20B/slim_weights/) - (No optimizer states, for inference or finetuning, 39GB)
 
 To download from the command line to a folder named `20B_checkpoints`, use the following command:
 
@@ -49,13 +49,15 @@ To download from the command line to a folder named `20B_checkpoints`, use the f
 wget --cut-dirs=5 -nH -r --no-parent --reject "index.html*" https://mystic.the-eye.eu/public/AI/models/GPT-NeoX-20B/slim_weights/ -P 20B_checkpoints
 ```
 
-[Full weights](https://mystic.the-eye.eu/public/AI/models/GPT-NeoX-20B/full_weights/) - (Including optimizer states)
+[Full weights](https://mystic.the-eye.eu/public/AI/models/GPT-NeoX-20B/full_weights/) - (Including optimizer states, 268GB)
 
 To download from the command line to a folder named `20B_checkpoints`, use the following command:
 
 ```bash
 wget --cut-dirs=5 -nH -r --no-parent --reject "index.html*" https://mystic.the-eye.eu/public/AI/models/GPT-NeoX-20B/full_weights/ -P 20B_checkpoints
 ```
+
+Alternatively, the models can be downloaded using a BitTorrent client. Torrent files can be downloaded here: [slim weights](https://mystic.the-eye.eu/public/AI/models/GPT-NeoX-20B/slim_weights.torrent), [full_weights](https://mystic.the-eye.eu/public/AI/models/GPT-NeoX-20B/full_weights.torrent).
 
 # Quick Start
 


### PR DESCRIPTION
As per issue #542:

 * Added links to Torrent files for 20B model to the main README
 * Specified download sizes to reduce the element of surprise, especially for the full weights