### PR TITLE
Fixed token_generation_end_index being too early

### DIFF
--- a/megatron/fused_kernels/__init__.py
+++ b/megatron/fused_kernels/__init__.py
@@ -28,6 +28,7 @@ srcpath = Path(__file__).parent.absolute()
 # extra_cuda_cflags below
 os.environ["TORCH_CUDA_ARCH_LIST"] = ""
 
+
 def load_fused_kernels():
     try:
         import scaled_upper_triang_masked_softmax_cuda
@@ -35,7 +36,9 @@ def load_fused_kernels():
     except (ImportError, ModuleNotFoundError):
         print("\n")
         print("=" * 100)
-        print(f'ERROR: Fused kernels configured but not installed. Please run `python {str(srcpath / "setup.py")} install` to install them')
+        print(
+            f'ERROR: Fused kernels configured but not installed. Please run `python {str(srcpath / "setup.py")} install` to install them'
+        )
         print("=" * 100)
         exit()
     return

--- a/megatron/fused_kernels/scaled_masked_softmax.h
+++ b/megatron/fused_kernels/scaled_masked_softmax.h
@@ -324,8 +324,8 @@ __global__ void scaled_masked_softmax_warp_backward(output_t* gradInput,
                 output_t out[ELEMENTS_PER_LDG_STG];
 #pragma unroll
                 for (int element = 0; element < ELEMENTS_PER_LDG_STG; ++element) {
-                    out[element] = (output_t)(
-                        scale * (grad_reg[i][it + element] - output_reg[i][it + element] * sum[i]));
+                    out[element] = (output_t)(scale * (grad_reg[i][it + element] -
+                                                       output_reg[i][it + element] * sum[i]));
                 }
                 copy_vector<output_t, ELEMENTS_PER_LDG_STG>(
                     gradInput + i * element_count + it * WARP_SIZE, out);

--- a/megatron/fused_kernels/scaled_upper_triang_masked_softmax.h
+++ b/megatron/fused_kernels/scaled_upper_triang_masked_softmax.h
@@ -350,8 +350,8 @@ __global__ void scaled_upper_triang_masked_softmax_warp_backward(output_t* gradI
                 output_t out[ELEMENTS_PER_LDG_STG];
 #pragma unroll
                 for (int element = 0; element < ELEMENTS_PER_LDG_STG; ++element) {
-                    out[element] = (output_t)(
-                        scale * (grad_reg[i][it + element] - output_reg[i][it + element] * sum[i]));
+                    out[element] = (output_t)(scale * (grad_reg[i][it + element] -
+                                                       output_reg[i][it + element] * sum[i]));
                 }
                 copy_vector<output_t, ELEMENTS_PER_LDG_STG>(
                     gradInput + i * element_count * stride + it * WARP_SIZE, out);

--- a/megatron/initialize.py
+++ b/megatron/initialize.py
@@ -193,6 +193,7 @@ def _initialize_distributed(neox_args):
     # Init DeepSpeed Activation Checkpointing Features
     setup_deepspeed_random_and_activation_checkpointing(neox_args=neox_args)
 
+
 def _init_autoresume(neox_args):
     """Set autoresume start time."""
 
@@ -210,6 +211,7 @@ def _init_autoresume(neox_args):
         torch.distributed.barrier()
         neox_args.adlr_autoresume_object.init()
         torch.distributed.barrier()
+
 
 def _set_random_seed(seed):
     """Set random seed for reproducability."""

--- a/megatron/logging.py
+++ b/megatron/logging.py
@@ -218,17 +218,30 @@ def training_log(
                     )
 
     # (optional) Log grad/param norms to wandb / tb every step
-    if neox_args.log_grad_pct_zeros or neox_args.log_grad_norm or neox_args.log_param_norm:
+    if (
+        neox_args.log_grad_pct_zeros
+        or neox_args.log_grad_norm
+        or neox_args.log_param_norm
+    ):
         if neox_args.log_grad_pct_zeros or neox_args.log_grad_norm:
             model.store_gradients = True  # start storing gradients
 
         for i, (name, param) in enumerate(model.module.named_parameters()):
             if neox_args.log_grad_pct_zeros:
-                if hasattr(model, 'stored_gradients') and model.stored_gradients is not None:
+                if (
+                    hasattr(model, "stored_gradients")
+                    and model.stored_gradients is not None
+                ):
                     grad = model.stored_gradients[i]
                     if grad is not None:
-                        tb_wandb_log(f'pct_grad_zeros/{name}', (grad == 0).float().mean().item()*100, iteration,
-                                     use_wandb=neox_args.use_wandb, tensorboard_writer=neox_args.tensorboard_writer, all_ranks=True)
+                        tb_wandb_log(
+                            f"pct_grad_zeros/{name}",
+                            (grad == 0).float().mean().item() * 100,
+                            iteration,
+                            use_wandb=neox_args.use_wandb,
+                            tensorboard_writer=neox_args.tensorboard_writer,
+                            all_ranks=True,
+                        )
             if neox_args.log_grad_norm:
                 if (
                     hasattr(model, "stored_gradients")

--- a/megatron/model/fused_softmax.py
+++ b/megatron/model/fused_softmax.py
@@ -18,7 +18,6 @@ import enum
 from ..fused_kernels import load_fused_kernels
 
 
-
 class ScaledUpperTriangMaskedSoftmax(torch.autograd.Function):
     """
     Fused operation which performs following three operations in sequence
@@ -122,7 +121,7 @@ class FusedScaleMaskSoftmax(nn.Module):
 
         if fusion_type != SoftmaxFusionTypes.none:
             load_fused_kernels()  # check fused kernels are installed
-            
+
         self.upper_triang_mask_fusion = fusion_type == SoftmaxFusionTypes.upper_triang
         self.general_mask_fusion = fusion_type == SoftmaxFusionTypes.general
         self.fusion = fusion_type != SoftmaxFusionTypes.none

--- a/megatron/text_generation_utils.py
+++ b/megatron/text_generation_utils.py
@@ -371,11 +371,11 @@ def stream_tokens(
                 )
             state_is_done = state_is_done | stop_tokens_produced
 
+            token_index_to_generate += 1
+
             token_generation_end_index[
                 (state_started.byte() & ~state_is_done).bool()
             ] = token_index_to_generate
-
-            token_index_to_generate += 1
 
             yield context_tokens, token_generation_start_index, token_generation_end_index, state_is_done.bool()
             if torch.all(state_is_done):

--- a/megatron/utils.py
+++ b/megatron/utils.py
@@ -147,7 +147,9 @@ def init_wandb(neox_args):
         return
 
     if not neox_args.wandb_init_all_ranks:
-        use_wandb = is_local_main() and (get_wandb_api_key(neox_args=neox_args) is not None)
+        use_wandb = is_local_main() and (
+            get_wandb_api_key(neox_args=neox_args) is not None
+        )
         neox_args.update_value("use_wandb", use_wandb)
     if neox_args.use_wandb:
         group_name = neox_args.wandb_group


### PR DESCRIPTION
When using stop_tokens I found that output was cut off 1 token too early. Incrementing token_index_to_generate before setting token_generation_end_index solves this.