### PR TITLE
[FIX] DeeperSpeed requirement doesn't use HTTPS.

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-git+git://github.com/EleutherAI/DeeperSpeed.git@eb7f5cff36678625d23db8a8fe78b4a93e5d2c75#egg=deepspeed
+git+https://github.com/EleutherAI/DeeperSpeed.git@eb7f5cff36678625d23db8a8fe78b4a93e5d2c75#egg=deepspeed
 einops==0.3.0
 ftfy==6.0.1
 lm_dataformat==0.0.19


### PR DESCRIPTION
 DeeperSpeed requirement doesn't use HTTPS but it should. So, I added a patch.

Here's the issue.
https://github.com/EleutherAI/gpt-neox/issues/589