### PR TITLE
Add documentation generation to CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,6 +12,17 @@ jobs:
           python-version: 3.8
       - uses: pre-commit/action@v2.0.3
 
+  update-documentation:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v3
+    - run: |
+        python configs/gen_docs.py
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        git add .
+        git commit -m "Update NeoXArgs docs automatically"
+        git push
   run-tests:
     runs-on: self-hosted
     steps:


### PR DESCRIPTION
This PR adds a new update documentation task, which runs the `gen_docs` script, then commits the changes as the `github-actions` user, to all new PRs, ensuring that any changes to NeoX arguments are updated in the documentation.