### PR TITLE
Load each stop_tokens token group into a Tensor

### DIFF
--- a/megatron/text_generation_utils.py
+++ b/megatron/text_generation_utils.py
@@ -192,7 +192,7 @@ def stream_tokens(
     temperature: float = 0.0,
     top_k: int = 0,
     top_p: float = 0.0,
-    stop_tokens=None,
+    stop_tokens: List[List[int]]=None,
 ):
     """
     iterator producing text completions
@@ -236,9 +236,8 @@ def stream_tokens(
     # convert to tensor and broadcast
     context_tokens = torch.cuda.LongTensor(context_tokens)
     if stop_tokens:
-        stop_tokens = torch.cuda.LongTensor(stop_tokens)
-        if stop_tokens.ndim == 1:
-            stop_tokens = stop_tokens.unsqueeze(0)
+        for i in range(0, len(stop_tokens)):
+            stop_tokens[i] = torch.cuda.LongTensor(stop_tokens[i])
 
     # Make sure context tokens + start tokens are the same across all ranks
     token_generation_start_index = torch.cuda.LongTensor(context_lengths)

--- a/megatron/text_generation_utils.py
+++ b/megatron/text_generation_utils.py
@@ -236,7 +236,7 @@ def stream_tokens(
     # convert to tensor and broadcast
     context_tokens = torch.cuda.LongTensor(context_tokens)
     if stop_tokens:
-        if stop_tokens.ndim == 1:
+        if len(stop_tokens) > 0 and type(stop_tokens[0]) is not list:
             stop_tokens = [stop_tokens]
         for i in range(0, len(stop_tokens)):
             stop_tokens[i] = torch.cuda.LongTensor(stop_tokens[i])

--- a/megatron/text_generation_utils.py
+++ b/megatron/text_generation_utils.py
@@ -192,7 +192,7 @@ def stream_tokens(
     temperature: float = 0.0,
     top_k: int = 0,
     top_p: float = 0.0,
-    stop_tokens: List[List[int]]=None,
+    stop_tokens=None,
 ):
     """
     iterator producing text completions
@@ -236,6 +236,8 @@ def stream_tokens(
     # convert to tensor and broadcast
     context_tokens = torch.cuda.LongTensor(context_tokens)
     if stop_tokens:
+        if stop_tokens.ndim == 1:
+            stop_tokens = [stop_tokens]
         for i in range(0, len(stop_tokens)):
             stop_tokens[i] = torch.cuda.LongTensor(stop_tokens[i])
 


### PR DESCRIPTION
Evaluation of stop_tokens fails when is a jagged array, because a jagged array cannot be converted to a Tensor. Thus all token groups must be the same length. This precludes stop_tokens being passed as, for example, `[[187,187],[535]]` which are both representations of `\n\n`.

A _jagged array_ is an array of arrays, a vector of vectors or a list of lists where each member of the outer list is another list which may be of a different length to any or all of its siblings. Another example of a jagged array is `[[1], [2,3], [4,5,6]]`

This change makes any usage of stop_tokens with a 1-dimensional list incompatible. LMK if maintaining compatibility is desired, and I'll make the requisite changes.