### PR TITLE
Update `eval_adapter` to conform to `lm_eval`'s `BaseLM`

### DIFF
--- a/eval_tasks/eval_adapter.py
+++ b/eval_tasks/eval_adapter.py
@@ -111,7 +111,7 @@ class EvalHarnessAdapter(GPT2LM):
 
     def tok_encode(self, string: str):
         return self.tokenizer.encode(string)
-    
+
     def tok_decode(self, tokens):
         return self.tokenizer.decode(tokens)
 

--- a/eval_tasks/eval_adapter.py
+++ b/eval_tasks/eval_adapter.py
@@ -23,9 +23,8 @@ from tqdm import tqdm
 import torch
 import torch.nn.functional as F
 
-from lm_eval.base import CacheHook
 from lm_eval.models.gpt2 import GPT2LM
-from lm_eval import tasks, evaluator, utils
+from lm_eval import tasks, evaluator, utils, base
 from megatron.text_generation_utils import generate_samples_from_prompt
 from megatron import mpu
 
@@ -42,16 +41,15 @@ class EvalHarnessAdapter(GPT2LM):
     """
 
     def __init__(self, model, forward_step_fn, neox_args, batch_size=None):
-
-        self.device = torch.device(f"cuda:{neox_args.local_rank}")
-        self.VOCAB_SIZE = neox_args.padded_vocab_size
-        self.tokenizer = neox_args.tokenizer
-        self.EOT_TOKEN_ID = neox_args.tokenizer.eod_id
+        self.cache_hook = base.CacheHook(None)
         self.model = model
         self.neox_args = neox_args
-        self.cache_hook = CacheHook(None)
-        self.max_length = neox_args.max_position_embeddings // 2
-        self.max_gen_toks = 128
+        self.tokenizer = neox_args.tokenizer
+        self._device = torch.device(f"cuda:{neox_args.local_rank}")
+        self._eot_token_id = neox_args.tokenizer.eod_id
+        self._max_length = neox_args.max_position_embeddings // 2
+        self._max_gen_toks = 128
+        self._vocab_size = neox_args.padded_vocab_size
 
         # parallelism args:
         self.is_main = neox_args.rank == 0
@@ -67,7 +65,7 @@ class EvalHarnessAdapter(GPT2LM):
         self.dp_group = mpu.get_data_parallel_group()
         self.is_mp_rank_0 = mpu.get_model_parallel_rank() == 0
 
-        self.batch_size = batch_size or (
+        self._batch_size = batch_size or (
             neox_args.batch_size * self.dp_world_size
         )  # default batch size to bs per gpu * dp size
 
@@ -82,9 +80,40 @@ class EvalHarnessAdapter(GPT2LM):
             generate_samples_from_prompt,
             neox_args=neox_args,
             model=model,
-            maximum_tokens=self.max_gen_toks,
+            maximum_tokens=self._max_gen_toks,
             temperature=0.0,
         )
+
+    @property
+    def vocab_size(self):
+        return self._vocab_size
+
+    @property
+    def eot_token_id(self):
+        # we use EOT because end of *text* is more accurate for what we're doing than end of *sentence*
+        return self._eos_token_id
+
+    @property
+    def max_length(self):
+        return self._max_length
+
+    @property
+    def max_gen_toks(self):
+        return self._max_gen_toks
+
+    @property
+    def batch_size(self):
+        return self._batch_size
+
+    @property
+    def device(self):
+        return self._device
+
+    def tok_encode(self, string: str):
+        return self.tokenizer.encode(string)
+    
+    def tok_decode(self, tokens):
+        return self.tokenizer.decode(tokens)
 
     def greedy_until(self, requests):
         """
@@ -156,7 +185,7 @@ class EvalHarnessAdapter(GPT2LM):
                 tqdm(reord.get_reordered(), disable=disable_tqdm), self.batch_size
             ):
                 inps, contlens, inplens, padding_length = [], [], [], None
-                for _, context_enc, continuation_enc in chunk:
+                for cache_key, context_enc, continuation_enc in chunk:
                     # when too long to fit in context, truncate from the left
                     inp = torch.tensor(
                         (context_enc + continuation_enc)[-(self.max_length + 1) :][:-1],
@@ -313,8 +342,12 @@ class EvalHarnessAdapter(GPT2LM):
             logits = logits[:batch_size, ...]
         return logits
 
+    def _model_generate(self, context, max_length, eos_token_id):
+        # Isn't used because we override `greedy_until``.
+        raise NotImplementedError()
+
     @torch.no_grad()
-    def run_eval(self, eval_tasks=None, num_fewshot=0, bootstrap_iters=2):
+    def run_eval(self, eval_tasks=None, num_fewshot=0, bootstrap_iters=2, description_dict=None, use_cache=True, name="gpt-neox"):
         was_training = self.model.training
         self.model.eval()
         in_micro_batches = (
@@ -342,10 +375,14 @@ class EvalHarnessAdapter(GPT2LM):
             torch.distributed.barrier()
         task_dict = tasks.get_task_dict(eval_tasks)
 
+        lm = self
+        if use_cache:
+            lm = base.CachingLM(lm, 'lm_cache/' + name + '.db')
+
         results = evaluator.evaluate(
-            lm=self,
+            lm=lm,
             task_dict=tasks.get_task_dict(eval_tasks),
-            provide_description=False,
+            description_dict=description_dict,
             num_fewshot=num_fewshot,
             limit=None,
             bootstrap_iters=bootstrap_iters,

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,8 +1,8 @@
 git+https://github.com/EleutherAI/DeeperSpeed.git@eb7f5cff36678625d23db8a8fe78b4a93e5d2c75#egg=deepspeed
 einops==0.3.0
 ftfy==6.0.1
-lm_dataformat==0.0.19
-git+https://github.com/EleutherAI/lm-evaluation-harness.git@dc937d4b70af819c5695e09d94e59e4cdb1e40ad#egg=lm_eval
+lm_dataformat==0.0.20
+lm_eval==0.2.0
 mpi4py==3.0.3
 numpy==1.21.0
 pybind11==2.6.2


### PR DESCRIPTION
Updates the `eval_adapter` to conform to the most recent lm-evaluation-harness `BaseLM` API. This allows for result caching during evaluation.

The following requirements in `requirements/requirements.txt` are bumped:
- `lm_eval==0.2.0`
- `lm_dataformat=0.0.20` This is a required dependency update for the former.