### PR TITLE
Fix `test_neoxargs_usage` Unit Test

### DIFF
--- a/tests/neox_args/test_neoxargs_usage.py
+++ b/tests/neox_args/test_neoxargs_usage.py
@@ -51,7 +51,7 @@ def test_neoxargs_usage():
 
         # find args matches
         matches = list(
-            re.findall(r"(?<=args\.).{2,}?(?=[\s\n(){}+-/*;:,=])", file_contents)
+            re.findall(r"(?<=args\.).{2,}?(?=[\s\n(){}+-/*;:,=,[,\]])", file_contents)
         )
         if len(matches) == 0:
             continue


### PR DESCRIPTION
The `test_neoxargs_usage` unit test was failing due to an unhandled edge case in the regular expression. I refactored the regex to handle it. Further context can be found in the closed issue. 

The configuration tests now all pass.

![image](https://user-images.githubusercontent.com/17308542/177204058-bc93c4cb-24ef-4909-8320-58cd48176a3b.png)


closes #641 