### PR TITLE
Update AliBi matrix caching for dynamic sequence lengths

### DIFF
--- a/megatron/model/positional_embeddings.py
+++ b/megatron/model/positional_embeddings.py
@@ -122,18 +122,28 @@ class AliBi(torch.nn.Module):
         # [b, np, sq, sk]
         seq_len_q = x.shape[-2]
         seq_len_k = x.shape[-1]
-        if self.cached_seq_len != seq_len_k:
+
+        # Initialize the AliBi matrix to match the first provided key length; grow it exponentially
+        # afterwards if longer inputs are provided. This is important for inference, where we will
+        # encounter progressively longer samples, while incurring no additional cost when input
+        # sequences are all equally long, as is typical at training time.
+        if self.cached_seq_len is None or self.cached_seq_len >= seq_len_k:
+            target_seq_len = seq_len_k if self.cached_seq_len is None else self.cached_seq_len * 4
             a = -torch.tril(
-                torch.arange(seq_len_k).view(seq_len_k, 1).repeat(1, seq_len_k)
-                + torch.arange(0, -seq_len_k, -1)
+                torch.arange(target_seq_len).view(target_seq_len, 1).repeat(1, target_seq_len)
+                + torch.arange(0, -target_seq_len, -1)
             )
             a = a.to(x.device).to(x.dtype)
             slopes = self.slopes.to(a.device).to(a.dtype)
             a = a * slopes.view(self.slopes.shape[0], 1, 1)
-            self.cached_seq_len = seq_len_k
+            self.cached_seq_len = target_seq_len
             self.cached_matrix = a
         else:
             a = self.cached_matrix
+        
+        # If the AliBi matrix is larger than the key length, clip it.
+        if self.cached_seq_len > seq_len_k:
+            a = self.cached_matrix[:, :seq_len_k, :seq_len_k]
 
         if seq_len_q != seq_len_k:
             # In the train case x has dimensionality [b, np, sq, sk] with sq == sk


### PR DESCRIPTION
When using a model trained with AliBi positional embedding for inference, the cached matrix gets invalidated and recomputed after every generated token, which is very expensive. This PR offers an alternative where the matrix is grown exponentially when longer sequences are encountered, while using clipping to ensure it works for shorter sequences. This will have no effect at training time, where it will be initialized to, and remain unchanged at, the target sequence length as before.

It may also be worth setting a minimum target length, e.g. at 64 tokens, possibly making this depend on the max length specified in the text generation config. In any case, the below has been tested with an AliBi-trained model and allows fast generation after the initial few resizing steps.