### PR TITLE
Update `lm_dataformat` dependency

### DIFF
--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -111,7 +111,7 @@ Logging Arguments
 
 - **git_hash**: str
 
-    Default = 04c7f3c
+    Default = 47abc1f
 
     current git hash of repository
 

--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -111,7 +111,7 @@ Logging Arguments
 
 - **git_hash**: str
 
-    Default = e43ec5f
+    Default = 04c7f3c
 
     current git hash of repository
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
 git+https://github.com/EleutherAI/DeeperSpeed.git@eb7f5cff36678625d23db8a8fe78b4a93e5d2c75#egg=deepspeed
 einops==0.3.0
 ftfy==6.0.1
-lm_dataformat==0.0.20
+git+https://github.com/EleutherAI/lm_dataformat.git@4eec05349977071bf67fc072290b95e31c8dd836
 lm_eval==0.2.0
 mpi4py==3.0.3
 numpy==1.22.0


### PR DESCRIPTION
We forked [https://github.com/EleutherAI/lm_dataformat](https://github.com/EleutherAI/lm_dataformat) so that we could continue maintaining it, but haven't updated the dependency in the main branch yet. this PR does that

The fork of lm_dataformat supports passing in a jsonl key correctly now.