### PR TITLE
Set hostfile in `get_deepspeed_main_args`

### DIFF
--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -111,7 +111,7 @@ Logging Arguments
 
 - **git_hash**: str
 
-    Default = 47abc1f
+    Default = e8fcee5
 
     current git hash of repository
 
@@ -930,7 +930,7 @@ Text Generation arguments
 
 - **eval_results_prefix**: str
 
-    Default =
+    Default = 
 
     prefix to which to save evaluation results - final fp will be {eval_results_prefix}_eval_results_yy-mm-dd-HH-MM.json
 
@@ -1518,6 +1518,7 @@ Args for deepspeed config
 
     Default = None
 
+    
 
 
 

--- a/megatron/neox_arguments/arguments.py
+++ b/megatron/neox_arguments/arguments.py
@@ -391,6 +391,10 @@ class NeoXArgs(*BASE_CLASSES):
                 args_list.extend(
                     self.convert_key_value_to_command_line_arg(key, configured_value)
                 )
+        if 'DLTS_HOSTFILE' in os.environ:
+            args_list.extend(
+                self.convert_key_value_to_command_line_arg("hostfile", os.environ['DLTS_HOSTFILE'])
+            )
 
         if (
             "--include" in args_list or "--exclude" in args_list


### PR DESCRIPTION
 This fixes the following error:

`[WARNING] [runner.py:178:fetch_hostfile] Unable to find hostfile, will proceed with training with local resources only.`

the hostfile was sometimes not set properly when launching multinode training. This would result in the following traceback:

```Traceback (most recent call last):
  File "/fsx/hailey/pythia/gpt-neox/train.py", line 30, in <module>
    pretrain(neox_args=neox_args)
  File "/fsx/hailey/pythia/gpt-neox/megatron/training.py", line 81, in pretrain
    initialize_megatron(neox_args=neox_args)
  File "/fsx/hailey/pythia/gpt-neox/megatron/initialize.py", line 75, in initialize_megatron
    finish_mpu_init()
  File "/fsx/hailey/pythia/gpt-neox/megatron/initialize.py", line 51, in finish_mpu_init
    _initialize_distributed(neox_args=neox_args)
  File "/fsx/hailey/pythia/gpt-neox/megatron/initialize.py", line 151, in _initialize_distributed
    distributed.init_distributed(
  File "/fsx/gpt-neox/conda/envs/neox-env-zphang/lib/python3.9/site-packages/deepspeed/utils/distributed.py", line 49, in init_distributed
    torch.distributed.init_process_group(backend=dist_backend,
  File "/fsx/gpt-neox/conda/envs/neox-env-zphang/lib/python3.9/site-packages/torch/distributed/distributed_c10d.py", line 595, in init_process_group
    store, rank, world_size = next(rendezvous_iterator)
Traceback (most recent call last):
  File "/fsx/hailey/pythia/gpt-neox/train.py", line 30, in <module>
    pretrain(neox_args=neox_args)
  File "/fsx/hailey/pythia/gpt-neox/megatron/training.py", line 81, in pretrain
    initialize_megatron(neox_args=neox_args)
  File "/fsx/hailey/pythia/gpt-neox/megatron/initialize.py", line 75, in initialize_megatron
    finish_mpu_init()
  File "/fsx/hailey/pythia/gpt-neox/megatron/initialize.py", line 51, in finish_mpu_init
    _initialize_distributed(neox_args=neox_args)
  File "/fsx/hailey/pythia/gpt-neox/megatron/initialize.py", line 151, in _initialize_distributed
    distributed.init_distributed(
  File "/fsx/gpt-neox/conda/envs/neox-env-zphang/lib/python3.9/site-packages/deepspeed/utils/distributed.py", line 49, in init_distributed
    torch.distributed.init_process_group(backend=dist_backend,
  File "/fsx/gpt-neox/conda/envs/neox-env-zphang/lib/python3.9/site-packages/torch/distributed/distributed_c10d.py", line 595, in init_process_group
    store, rank, world_size = next(rendezvous_iterator)
  File "/fsx/gpt-neox/conda/envs/neox-env-zphang/lib/python3.9/site-packages/torch/distributed/rendezvous.py", line 257, in _env_rendezvous_handler
    store = _create_c10d_store(master_addr, master_port, rank, world_size, timeout)
  File "/fsx/gpt-neox/conda/envs/neox-env-zphang/lib/python3.9/site-packages/torch/distributed/rendezvous.py", line 188, in _create_c10d_store
    return TCPStore(
RuntimeError: The server socket has failed to listen on any local network address. The server socket has failed to bind to [::]:29500 (errno: 98 - Address already in use). The server socket has failed to bind to 0.0.0.0:29500 (errno: 98 - Address already in use).
  File "/fsx/gpt-neox/conda/envs/neox-env-zphang/lib/python3.9/site-packages/torch/distributed/rendezvous.py", line 257, in _env_rendezvous_handler
    store = _create_c10d_store(master_addr, master_port, rank, world_size, timeout)
  File "/fsx/gpt-neox/conda/envs/neox-env-zphang/lib/python3.9/site-packages/torch/distributed/rendezvous.py", line 188, in _create_c10d_store
    return TCPStore(
RuntimeError: The server socket has failed to listen on any local network address. The server socket has failed to bind to [::]:29500 (errno: 98 - Address already in use). The server socket has failed to bind to 0.0.0.0:29500 (errno: 98 - Address already in use).
  File "/fsx/gpt-neox/conda/envs/neox-env-zphang/lib/python3.9/site-packages/torch/distributed/rendezvous.py", line 188, in _create_c10d_store
    return TCPStore(
RuntimeError: The server socket has failed to listen on any local network address. The server socket has failed to bind to [::]:29500 (errno: 98 - Address already in use). The server socket has failed to bind to 0.0.0.0:29500 (errno: 98 - Address already in use).```

@ShivanshuPurohit @StellaAthena @zphang 