### PR TITLE
Update the pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,10 +23,10 @@ repos:
             args: []
 
     - repo: https://github.com/psf/black
-      rev: 21.8b0
+      rev: 22.3.0
       hooks:
           - id: black
-            language_version: python3.8
+            language_version: python3
     - repo: https://github.com/codespell-project/codespell
       rev: v2.1.0
       hooks:


### PR DESCRIPTION
This fixes two issues:

**Problem:** Using pre-commit with python versions != 3.8 errors out with `RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.8'`.
**Fix:** Replace `language_version` with `python3` so that versioning is not strict

**Problem:** The `black` version in use is not compatible with new click. Fails with: `ImportError: cannot import name '_unicodefun' from 'click'`
**Fix:** Update version of `black` to `22.3.0`