### PR TITLE
Allow building of fused kernels without GPU

### DIFF
--- a/megatron/fused_kernels/setup.py
+++ b/megatron/fused_kernels/setup.py
@@ -1,7 +1,6 @@
 from setuptools import setup, find_packages
 from torch.utils import cpp_extension
 from torch.utils.cpp_extension import BuildExtension, CUDAExtension
-from torch.cuda import is_available as torch_cuda_available
 from pathlib import Path
 import subprocess
 

--- a/megatron/fused_kernels/setup.py
+++ b/megatron/fused_kernels/setup.py
@@ -64,8 +64,6 @@ setup(
             ],
             extra_compile_args=cuda_ext_args,
         ),
-    ]
-    if torch_cuda_available()
-    else [],
+    ],
     cmdclass={"build_ext": BuildExtension},
 )


### PR DESCRIPTION
The pytorch based CUDA check in the setup script of the Megatron fused kernels would return False if a GPU is not available. A GPU is not required to build the fused kernels. This check prevents properly building NeoX image in CI.
