### PR TITLE
Allow wildcard-style Eval Harness task selection

### DIFF
--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -111,7 +111,7 @@ Logging Arguments
 
 - **git_hash**: str
 
-    Default = 2b001f8
+    Default = 32deba2
 
     current git hash of repository
 

--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -111,7 +111,7 @@ Logging Arguments
 
 - **git_hash**: str
 
-    Default = 56b7427
+    Default = 4d2da1e
 
     current git hash of repository
 
@@ -737,6 +737,14 @@ Misc. Arguments
 
 
 
+- **deepspeed_slurm**: bool
+
+    Default = False
+
+    Run via SLURM, this will attempt to discover the necessary variables to initialize torch distributed from the SLURM environment
+
+
+
 - **user_script**: str
 
     Default = None
@@ -930,7 +938,7 @@ Text Generation arguments
 
 - **eval_results_prefix**: str
 
-    Default =
+    Default = 
 
     prefix to which to save evaluation results - final fp will be {eval_results_prefix}_eval_results_yy-mm-dd-HH-MM.json
 
@@ -1518,7 +1526,7 @@ Args for deepspeed config
 
     Default = None
 
-
+    
 
 
 
@@ -1644,3 +1652,12 @@ Args for deepspeed runner (deepspeed.launcher.runner).
     Default = False
 
     If true, autodetects nvlink pairs and remaps cuda visible devices to place them next to each other. This is an Eleuther addition to deepspeed, and should speed up model parallel training on setups with nvlink pairs when mp=2.
+
+
+
+- **slurm_comment**: str
+
+    Default = None
+
+    If using SLURM launcher adds a `--comment` to the srun command that launches the job. Sometimes necessary for cluster rules, or so I've heard.
+

--- a/eval_tasks/eval_adapter.py
+++ b/eval_tasks/eval_adapter.py
@@ -439,7 +439,7 @@ def run_eval_harness(
     bootstrap_iters=2,
 ):
     print_rank_0("Running evaluation harness...")
-    adapter = EvalHarnessAdapter(model, forward_step_fn, neox_args, batch_size=32)
+    adapter = EvalHarnessAdapter(model, forward_step_fn, neox_args, batch_size=batch_size)
     return adapter.run_eval(
-        eval_tasks=eval_tasks, num_fewshot=num_fewshot, bootstrap_iters=bootstrap_iters, use_cache=False,
+        eval_tasks=eval_tasks, num_fewshot=num_fewshot, bootstrap_iters=bootstrap_iters,
     )

--- a/eval_tasks/eval_adapter.py
+++ b/eval_tasks/eval_adapter.py
@@ -69,7 +69,6 @@ class EvalHarnessAdapter(GPT2LM):
         self._batch_size = batch_size or (
             neox_args.batch_size * self.dp_world_size
         )  # default batch size to bs per gpu * dp size
-
         # some utility functions:
         # we need to patch tokenizer methods, because lm_eval uses them internally:
         self.tokenizer.encode = self.tokenizer.tokenize
@@ -374,6 +373,18 @@ class EvalHarnessAdapter(GPT2LM):
                 "pubmedqa",
             ]
 
+        # Returns a list containing all values of the task registry that
+        # match at least one of the patterns
+        import fnmatch
+        def pattern_match(patterns, source_list):
+            task_names = set()
+            for pattern in patterns:
+                for matching in fnmatch.filter(source_list, pattern):
+                    task_names.add(matching)
+            return list(task_names)
+        eval_tasks = pattern_match(eval_tasks, tasks.ALL_TASKS)
+        print(f"Found tasks: {eval_tasks}")
+
         # **HACK INCOMING**:
         # first get task dict on local main rank
         # the tasks are downloaded *as they are initialized*, and the downloads don't like multithreading.
@@ -428,7 +439,7 @@ def run_eval_harness(
     bootstrap_iters=2,
 ):
     print_rank_0("Running evaluation harness...")
-    adapter = EvalHarnessAdapter(model, forward_step_fn, neox_args, batch_size)
+    adapter = EvalHarnessAdapter(model, forward_step_fn, neox_args, batch_size=32)
     return adapter.run_eval(
-        eval_tasks=eval_tasks, num_fewshot=num_fewshot, bootstrap_iters=bootstrap_iters
+        eval_tasks=eval_tasks, num_fewshot=num_fewshot, bootstrap_iters=bootstrap_iters, use_cache=False,
     )

--- a/evaluate.py
+++ b/evaluate.py
@@ -23,7 +23,7 @@ sys.path.append(
     os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir))
 )
 from megatron.training import forward_step
-from megatron.utils import setup_for_inference_or_eval
+from megatron.utils import setup_for_inference_or_eval, init_wandb
 from megatron.logging import tb_wandb_log
 from eval_tasks import run_eval_harness
 from pprint import pprint
@@ -31,7 +31,7 @@ from datetime import datetime
 import json
 
 
-def main(): 
+def main():
     model, neox_args = setup_for_inference_or_eval(use_cache=False)
     results = run_eval_harness(
         model,
@@ -41,7 +41,7 @@ def main():
         bootstrap_iters=10000,
     )
     if neox_args.rank == 0:
-
+        init_wandb(neox_args=neox_args)
         # log to wandb
         for k, v in results["results"].items():
             if isinstance(v, dict):


### PR DESCRIPTION
The lm-eval-harness uses Linux wildcards to allow for the selection of multiple tasks sharing a prefix in their name at once, via passing `--tasks blimp_* ` to select all BLiMP tasks at once rather than manually.

This PR adds support for this pattern to the Eval-harness adapter, so that one can pass ` --eval_tasks blimp_* ` or `--eval_tasks hendrycks_* ` to run on all BLiMP or MMLU tasks without passing all task names individually, as a minor QoL fix.