### PR TITLE
Fix Typo in requirements

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -11,5 +11,5 @@ sentencepiece
 six
 tokenizers==0.12.1
 transformers~=4.24.0
-huggingface_hub=0.11.0
+huggingface_hub==0.11.0
 wandb==0.10.28


### PR DESCRIPTION
when use `pip install -r requirements/requirements.txt` it raise error missing `=` 