### PR TITLE
Raise error in HF conversion script if using single tied layernorm with GPT-J residual

### DIFF
--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -111,7 +111,7 @@ Logging Arguments
 
 - **git_hash**: str
 
-    Default = ace36f4
+    Default = 23a5ccd
 
     current git hash of repository
 

--- a/tools/convert_to_hf.py
+++ b/tools/convert_to_hf.py
@@ -75,6 +75,16 @@ def create_config(neox_config):
     except:
         pad_token = 1 # pad defaulting to 1. follows convention from GPT-NeoX-20b tokenizer
 
+
+    # TODO: change the default value here based on discussion regarding `gpt_j_tied` config parameter's default
+    use_tied_lns = get_key(neox_config, 'gpt-j-tied', False)
+
+    if not use_tied_lns:
+        raise NotImplementedError(
+                """ERROR: Huggingface Transformers does not yet support a single shared layernorm 
+                per transformer block for GPT-NeoX models trained  w/ GPT-J parallel residuals.
+                See https://github.com/EleutherAI/gpt-neox/pull/481 for further details."""
+    
     # set all config values.
     hf_config = GPTNeoXConfig(
         vocab_size=args.padded_vocab_size,


### PR DESCRIPTION
This PR makes the conversion to HF format raise an error if a model with a single layernorm and GPT-J residual setup is used, since it's not currently supported by HF.






cc @Quentin-Anthony @StellaAthena 