### PR TITLE
Fix shared LN error in HF conversion script

### DIFF
--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -111,7 +111,7 @@ Logging Arguments
 
 - **git_hash**: str
 
-    Default = 5bba068
+    Default = 34e8816
 
     current git hash of repository
 

--- a/tools/convert_to_hf.py
+++ b/tools/convert_to_hf.py
@@ -105,11 +105,11 @@ def create_config(neox_config):
     # TODO: change the default value here based on discussion regarding `gpt_j_tied` config parameter's default
     use_tied_lns = get_key(neox_config, 'gpt-j-tied', False)
 
-    if not use_tied_lns:
+    if use_tied_lns:
         raise NotImplementedError(
                 """ERROR: Huggingface Transformers does not yet support a single shared layernorm 
                 per transformer block for GPT-NeoX models trained  w/ GPT-J parallel residuals.
-                See https://github.com/EleutherAI/gpt-neox/pull/481 for further details."""
+                See https://github.com/EleutherAI/gpt-neox/pull/481 for further details.""")
     
     # set all config values.
     hf_config = GPTNeoXConfig(


### PR DESCRIPTION
Oops--the script should refuse to convert models when layernorms ARE shared, since what's supported by HF right now is 2 separate layernorms.

@StellaAthena 