### PR TITLE
`save-interval` -> `checkpoint-factor` in all example configs

### DIFF
--- a/configs/1-3B.yml
+++ b/configs/1-3B.yml
@@ -79,7 +79,7 @@
    "distributed-backend": "nccl",
    "lr-decay-style": "cosine",
    "warmup": 0.01,
-   "save-interval": 10000,
+   "checkpoint-factor": 10000,
    "eval-interval": 1000,
    "eval-iters": 10,
 

--- a/configs/125M.yml
+++ b/configs/125M.yml
@@ -79,7 +79,7 @@
    "distributed-backend": "nccl",
    "lr-decay-style": "cosine",
    "warmup": 0.01,
-   "save-interval": 10000,
+   "checkpoint-factor": 10000,
    "eval-interval": 1000,
    "eval-iters": 10,
 

--- a/configs/13B.yml
+++ b/configs/13B.yml
@@ -80,7 +80,7 @@
    "distributed-backend": "nccl",
    "lr-decay-style": "cosine",
    "warmup": 0.01,
-   "save-interval": 10000,
+   "checkpoint-factor": 10000,
    "eval-interval": 1000,
    "eval-iters": 10,
 

--- a/configs/175B.yml
+++ b/configs/175B.yml
@@ -78,7 +78,7 @@
    "distributed-backend": "nccl",
    "lr-decay-style": "cosine",
    "warmup": 0.01,
-   "save-interval": 10000,
+   "checkpoint-factor": 10000,
    "eval-interval": 1000,
    "eval-iters": 10,
 

--- a/configs/19M.yml
+++ b/configs/19M.yml
@@ -74,7 +74,7 @@
   "distributed-backend": "nccl",
   "lr-decay-style": "cosine",
   "warmup": 0.01,
-  "save-interval": 1000,
+  "checkpoint-factor": 1000,
   "eval-interval": 100000,
   "eval-iters": 10,
 

--- a/configs/2-7B.yml
+++ b/configs/2-7B.yml
@@ -79,7 +79,7 @@
    "distributed-backend": "nccl",
    "lr-decay-style": "cosine",
    "warmup": 0.01,
-   "save-interval": 10000,
+   "checkpoint-factor": 10000,
    "eval-interval": 1000,
    "eval-iters": 10,
 

--- a/configs/20B.yml
+++ b/configs/20B.yml
@@ -94,7 +94,7 @@
   "distributed-backend": "nccl",
   "lr-decay-style": "cosine",
   "warmup": 0.01,
-  "save-interval": 500,
+  "checkpoint-factor": 500, # this variable previously called `save-interval`
   "eval-interval": 1000,
   "eval-iters": 10,
 

--- a/configs/350M.yml
+++ b/configs/350M.yml
@@ -78,7 +78,7 @@
    "distributed-backend": "nccl",
    "lr-decay-style": "cosine",
    "warmup": 0.01,
-   "save-interval": 10000,
+   "checkpoint-factor": 10000,
    "eval-interval": 1000,
    "eval-iters": 10,
 

--- a/configs/49M.yml
+++ b/configs/49M.yml
@@ -80,7 +80,7 @@
   "distributed-backend": "nccl",
   "lr-decay-style": "cosine",
   "warmup": 0.01,
-  "save-interval": 1000,
+  "checkpoint-factor": 1000,
   "eval-interval": 100000,
   "eval-iters": 10,
 

--- a/configs/6-7B.yml
+++ b/configs/6-7B.yml
@@ -79,7 +79,7 @@
    "distributed-backend": "nccl",
    "lr-decay-style": "cosine",
    "warmup": 0.01,
-   "save-interval": 10000,
+   "checkpoint-factor": 10000,
    "eval-interval": 1000,
    "eval-iters": 10,
 

--- a/configs/760M.yml
+++ b/configs/760M.yml
@@ -79,7 +79,7 @@
    "distributed-backend": "nccl",
    "lr-decay-style": "cosine",
    "warmup": 0.01,
-   "save-interval": 10000,
+   "checkpoint-factor": 10000,
    "eval-interval": 1000,
    "eval-iters": 10,
 

--- a/configs/800M.yml
+++ b/configs/800M.yml
@@ -74,7 +74,7 @@
   "distributed-backend": "nccl",
   "lr-decay-style": "cosine",
   "warmup": 0.01,
-  "save-interval": 1000,
+  "checkpoint-factor": 1000,
   "eval-interval": 40000,
   "eval-iters": 10,
 

--- a/configs/bf16_125M.yml
+++ b/configs/bf16_125M.yml
@@ -74,7 +74,7 @@
    "distributed-backend": "nccl",
    "lr-decay-style": "cosine",
    "warmup": 0.01,
-   "save-interval": 10000,
+   "checkpoint-factor": 10000,
    "eval-interval": 1000,
    "eval-iters": 10,
 

--- a/configs/bnb_125M.yml
+++ b/configs/bnb_125M.yml
@@ -73,7 +73,7 @@
    "distributed-backend": "nccl",
    "lr-decay-style": "cosine",
    "warmup": 0.01,
-   "save-interval": 10000,
+   "checkpoint-factor": 10000,
    "eval-interval": 1000,
    "eval-iters": 10,
 

--- a/configs/gmlp_small.yml
+++ b/configs/gmlp_small.yml
@@ -60,7 +60,7 @@
    "distributed-backend": "nccl",
    "lr-decay-style": "cosine",
    "warmup": 0.01,
-   "save-interval": 10000,
+   "checkpoint-factor": 10000,
    "eval-interval": 1000,
    "eval-iters": 10,
 

--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -111,7 +111,7 @@ Logging Arguments
 
 - **git_hash**: str
 
-    Default = 12f6f76
+    Default = 9fd1b6b
 
     current git hash of repository
 

--- a/configs/slurm_125M.yml
+++ b/configs/slurm_125M.yml
@@ -51,7 +51,7 @@
    "distributed-backend": "nccl",
    "lr-decay-style": "cosine",
    "warmup": 0.01,
-   "save-interval": 10000,
+   "checkpoint-factor": 10000,
    "eval-interval": 1000,
    "eval-iters": 10,
    "log-interval": 100,


### PR DESCRIPTION
This PR addresses #749 and #748 . The example configs need patching to reflect the removal of the `save-interval` arg.

@StellaAthena @ShivanshuPurohit 