### PR TITLE
set gpt_j_tied to true so that 20B inference works again

### DIFF
--- a/configs/20B.yml
+++ b/configs/20B.yml
@@ -27,6 +27,7 @@
   "rotary_pct": 0.25,
   "no-weight-tying": true,
   "gpt_j_residual": true,
+  "gpt_j_tied": true,
   "output_layer_parallelism": "column",
   "scaled-upper-triang-masked-softmax-fusion": true,
   "bias-gelu-fusion": true,


### PR DESCRIPTION
`gpt_j_tied=false` will cause 20B model generate gibberish results. This is reported [here](https://github.com/EleutherAI/gpt-neox/issues/745) and [here](https://github.com/EleutherAI/gpt-neox/issues/755).

The source of the problem is this [commit](https://github.com/EleutherAI/gpt-neox/commit/0accac618d70bd62de3965c037a7b2a36d07deb1).

To reproduce, run `./deepy.py generate.py ./configs/20B.yml`

"gpt_j_tied": false
```
{"context": "", "text": " de de general de general de2a1a\u00ada\u00ada\u00ada\u00ada\u00ada\u00ada\u00ado\u00ado\u00ado\u00ado\u00ado\u00ado\u00ado\u00ado\u00ado\u00ado3\u00ado\u00ado3\u00ado3\u00ado3\u00ado\u00ado\u00ado\u00ado\u00ado", "length": 64, "finished": false, "message": null, "duration_seconds": 4.648434400558472}
```
"gpt_j_tied": true

```
{"context": "", "text": "Q:\n\nHow to get the value of a variable in a function in a different file?\n\nI have a file called \"main.py\" and a file called \"functions.py\".\nIn \"main.py\" I have:\nfrom functions import *\n\ndef main():\n    print", "length": 64, "finished": false, "message": null, "duration_seconds": 4.764044523239136}
```