### PR TITLE
Update lm-eval version

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,7 +3,7 @@ einops==0.3.0
 ftfy==6.0.1
 git+https://github.com/EleutherAI/lm_dataformat.git@4eec05349977071bf67fc072290b95e31c8dd836
 huggingface_hub==0.11.0
-lm_eval==0.2.0
+lm_eval==0.3.0
 mpi4py==3.0.3
 numpy==1.22.0
 pybind11==2.6.2


### PR DESCRIPTION
`lm-eval` was pined to `0.2.0`. Seems to be outdated because some tests can't be found (e.g. lambada_openai, lambada_standard)

Upgrade it to `0.3.0` solved the problem.