### PR TITLE
Bugfix for Iteration 0 checkpointing

### DIFF
--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -111,7 +111,7 @@ Logging Arguments
 
 - **git_hash**: str
 
-    Default = 27e56e3
+    Default = 075a525
 
     current git hash of repository
 

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -101,10 +101,10 @@ def pretrain(neox_args):
     timers.log(["model and optimizer", "train/valid/test data iterators"])
     print_rank_0("training ...")
 
-    iteration = 0
+    iteration = neox_args.iteration
     if neox_args.do_train and neox_args.train_iters > 0:
-        # edge case: save step 0 checkpoint if requested
-        if neox_args.save and 0 in neox_args.save_iters:
+        # edge case: save step 0 checkpoint if requested and we're starting from step 0
+        if neox_args.save and 0 in neox_args.save_iters and iteration == 0:
             save_checkpoint(
                 neox_args=neox_args,
                 iteration=iteration,


### PR DESCRIPTION
In #737 I added functionality to specify arbitrary training steps at which a checkpoint should be saved, including step 0 of training.

There is a bug with the step 0 checkpointing currently. For some reason, `iteration = 0` was already set before that PR in the `pretrain()` function but never used. However, this leads the step 0 checkpointing to save a "step 0" checkpoint whenever training is resumed (if a step 0 checkpoint is asked for). 

This means that the supposed "step 0" checkpoint would be overwritten at each resumption of training. 

This PR fixes that issue. It doesn't affect any models we trained, luckily.

@Quentin-Anthony @StellaAthena 