### PR TITLE
Optimize data preprocessing by using numpy

### DIFF
--- a/tools/preprocess_data.py
+++ b/tools/preprocess_data.py
@@ -23,6 +23,7 @@ import os
 import sys
 
 import lm_dataformat as lmd
+import numpy as np
 
 sys.path.append(
     os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir))
@@ -217,7 +218,7 @@ def main():
         # add each tokenized document / sentence
         for key, sentences in doc.items():
             for sentence in sentences:
-                builders[key].add_item(torch.IntTensor(sentence))
+                builders[key].add_item(np.array(sentence, dtype=builders[key].dtype))
             # separate with eos token
             builders[key].end_document()
 


### PR DESCRIPTION
This PR is trying to accelerate `preprocess_data.py`. There are mainly 2 optimizations:

 - pass `numpy.ndarray` to `add_item` of `IndexDatasetBuilder` to avoid an immediate `tensor.numpy()`.
 - use `np.cumsum` instead of a loop to calculate the pointer offsets.

Thank you for your time on reviewing this PR :)