### PR TITLE
Add DeepSpeed bf16 configuration

### DIFF
--- a/megatron/neox_arguments/deepspeed_args.py
+++ b/megatron/neox_arguments/deepspeed_args.py
@@ -89,6 +89,11 @@ class NeoXArgsDeepspeedConfig(NeoXArgsTemplate):
     Configuration for using mixed precision/FP16 training that leverages NVIDIA’s Apex package.
     """
 
+    bf16: dict = None
+    """
+    Configuration for using bfloat16 precision during training.
+    """
+
     amp: dict = None
     """
     Dictionary as described in Deepspeed documentation: https://www.deepspeed.ai/docs/config-json/#automatic-mixed-precision-amp-training-options


### PR DESCRIPTION
Let's try this again: DeepSpeed uses a special `bf16` configuration to enable using bf16 precision during. This adds that configuration to NeoX and main DeepSpeed does the rest of the work.