### PR TITLE
Remove deprecated numpy calls

### DIFF
--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -111,7 +111,7 @@ Logging Arguments
 
 - **git_hash**: str
 
-    Default = 7ed7bc6
+    Default = a7febb2
 
     current git hash of repository
 

--- a/megatron/data/indexed_dataset.py
+++ b/megatron/data/indexed_dataset.py
@@ -101,8 +101,8 @@ dtypes = {
     3: np.int16,
     4: np.int32,
     5: np.int64,
-    6: np.float,
-    7: np.double,
+    6: np.float32,
+    7: np.float64,
     8: np.uint16,
 }
 
@@ -274,8 +274,8 @@ class IndexedDatasetBuilder(object):
         np.int16: 2,
         np.int32: 4,
         np.int64: 8,
-        np.float: 4,
-        np.double: 8,
+        np.float32: 4,
+        np.float64: 8,
     }
 
     def __init__(self, out_file, dtype=np.int32):


### PR DESCRIPTION
tested to be backwards-compatible to as old as numpy==1.18.0

https://numpy.org/doc/stable/release/1.24.0-notes.html#expired-deprecations