### PR TITLE
fix unexpected indent error for conditional `tiktoken` import

### DIFF
--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -111,7 +111,7 @@ Logging Arguments
 
 - **git_hash**: str
 
-    Default = 496f987
+    Default = 5face7a
 
     current git hash of repository
 

--- a/megatron/tokenizer/tokenizer.py
+++ b/megatron/tokenizer/tokenizer.py
@@ -352,11 +352,11 @@ class CharLevelTokenizer(AbstractTokenizer):
 
 class TiktokenTokenizer(AbstractTokenizer):
     """Tokenizer from OpenAI's tiktoken implementation"""
-        try:
-            import tiktoken
-        except ModuleNotFoundError:
-            print("Please install tiktoken: (https://github.com/openai/tiktoken)")
-            raise Exception
+    try:
+        import tiktoken
+    except ModuleNotFoundError:
+        print("Please install tiktoken: (https://github.com/openai/tiktoken)")
+        raise Exception
 
     def __init__(self, vocab_file):
         name = "TiktokenTokenizer"


### PR DESCRIPTION
Fixes the following error: 
```bash
../gpt-neox/megatron/tokenizer/tokenizer.py", line 355
    try:
    ^
IndentationError: unexpected indent
```