### PR TITLE
Update deepspeed_args.py - Avoid SyntaxError: unterminated string literal (detected at line 218)

### DIFF
--- a/megatron/neox_arguments/deepspeed_args.py
+++ b/megatron/neox_arguments/deepspeed_args.py
@@ -202,15 +202,14 @@ class NeoXArgsDeepspeedRunner(NeoXArgsTemplate):
     If true, autodetects nvlink pairs and remaps cuda visible devices to place them next to each other. This is an Eleuther addition to deepspeed, and should speed up model parallel training on setups with nvlink pairs when mp=2.
     """
 
-
     autotuning_run: str = None
     """
     Either "tune", "run", or `None`.
+    """
 
     no_ssh_check: bool = False
     """
     If true, overrides the default check where DeepSpeed confirms that the headnode is accessible via ssh.
-
     """
 
     comment: str = None


### PR DESCRIPTION
Missing end of comment
Avoid `SyntaxError: unterminated string literal (detected at line 218)`