### PR TITLE
Fix ssh login

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ ENV PASSWORD=password
 RUN mkdir /var/run/sshd && \
     echo "root:${PASSWORD}" | chpasswd && \
     # Allow root login with password
-    sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /etc/ssh/sshd_config && \
+    sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config && \
     # Prevent user being kicked off after login
     sed -i 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' /etc/pam.d/sshd && \
     echo 'AuthorizedKeysFile     .ssh/authorized_keys' >> /etc/ssh/sshd_config && \


### PR DESCRIPTION

## login fail
```
$ ssh root@IP
Permission denied, please try again.
```

## /etc/ssh/sshd_config
default config `#PermitRootLogin prohibit-password` should be replaced by `PermitRootLogin yes`


