### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -9,6 +9,7 @@ pybind11>=2.6.2
 regex
 sentencepiece
 six
+best_download
 tiktoken>=0.1.2
 tokenizers>=0.12.1
 transformers>=4.24.0


### PR DESCRIPTION

No module named 'best_download' while training

```
$  python ./deepy.py ./train.py ./configs/125M.yml ./configs/local_setup.yml
...
Traceback (most recent call last):
  File "./train.py", line 20, in <module>
    from eval_tasks import run_eval_harness
  File "/gpt-neox/eval_tasks/__init__.py", line 15, in <module>
    import best_download
ModuleNotFoundError: No module named 'best_download'
    from megatron.training import pretrain
  File "/gpt-neox/megatron/training.py", line 58, in <module>
    from .eval_adapter import EvalHarnessAdapter, run_eval_harness
  File "/gpt-neox/eval_tasks/eval_adapter.py", line 16, in <module>
    from eval_tasks import run_eval_harness
  File "/gpt-neox/eval_tasks/__init__.py", line 15, in <module>
    import best_download
ModuleNotFoundError: No module named 'best_download'
    from .eval_adapter import EvalHarnessAdapter, run_eval_harness
  File "/gpt-neox/eval_tasks/eval_adapter.py", line 16, in <module>
    import best_download
ModuleNotFoundError: No module named 'best_download'

```