### PR TITLE
Remove duplicate no_ssh_check arg

### DIFF
--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -111,7 +111,7 @@ Logging Arguments
 
 - **git_hash**: str
 
-    Default = cbed1b5
+    Default = fa1db22
 
     current git hash of repository
 
@@ -1830,7 +1830,9 @@ Args for deepspeed runner (deepspeed.launcher.runner).
     Default = None
 
     Either "tune", "run", or `None`.
-    
+
+
+
 - **no_ssh_check**: bool
 
     Default = False
@@ -1844,12 +1846,4 @@ Args for deepspeed runner (deepspeed.launcher.runner).
     Default = None
 
     Adds a `--comment` to the DeepSpeed launch command. In DeeperSpeed this is passed on to the SlurmLauncher as well. Sometime necessary for cluster rules, or so I've heard.
-
-
-
-- **no_ssh_check**: bool
-
-    Default = False
-
-    If `True` and running with multiple nodes, then DeepSpeedd doesn't conduct a check to ensure the head node is reachable with ssh.
 

--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -111,7 +111,7 @@ Logging Arguments
 
 - **git_hash**: str
 
-    Default = fa1db22
+    Default = e0587af
 
     current git hash of repository
 

--- a/megatron/neox_arguments/deepspeed_args.py
+++ b/megatron/neox_arguments/deepspeed_args.py
@@ -216,8 +216,3 @@ class NeoXArgsDeepspeedRunner(NeoXArgsTemplate):
     """
     Adds a `--comment` to the DeepSpeed launch command. In DeeperSpeed this is passed on to the SlurmLauncher as well. Sometime necessary for cluster rules, or so I've heard.
     """
-
-    no_ssh_check: bool = False
-    """
-    If `True` and running with multiple nodes, then DeepSpeedd doesn't conduct a check to ensure the head node is reachable with ssh.
-    """


### PR DESCRIPTION
Looks like I accidentally uncommented and committed a duplicate `no_ssh_check` arg in https://github.com/EleutherAI/gpt-neox/commit/e897c23e921101a3d84208f2717e0c462e8bd20a