### PR TITLE
No longer ignore `--iteration` when passed to train.py

### DIFF
--- a/megatron/training.py
+++ b/megatron/training.py
@@ -190,7 +190,7 @@ def pretrain(neox_args):
     # Model, optimizer, and learning rate.
     timers("model and optimizer").start()
     model, optimizer, lr_scheduler = setup_model_and_optimizer(
-        neox_args=neox_args, use_cache=False
+        neox_args=neox_args, use_cache=False, iteration=neox_args.iteration
     )
     timers("model and optimizer").stop()
 


### PR DESCRIPTION
We currently resume training using the checkpoint tag provided in the "latest" file within the save folder, following Deepspeed's default behavior. However, we want to be able to override this "latest" tag when launching a job when, for example, resuming several checkpoints back from a corrupted run.

An `--iteration` flag that can be passed to `deepy.py` already exists, and can be successfully used to evaluate a model from any step with evaluate.py , ignoring the "latest" file. However, though this flag properly sets `neox_args.iteration` at initialization, when initializing a model we ignore this because it is not passed to `setup_model_and_optimizer`.

This PR resolves this, allowing users to successfully use `--iteration` alongside `train.py`.

@Quentin-Anthony @ShivanshuPurohit 