### PR TITLE
feat(ci): add `pip` caching to CI

### DIFF
--- a/.github/workflows/cpu_ci.yml
+++ b/.github/workflows/cpu_ci.yml
@@ -12,6 +12,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.8"
+          cache: "pip"
+          cache-dependency-path: "**/requirements*.txt"
 
       - name: Upgrade Pip
         run: python -m pip install --upgrade pip

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,9 +7,11 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.8
+          cache: "pip"
+          cache-dependency-path: "**/requirements*.txt"
       - uses: pre-commit/action@v2.0.3
 
   update-documentation:


### PR DESCRIPTION
Changes made by this PR can be summarized as follows:

- Set the `cache` and `cache-dependency-path` argument to enable caching to speed up CI times.