### PR TITLE
Fix minor issues

### DIFF
--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -111,7 +111,7 @@ Logging Arguments
 
 - **git_hash**: str
 
-    Default = 1b1e4eb
+    Default = 507ad04
 
     current git hash of repository
 
@@ -135,7 +135,7 @@ Logging Arguments
 
 - **log_interval**: int
 
-    Default = None
+    Default = 100
 
     Interval between logging.
 

--- a/megatron/neox_arguments/arguments.py
+++ b/megatron/neox_arguments/arguments.py
@@ -784,7 +784,7 @@ class NeoXArgs(*BASE_CLASSES):
         else:
             assert (
                 False
-            ), "Either train_batch_size or micro_batch_per_gpu needs to be provided"
+            ), "Either train_batch_size or train_micro_batch_size_per_gpu needs to be provided"
         return int(train_batch), int(micro_batch), int(grad_acc)
 
     @staticmethod
@@ -907,11 +907,11 @@ class NeoXArgs(*BASE_CLASSES):
             save_iters = list(save_iters)
             save_iters.sort()
 
-        self.update_values(
-            {
-                "save_iters": save_iters,
-            }
-        )
+            self.update_values(
+                {
+                    "save_iters": save_iters,
+                }
+            )
 
         # derive precision
         if (self.fp16 or {}).get("type", self.precision) == "bfloat16":

--- a/megatron/neox_arguments/neox_args.py
+++ b/megatron/neox_arguments/neox_args.py
@@ -490,7 +490,7 @@ class NeoXArgsLogging(NeoXArgsTemplate):
     Write TensorBoard logs to this directory.
     """
 
-    log_interval: int = None
+    log_interval: int = 100
     """
     Interval between logging.
     """

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -447,6 +447,10 @@ def get_optimizer(model, neox_args):
     """Set up the optimizer."""
     if neox_args.no_load_optim:
         return None, None
+    
+    if neox_args.optimizer is None:
+        print_rank_0(f'ERROR: Optimizer is None. Either set the optimizer dict in your config (if training) or set no_load_optim in your config (if inference)')
+        exit()
     # Build parameter groups (weight decay and non-decay).
     param_groups = get_params_for_weight_decay_optimization(model, neox_args)
     print_rank_0(


### PR DESCRIPTION
Cleans up a few gotchas:
- If the config doesn't specify all batch size params, our `calculate_derived` function failed due to an indentation mismatch
- Our error output `"Either train_batch_size or micro_batch_per_gpu needs to be provided"` doesn't reflect the actual config option to set, which should be `train_micro_batch_size_per_gpu`
- If `log_interval` or `optimizer` isn't set, neox fails cryptically. I added some error messages so that users know what's missing