### PR TITLE
Remove duplicate deepspeed config and allow forced multinode

### DIFF
--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -111,7 +111,7 @@ Logging Arguments
 
 - **git_hash**: str
 
-    Default = 6e60b1e
+    Default = b130d58
 
     current git hash of repository
 

--- a/megatron/neox_arguments/deepspeed_args.py
+++ b/megatron/neox_arguments/deepspeed_args.py
@@ -351,6 +351,11 @@ class NeoXArgsDeepspeedRunner(NeoXArgsTemplate):
     If true, overrides the default check where DeepSpeed confirms that the headnode is accessible via ssh.
     """
 
+    force_multi: bool = False
+    """
+    If true, Force multi-node launcher mode, helps in cases where user wants to launch on single remote node.
+    """
+
     comment: str = None
     """
     Adds a `--comment` to the DeepSpeed launch command. In DeeperSpeed this is passed on to the SlurmLauncher as well. Sometime necessary for cluster rules, or so I've heard.

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -624,7 +624,8 @@ def setup_model_and_optimizer(neox_args, use_cache=False, iteration=None):
             lr_scheduler=_lr_scheduler,
             dist_init_required=False,
             model_parameters=_model_params,
-            config_params=neox_args.deepspeed_config,
+            # Need to remove the below so that it doesn't conflict with --deepspeed_config required by autotuning
+            #config_params=neox_args.deepspeed_config,
             mpu=mpu if not neox_args.is_pipe_parallel else None,
         )
         model.total_params = get_total_params(model.module)


### PR DESCRIPTION
We currently pass the `--deepspeed_config` in 
https://github.com/EleutherAI/gpt-neox/blob/056e9caf23e04a2ee13b5066cb6b7bef5404aa33/megatron/neox_arguments/arguments.py#L546
but also pass the config in
https://github.com/EleutherAI/gpt-neox/blob/056e9caf23e04a2ee13b5066cb6b7bef5404aa33/megatron/training.py#L627

This used to be allowed by DS, but the latest version requires us to choose ([DS commit](https://github.com/microsoft/DeepSpeed/commit/47f9f13bd3236d426d558d61ef358b36191ef026) and [gpt-neox user facing this issue](https://github.com/EleutherAI/gpt-neox/issues/885)). Restricting to a single config passed is backwards-compatible and fixes this issue.

Further, DeepSpeed will automatically launch with `torch.dist` if a single node is used, and will disregard if a user requests `srun` or `mpirun`. There are cases where a user needs `srun` or `mpirun` even on a single node, so this PR introduces `force_multi`, which exposes DS's internal param to force the requested multinode runner on a single node.