### PR TITLE
Return to broadcasting megatron and deepspeed configs as training.py arguments

### DIFF
--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -111,7 +111,7 @@ Logging Arguments
 
 - **git_hash**: str
 
-    Default = a6b9622
+    Default = e67f027
 
     current git hash of repository
 

--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -111,7 +111,7 @@ Logging Arguments
 
 - **git_hash**: str
 
-    Default = 5d2d78a
+    Default = 14e4310
 
     current git hash of repository
 
@@ -952,7 +952,7 @@ Text Generation arguments
 
 - **prompt_end**: str
 
-    Default =
+    Default = 
 
 
     a single prompt's end. Defaults to newline
@@ -994,7 +994,7 @@ Text Generation arguments
 
 - **eval_results_prefix**: str
 
-    Default =
+    Default = 
 
     prefix to which to save evaluation results - final fp will be {eval_results_prefix}_eval_results_yy-mm-dd-HH-MM.json
 
@@ -1712,7 +1712,7 @@ Args for deepspeed config
 
     Default = None
 
-
+    
 
 
 
@@ -2014,3 +2014,4 @@ Args for deepspeed runner (deepspeed.launcher.runner).
     Default = None
 
     Adds a `--comment` to the DeepSpeed launch command. In DeeperSpeed this is passed on to the SlurmLauncher as well. Sometime necessary for cluster rules, or so I've heard.
+

--- a/megatron/neox_arguments/arguments.py
+++ b/megatron/neox_arguments/arguments.py
@@ -557,16 +557,15 @@ class NeoXArgs(*BASE_CLASSES):
             ).decode("utf-8")
             args_list.append(encoded_ds_config)
 
-        megatron_fp = cwd / Path("megatron_config.json")
         # get all config values
         args_list.append("--megatron_config")
-        args_list.append(str(megatron_fp))
         neox_args = self.get_parent_class_value_dict(
             *self.__class__.__bases__, only_non_defaults=True
         )
-        if self.rank == 0:
-            with open(megatron_fp, mode="w") as megafile:
-                json.dump(neox_args, megafile)
+        encoded_mega_config = base64.urlsafe_b64encode(
+            json.dumps(neox_args).encode("utf-8")
+        ).decode("utf-8")
+        args_list.append(str(encoded_mega_config))
         return args_list
 
     ############################################################################################################################

--- a/megatron/neox_arguments/arguments.py
+++ b/megatron/neox_arguments/arguments.py
@@ -420,8 +420,9 @@ class NeoXArgs(*BASE_CLASSES):
             help="Only need this (at this stage) for autotuning",
         )
         args_parsed, _ = parser.parse_known_args()
-        with open(args_parsed.megatron_config) as jsonfile:
-            megatron_config = json.load(jsonfile)
+        megatron_config = json.loads(
+            base64.urlsafe_b64decode(args_parsed.megatron_config).decode("utf-8")
+        )
         if args_parsed.deepspeed_config is not None:
             overwrite_values = cls.set_up_autotuning(
                 args_parsed.deepspeed_config, overwrite_values


### PR DESCRIPTION
This restores prior behavior of using serialized versions of the deepspeed and megatron configs as command line params passed to `deepy.py` and then to `training.py`. This allows each node and process to get the same configuration parameters in a cluster-agnostic way. 