### PR TITLE
Adding the possibility of passing a label dataset

### DIFF
--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -1061,6 +1061,13 @@ Training Arguments
     List of paths to train datasets.
 
 
+- **label_data_paths**: list
+
+    Default = None
+
+    List of paths to label datasets (should be fully in sync with train data, not shifted by 1!).
+
+
 
 - **test_data_paths**: list
 

--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -111,7 +111,7 @@ Logging Arguments
 
 - **git_hash**: str
 
-    Default = a6b9622
+    Default = e67f027
 
     current git hash of repository
 

--- a/megatron/data/data_utils.py
+++ b/megatron/data/data_utils.py
@@ -207,7 +207,7 @@ def build_weighted_datasets(
     for i, (train_path, label_path, valid_path, test_path) in enumerate(
         zip_longest(
             neox_args.train_data_paths,
-            neox_args.label_data_paths,
+            neox_args.label_data_paths if neox_args.label_data_paths else [],
             neox_args.valid_data_paths,
             neox_args.test_data_paths,
         )

--- a/megatron/data/data_utils.py
+++ b/megatron/data/data_utils.py
@@ -60,10 +60,15 @@ def build_the_dataset(
     seed,
     skip_warmup,
     build_index_mappings=True,
+    label_prefix=None,
 ):
     """Build train/valid/test datasets."""
 
     indexed_dataset = make_indexed_dataset(data_prefix, data_impl, skip_warmup)
+    if label_prefix is None:
+        label_dataset = None
+    else:
+        label_dataset = make_indexed_dataset(label_prefix, data_impl, skip_warmup)
 
     total_num_of_documents = indexed_dataset.sizes.shape[0]
     print_rank_0("    {}:".format(name))
@@ -79,6 +84,7 @@ def build_the_dataset(
         seq_length,
         seed,
         build_index_mappings=build_index_mappings,
+        label_dataset=label_dataset,
     )
     return dataset
 
@@ -198,9 +204,10 @@ def build_weighted_datasets(
 ):
     # build individual datasets
     train_datasets, valid_datasets, test_datasets = [], [], []
-    for i, (train_path, valid_path, test_path) in enumerate(
+    for i, (train_path, label_path, valid_path, test_path) in enumerate(
         zip_longest(
             neox_args.train_data_paths,
+            neox_args.label_data_paths,
             neox_args.valid_data_paths,
             neox_args.test_data_paths,
         )
@@ -216,6 +223,7 @@ def build_weighted_datasets(
                     seed=neox_args.seed,
                     skip_warmup=(not neox_args.mmap_warmup),
                     build_index_mappings=build_index_mappings,
+                    label_prefix=label_path,
                 )
             )
 

--- a/megatron/data/gpt2_dataset.py
+++ b/megatron/data/gpt2_dataset.py
@@ -38,10 +38,12 @@ class GPT2Dataset(torch.utils.data.Dataset):
         seed,
         build_index_mappings=True,
         use_shared_fs=True,
+        label_dataset=None,
     ):
 
         self.name = name
         self.indexed_dataset = indexed_dataset
+        self.label_dataset = label_dataset
 
         # Checks
         assert np.min(documents) >= 0
@@ -79,30 +81,37 @@ class GPT2Dataset(torch.utils.data.Dataset):
             doc_index_l = self.sample_idx[idx + 1][0]
             offset_f = self.sample_idx[idx][1]
             offset_l = self.sample_idx[idx + 1][1]
+            # Labels and texts are supposed to be fully in sync.
+            datasets = [self.indexed_dataset] if self.label_dataset is None else [self.indexed_dataset, self.label_dataset]
+            samples = []
             # If we are within the same document, just extract the chunk.
-            if doc_index_f == doc_index_l:
-                sample = self.indexed_dataset.get(
-                    self.doc_idx[doc_index_f],
-                    offset=offset_f,
-                    length=offset_l - offset_f + 1,
-                )
-            else:
-                # Otherwise, get the rest of the initial document.
-                sample_list = [
-                    self.indexed_dataset.get(self.doc_idx[doc_index_f], offset=offset_f)
-                ]
-                # Loop over all in between documents and add the entire document.
-                for i in range(doc_index_f + 1, doc_index_l):
-                    sample_list.append(self.indexed_dataset.get(self.doc_idx[i]))
-                # And finally add the relevant portion of last document.
-                sample_list.append(
-                    self.indexed_dataset.get(
-                        self.doc_idx[doc_index_l], length=offset_l + 1
+            for n, dataset in enumerate(datasets):
+                if doc_index_f == doc_index_l:
+                    samples.append(dataset.get(
+                        self.doc_idx[doc_index_f],
+                        offset=offset_f,
+                        length=offset_l - offset_f + 1,
+                    ))
+                else:
+                    # Otherwise, get the rest of the initial document.
+                    sample_list = [
+                        dataset.get(self.doc_idx[doc_index_f], offset=offset_f)
+                    ]
+                    # Loop over all in between documents and add the entire document.
+                    for i in range(doc_index_f + 1, doc_index_l):
+                        sample_list.append(dataset.get(self.doc_idx[i]))
+                    # And finally add the relevant portion of last document.
+                    sample_list.append(
+                        dataset.get(
+                            self.doc_idx[doc_index_l], length=offset_l + 1
+                        )
                     )
-                )
-                sample = np.concatenate(sample_list)
+                    samples.append(np.concatenate(sample_list))
 
-            return {"text": np.array(sample, dtype=np.int64)}
+            if len(datasets) == 1:
+                return {"text": np.array(samples[0], dtype=np.int64)}
+            else:
+                return {"text": np.array(samples[0], dtype=np.int64), "label": np.array(samples[1], dtype=np.int64)}
         except IndexError:
             new_idx = idx % len(self)
             print(

--- a/megatron/neox_arguments/neox_args.py
+++ b/megatron/neox_arguments/neox_args.py
@@ -719,6 +719,11 @@ class NeoXArgsTraining(NeoXArgsTemplate):
     List of paths to train datasets.
     """
 
+    label_data_paths: list = None
+    """
+    List of paths to label datasets (not shifted by 1 yet!).
+    """
+
     test_data_paths: list = None
     """
     List of paths to test datasets.

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -278,7 +278,14 @@ def _get_batch(neox_args, tokenizer, keys, data, datatype):
 
     # Unpack.
     tokens_ = data_b["text"].long()
-    labels = tokens_[:, 1:].contiguous()
+    if "label" in data_b:
+        labels = torch.where(
+            data_b["label"].long() >= 0,
+            data_b["label"].long(),
+            torch.zeros_like(data_b["label"].long()),
+        )[:, 1:].contiguous()
+    else:
+        labels = tokens_[:, 1:].contiguous()
     tokens = tokens_[:, :-1].contiguous()
 
     # Get the masks and position ids.
@@ -289,7 +296,7 @@ def _get_batch(neox_args, tokenizer, keys, data, datatype):
     )
     # If `label` is present, any token < 0 (e.g., -100, the default for torch) skips the loss computation
     if "label" in data_b:
-        loss_mask = (data_b["label"][:, 1:] >= 0).to(tokens.dtype)
+        loss_mask = (data_b["label"][:, 1:] >= 0).to(loss_mask.dtype)
     return tokens, labels, loss_mask, attention_mask, position_ids
 
 

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -273,7 +273,7 @@ def pretrain(neox_args):
 
 def _get_batch(neox_args, tokenizer, keys, data, datatype):
     """Support function for get_batch / get_batch pipe (to avoid code repetition)"""
-    _keys = [k for k in keys if k in data]
+    _keys = [k for k in keys if k in data] if data else keys
     data_b = mpu.broadcast_data(_keys, data, datatype)
 
     # Unpack.

--- a/megatron/utils.py
+++ b/megatron/utils.py
@@ -422,6 +422,7 @@ def setup_for_inference_or_eval(
         "checkpoint_activations": False,
         "partition_activations": False,
         "no_load_optim": True,
+        "optimizer": None,  # prevent loading optimizer (no_load_optim alone won't work)
         "zero_optimization": None,  # disable zero optimization (won't be used in inference, and loading zero optimizer can cause errors)
     }
     if overwrite_values:

--- a/tools/preprocess_data_with_mask.py
+++ b/tools/preprocess_data_with_mask.py
@@ -134,7 +134,7 @@ def get_args():
     group.add_argument(
         "--mask-before-token",
         default=None,
-        help="apply loss masks before certain token(s). If multiple tokens, separate by comma without space",
+        help="apply loss masks before certain token(s). If multi-token pattern, separate by commas without space, e.g. --mask-before-token 0,1,1270 to use the token pattern [0,1,1270].",
         type=str,
     )
     group.add_argument(
@@ -315,13 +315,8 @@ def main():
         for key, sentences in doc.items():
             for sentence in sentences:
                 builders[key].add_item(np.array(sentence, dtype=builders[key].dtype))
-                #print(len(sentence))
-                #print(sentence)
                 if token_mask: 
                     masked_sentence = mask(sentence, token_mask)
-                    #print(sentence)
-                    #print(masked_sentence)
-                    #exit()
                     builders["label"].add_item(np.array(masked_sentence, dtype=builders["text"].dtype))
             # separate with eos token
             builders[key].end_document()

--- a/tools/preprocess_data_with_mask.py
+++ b/tools/preprocess_data_with_mask.py
@@ -1,0 +1,351 @@
+# Copyright (c) 2021, EleutherAI
+# This file is based on code by the authors denoted below and has been modified from its original version.
+#
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Processing data for pretraining."""
+
+import argparse
+import multiprocessing
+import os
+import sys
+import re
+
+import lm_dataformat as lmd
+import numpy as np
+
+sys.path.append(
+    os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir))
+)
+import time
+import tqdm
+import torch
+import ftfy
+
+from megatron.tokenizer import build_tokenizer
+from megatron.data import indexed_dataset
+from threading import Semaphore
+from functools import lru_cache
+
+
+@lru_cache(maxsize=None)
+def build_nxt(pattern: tuple) -> tuple:
+    # The function is being cached. Use tuple to avoid the cache being tampered out of scope.
+    nxt = [0]
+    current = 1
+    match_idx = 0
+
+    while current < len(pattern):
+        if pattern[match_idx] == pattern[current]:
+            current += 1
+            match_idx += 1
+            nxt.append(match_idx)
+        elif match_idx != 0:
+            match_idx = nxt[match_idx - 1]
+        else:
+            nxt.append(0)
+            current += 1
+
+    return tuple(nxt)
+
+
+def kmp(seq, pattern, first_appearance=False):
+    """
+    Search for the location of a subsequence in a list. Not sure if there is a python built-in
+    implementation of kmp somewhere...
+    """
+    nxt = build_nxt(tuple(pattern))
+    current = 0
+    match_idx = 0
+
+    matched = []
+
+    while current < len(seq):
+        if seq[current] == pattern[match_idx]:
+            current += 1
+            match_idx += 1
+        elif match_idx != 0:
+            match_idx = nxt[match_idx - 1]
+        else:
+            current += 1
+
+        if match_idx == len(pattern):
+            matched.append(current - len(pattern))
+            if first_appearance:
+                return matched
+            match_idx = nxt[match_idx - 1]
+
+    return matched
+
+
+class Encoder(object):
+    def __init__(self, args):
+        self.args = args
+
+    def initializer(self):
+        # Use Encoder class as a container for global data
+        Encoder.tokenizer = build_tokenizer(self.args)
+
+    def encode(self, text):
+        if self.args.ftfy:
+            text = ftfy.fix_text(text)
+        if isinstance(text, str):
+            text = {"text": text}
+        ids = {}
+        for key in self.args.jsonl_keys:
+            doc_ids = []
+            text_ids = Encoder.tokenizer.tokenize(text['text'])
+            if len(text_ids) > 0:
+                doc_ids.append(text_ids)
+            if self.args.append_eod:
+                doc_ids[-1].append(Encoder.tokenizer.eod)
+            ids[key] = doc_ids
+        return ids, len(text)
+
+
+def get_args():
+    parser = argparse.ArgumentParser()
+    group = parser.add_argument_group(title="input data")
+    group.add_argument(
+        "--input",
+        type=str,
+        required=True,
+        help="Path to input jsonl files or lmd archive(s) - if using multiple archives, put them in a comma separated "
+        "list",
+    )
+    group.add_argument(
+        "--jsonl-keys",
+        nargs="+",
+        default=["text"],
+        help="space separate listed of keys to extract from jsonl. Defa",
+    )
+    group.add_argument(
+        "--mask-before-token",
+        default=None,
+        help="apply loss masks before certain token(s). If multiple tokens, separate by comma without space",
+        type=str,
+    )
+    group.add_argument(
+        "--num-docs",
+        default=None,
+        help="Optional: Number of documents in the input data (if known) for an accurate progress bar.",
+        type=int,
+    )
+    group = parser.add_argument_group(title="tokenizer")
+    group.add_argument(
+        "--tokenizer-type",
+        type=str,
+        required=True,
+        choices=[
+            "HFGPT2Tokenizer",
+            "HFTokenizer",
+            "GPT2BPETokenizer",
+            "CharLevelTokenizer",
+        ],
+        help="What type of tokenizer to use.",
+    )
+    group.add_argument(
+        "--vocab-file", type=str, default=None, help="Path to the vocab file"
+    )
+    group.add_argument(
+        "--merge-file",
+        type=str,
+        default=None,
+        help="Path to the BPE merge file (if necessary).",
+    )
+    group.add_argument(
+        "--append-eod",
+        action="store_true",
+        help="Append an <eod> token to the end of a document.",
+    )
+    group.add_argument("--ftfy", action="store_true", help="Use ftfy to clean text")
+    group = parser.add_argument_group(title="output data")
+    group.add_argument(
+        "--output-prefix",
+        type=str,
+        required=True,
+        help="Path to binary output file without suffix",
+    )
+    group.add_argument(
+        "--dataset-impl",
+        type=str,
+        default="mmap",
+        choices=["lazy", "cached", "mmap"],
+        help="Dataset implementation to use. Default: mmap",
+    )
+
+    group = parser.add_argument_group(title="runtime")
+    group.add_argument(
+        "--workers", type=int, default=1, help="Number of worker processes to launch"
+    )
+    group.add_argument(
+        "--log-interval",
+        type=int,
+        default=100,
+        help="Interval between progress updates",
+    )
+    args = parser.parse_args()
+    args.keep_empty = False
+
+    # some default/dummy values for the tokenizer
+    args.rank = 0
+    args.make_vocab_size_divisible_by = 128
+    args.model_parallel_size = 1
+
+    return args
+
+
+def yield_from_files(fnames: list, semaphore):
+    """
+    Iterator over input documents using lm_dataformat. Should be able to handle jsons / texts /
+    other compressed formats. Also filters out empty documents.
+
+    :param fnames: list of filenames
+    """
+
+    def yielder(fname, semaphore):
+        for f in filter(lambda x: x, lmd.Reader(fname).stream_data()):
+            semaphore.acquire()
+            yield f
+
+    for fname in fnames:
+        semaphore.acquire()
+
+        yield from yielder(fname, semaphore)
+
+
+def mask(sentence: list, pivot_tokens: list, include_pivot=True):
+    inds = kmp(sentence, pivot_tokens)
+    if not inds:
+        return sentence
+    index = inds[0]
+    if include_pivot:
+        index += len(pivot_tokens)
+
+    return [-100] * index + sentence[index:]
+
+
+def main():
+    args = get_args()
+    encoder = Encoder(args)
+    tokenizer = build_tokenizer(args)
+    print(f"Vocab size: {tokenizer.vocab_size}")
+    print(f"Output prefix: {args.output_prefix}")
+
+    # build a semaphore object to stop `yield_from_files` from getting ahead of encoder.encode and
+    # hence building up memory
+    semaphore = Semaphore(10000 + args.workers)
+
+    # use multiprocessing to iterate over input documents
+    fin = yield_from_files(args.input.split(","), semaphore)
+
+    if args.workers > 1:
+        pool = multiprocessing.Pool(args.workers, initializer=encoder.initializer)
+        encoded_docs = pool.imap(encoder.encode, fin, chunksize=25)
+    else:
+        encoder.initializer()
+        encoded_docs = (encoder.encode(doc) for doc in fin)
+
+    
+    if args.mask_before_token is not None:
+        token_mask = [int(re.sub(r'[^0-9]', '', r)) for r in args.mask_before_token.split(",") if re.sub(r'[^0-9]', '', r)]
+    else:
+        token_mask = []
+
+
+    # make a dataset builder for each key in args.jsonl_keys
+    # each key will output to a different file beginning with args.output_prefix
+    output_bin_files = {}
+    output_idx_files = {}
+    builders = {}
+    for key in args.jsonl_keys:
+        output_bin_files[key] = "{}_{}_{}.bin".format(
+            args.output_prefix, key, "document"
+        )
+        output_idx_files[key] = "{}_{}_{}.idx".format(
+            args.output_prefix, key, "document"
+        )
+        builders[key] = indexed_dataset.make_builder(
+            output_bin_files[key],
+            impl=args.dataset_impl,
+            vocab_size=tokenizer.vocab_size,
+        )
+    if token_mask:
+        assert "label" not in args.jsonl_keys, "label should not be included as it will be generated according to the mask."
+        key = "label"
+        output_bin_files[key] = "{}_{}_{}.bin".format(
+            args.output_prefix, key, "document"
+        )
+        output_idx_files[key] = "{}_{}_{}.idx".format(
+            args.output_prefix, key, "document"
+        )
+        builders[key] = indexed_dataset.make_builder(
+            output_bin_files[key],
+            impl=args.dataset_impl,
+            vocab_size=tokenizer.vocab_size,
+        )
+    int32_labels = ["text", "label"]
+    for l in int32_labels:
+        builders[l]._dtype = np.int32
+
+
+    # actually do tokenization
+    proc_start = time.time()
+    total_bytes_processed = 0
+    pbar = tqdm.tqdm()
+    for i, (doc, bytes_processed) in enumerate(encoded_docs, start=1):
+        total_bytes_processed += bytes_processed
+
+        # release semaphore so `yield_from_files` can add another file to the buffer
+        semaphore.release()
+
+        # add each tokenized document / sentence
+        for key, sentences in doc.items():
+            for sentence in sentences:
+                builders[key].add_item(np.array(sentence, dtype=builders[key].dtype))
+                #print(len(sentence))
+                #print(sentence)
+                if token_mask: 
+                    masked_sentence = mask(sentence, token_mask)
+                    #print(sentence)
+                    #print(masked_sentence)
+                    #exit()
+                    builders["label"].add_item(np.array(masked_sentence, dtype=builders["text"].dtype))
+            # separate with eos token
+            builders[key].end_document()
+            if token_mask:
+                builders["label"].end_document()
+
+
+        # log progress
+        if i % args.log_interval == 0:
+            current = time.time()
+            elapsed = current - proc_start
+            mbs = total_bytes_processed / elapsed / 1024 / 1024
+            pbar.set_description(
+                f"Processed {i}{'' if args.num_docs is None else '/' + str(args.num_docs)} documents ({i / elapsed} docs/s, {mbs} MB/s)."
+            )
+            if i != 0:
+                pbar.update(args.log_interval)
+
+    # save output file
+    update_keys = args.jsonl_keys + ["label"] if token_mask else args.jsonl_keys
+    for key in update_keys:
+        builders[key].finalize(output_idx_files[key])
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
As discussed with @haileyschoelkopf in DM, I'm cleaning up my personal fork and putting the major difference out here in case it is a useful feature. It allows to take an optional `label_data_paths` (which is assumed to be perfectly in sync with the training data). 

But if there is anything that does not fit with the current design or anything, feel free to close it though.

## Why do I need it
It was used when finetuning diff models, where a custom loss mask needs to be applied to the dataset. It is very controllable if I can do it on the dataset level and easy to double-check by poking into the generated masks.
I also used this in some experiments of finetuning pythia for text repairing. It works well.

## How it works
- Without the argument `label_data_paths`, nothing should change. 
- With the argument, it will 
  - also load the labels into training dataset (see `build_the_dataset` function), so that the dataset yields an extra "label" item;
  - apply loss mask to negative labels, shift by 1 and use it as target labels during training (see `_get_batch` function).

Besides the label, there is also a minor fix in `setup_for_inference_or_eval`. Not sure if it's an issue with newer version of DeepSpeed, but the `no_load_optim` wasn't enough to prevent the optimizer from loaded when I do inference and use stuff like `generate_samples_unconditional`.