### PR TITLE
Fix setup README and tensorboard version

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ To install the remaining basic dependencies, run:
 
 ```bash
 pip install -r requirements/requirements.txt
+pip install -r requirements/requirements-wandb.txt
+pip install -r requirements/requirements-tensorboard.txt
 python ./megatron/fused_kernels/setup.py install # optional if not using fused kernels
 ```
 

--- a/requirements/requirements-tensorboard.txt
+++ b/requirements/requirements-tensorboard.txt
@@ -1,1 +1,1 @@
-tensorboard==2.5.0
+tensorboard==2.13.0


### PR DESCRIPTION
requirements/requirements-tensorboard.txt
The following error was generated from a dependency on the tensorboard version specified in
By modifying the tensorboard version, it now works. 
tensorboard == 2.5.0 then the error occurs (The second error corresponds to)again and the version needs to be corrected!

Traceback (most recent call last):
  File "train.py", line 20, in <module>
	from megatron.training import pretrain
  File "/home/tn/gptneox-test/gpt-neox/megatron/training.py", line 58, in <module>
	from eval_tasks import run_eval_harness
  File "/home/tn/gptneox-test/gpt-neox/eval_tasks/__init__.py", line 15, in <module>
	from .eval_adapter import EvalHarnessAdapter, run_eval_harness
  File "/home/tn/gptneox-test/gpt-neox/eval_tasks/eval_adapter.py", line 16, in <module>
	import best_download
  File "/home/tn/.pyenv/versions/neox/lib/python3.8/site-packages/best_download/__init__.py", line 35, in <module>
	retry_strategy = Retry(
TypeError: __init__() got an unexpected keyword argument 'method_whitelist'


Traceback (most recent call last):
  File "train.py", line 26, in <module>
    neox_args.initialize_tensorboard_writer()  # is initialized if tensorboard directory is defined
  File "/home/tn/gptneox-test/gpt-neox/megatron/neox_arguments/arguments.py", line 152, in initialize_tensorboard_writer
    from torch.utils.tensorboard import SummaryWriter
  File "/home/tn/.pyenv/versions/gptn/lib/python3.8/site-packages/torch/utils/tensorboard/__init__.py", line 12, in <module>
    from .writer import FileWriter, SummaryWriter  # noqa: F401
  File "/home/tn/.pyenv/versions/gptn/lib/python3.8/site-packages/torch/utils/tensorboard/writer.py", line 9, in <module>
    from tensorboard.compat.proto.event_pb2 import SessionLog
  File "/home/tn/.pyenv/versions/gptn/lib/python3.8/site-packages/tensorboard/compat/proto/event_pb2.py", line 17, in <module>
    from tensorboard.compat.proto import summary_pb2 as tensorboard_dot_compat_dot_proto_dot_summary__pb2
  File "/home/tn/.pyenv/versions/gptn/lib/python3.8/site-packages/tensorboard/compat/proto/summary_pb2.py", line 17, in <module>
    from tensorboard.compat.proto import tensor_pb2 as tensorboard_dot_compat_dot_proto_dot_tensor__pb2
  File "/home/tn/.pyenv/versions/gptn/lib/python3.8/site-packages/tensorboard/compat/proto/tensor_pb2.py", line 16, in <module>
    from tensorboard.compat.proto import resource_handle_pb2 as tensorboard_dot_compat_dot_proto_dot_resource__handle__pb2
  File "/home/tn/.pyenv/versions/gptn/lib/python3.8/site-packages/tensorboard/compat/proto/resource_handle_pb2.py", line 16, in <module>
    from tensorboard.compat.proto import tensor_shape_pb2 as tensorboard_dot_compat_dot_proto_dot_tensor__shape__pb2
  File "/home/tn/.pyenv/versions/gptn/lib/python3.8/site-packages/tensorboard/compat/proto/tensor_shape_pb2.py", line 36, in <module>
    _descriptor.FieldDescriptor(
  File "/home/tn/.pyenv/versions/gptn/lib/python3.8/site-packages/google/protobuf/descriptor.py", line 561, in __new__
    _message.Message._CheckCalledFromGeneratedFile()
TypeError: Descriptors cannot not be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
