### PR TITLE
[WIP] Adding AxoNN's two-dimensional tensor parallelism to GPT-NeoX

### DIFF
--- a/configs/125M-json.yml
+++ b/configs/125M-json.yml
@@ -1,6 +1,8 @@
 {
   "pipe-parallel-size": 1,
-  "model-parallel-size": 1,
+  "model-parallel-size": 2,
+  "inner-model-parallel-size": 2,
+  "outer-model-parallel-size": 1,
 
   "num-layers": 12,
   "hidden-size": 768,
@@ -8,7 +10,7 @@
   "seq-length": 2048,
   "max-position-embeddings": 2048,
   "norm": "layernorm",
-  "pos-emb": "rotary",
+  "pos-emb": "learned",
   "no-weight-tying": true,
   "gpt_j_residual": false,
   "output_layer_parallelism": "column",
@@ -74,5 +76,9 @@
   "keep-last-n-checkpoints": 4,
   "wall_clock_breakdown": true,
 
-  "hostfile": "/mock_path"
+  "hostfile": "/mock_path",
+
+  "data-path": "./data/enwik8/enwik8_text_document",
+  "vocab_file": "./data/gpt2-vocab.json",
+  "merge_file": "./data/gpt2-merges.txt"
 }

--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -111,7 +111,7 @@ Logging Arguments
 
 - **git_hash**: str
 
-    Default = 6dd0344
+    Default = 2fbdd43
 
     current git hash of repository
 
@@ -758,6 +758,14 @@ Misc. Arguments
 
 
 
+- **deepspeed_jsrun**: bool
+
+    Default = False
+
+    Run via JSRUN, this will attempt to discover the necessary variables to initialize torch distributed from the IBM LSF environment
+
+
+
 - **user_script**: str
 
     Default = None
@@ -829,6 +837,22 @@ Parallelism Arguments
 
 
 - **model_parallel_size**: int
+
+    Default = 1
+
+    
+
+
+
+- **inner_model_parallel_size**: int
+
+    Default = 1
+
+    
+
+
+
+- **outer_model_parallel_size**: int
 
     Default = 1
 

--- a/megatron/initialize.py
+++ b/megatron/initialize.py
@@ -186,6 +186,8 @@ def _initialize_distributed(neox_args):
         else:
             mpu.initialize_model_parallel(
                 neox_args.model_parallel_size,
+                neox_args.inner_model_parallel_size,
+                neox_args.outer_model_parallel_size,
                 topology=topo,
                 fp32_allreduce=neox_args.fp32_allreduce,
             )

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -40,6 +40,8 @@ from megatron.model.fused_bias_dropout import (
 )
 from megatron.model.utils import configure_sparse_attention
 
+from axonn.intra_layer import Tensor_Parallel_Linear, drop, gather
+
 # flags required to enable jit fusion kernels
 torch._C._jit_set_profiling_mode(False)
 torch._C._jit_set_profiling_executor(False)
@@ -93,30 +95,48 @@ class ParallelMLP(nn.Module):
             if self.activation_type == "geglu"
             else ff_mult * neox_args.hidden_size
         )
-        self.dense_h_to_4h = mpu.ColumnParallelLinear(
-            neox_args=neox_args,
-            input_size=neox_args.hidden_size,
-            output_size=ff_dim,
-            gather_output=False,
-            init_method=init_method,
-            skip_bias_add=True,
-        )
+        #self.dense_h_to_4h = mpu.ColumnParallelLinear(
+        #    neox_args=neox_args,
+        #    input_size=neox_args.hidden_size,
+        #    output_size=ff_dim,
+        #    gather_output=False,
+        #    init_method=init_method,
+        #    skip_bias_add=True,
+        #)
+        self.dense_h_to_4h = Tensor_Parallel_Linear(
+                                in_features=neox_args.hidden_size,
+                                out_features=ff_dim,
+                                bias=False
+                            )
+        self.dense_h_to_4h_bias = torch.nn.Parameter(torch.zeros(
+                    mpu.divide(ff_dim, neox_args.outer_model_parallel_size)))
+
+
         ff_dim_in = ff_dim // 2 if self.activation_type == "geglu" else ff_dim
         # Project back to h.
-        self.dense_4h_to_h = mpu.RowParallelLinear(
-            neox_args=neox_args,
-            input_size=ff_dim_in,
-            output_size=neox_args.hidden_size,
-            input_is_parallel=True,
-            init_method=output_layer_init_method,
-            skip_bias_add=True,
-            parallel_output=parallel_output,
-        )
+        #self.dense_4h_to_h = mpu.RowParallelLinear(
+        #    neox_args=neox_args,
+        #    input_size=ff_dim_in,
+        #    output_size=neox_args.hidden_size,
+        #    input_is_parallel=True,
+        #    init_method=output_layer_init_method,
+        #    skip_bias_add=True,
+        #    parallel_output=parallel_output,
+        #)
+        self.dense_4h_to_h = Tensor_Parallel_Linear(
+                                in_features=ff_dim_in,
+                                out_features=neox_args.hidden_size,
+                                bias=False,
+                                transpose=True
+                            )
+        self.dense_4h_to_h_bias = torch.nn.Parameter(torch.zeros(
+                    mpu.divide(neox_args.hidden_size, neox_args.inner_model_parallel_size)))
 
     def forward(self, hidden_states):
 
         # [s, b, 4hp]
-        intermediate_parallel, bias_parallel = self.dense_h_to_4h(hidden_states)
+        intermediate_parallel = self.dense_h_to_4h(hidden_states)
+        bias_parallel = self.dense_h_to_4h_bias
 
         if (
             self.activation_type == "gelu" and self.bias_gelu_fusion
@@ -130,7 +150,8 @@ class ParallelMLP(nn.Module):
             )
 
         # [s, b, h]
-        output, output_bias = self.dense_4h_to_h(intermediate_parallel)
+        output = self.dense_4h_to_h(intermediate_parallel)
+        output_bias = self.dense_4h_to_h_bias
         return output, output_bias
 
 
@@ -207,7 +228,8 @@ class ParallelSelfAttention(nn.Module):
             self.attention_softmax_in_fp32 = True
         self.layer_number = layer_number
         # Per attention head and per partition values.
-        world_size = mpu.get_model_parallel_world_size()
+        world_size = neox_args.outer_model_parallel_size #mpu.get_model_parallel_world_size()
+        
         self.hidden_size_per_partition = mpu.divide(neox_args.hidden_size, world_size)
         self.hidden_size_per_attention_head = mpu.divide(
             neox_args.hidden_size, neox_args.num_attention_heads
@@ -218,13 +240,18 @@ class ParallelSelfAttention(nn.Module):
         self.pos_emb = neox_args.pos_emb
 
         # Strided linear layer.
-        self.query_key_value = mpu.ColumnParallelLinear(
-            neox_args=neox_args,
-            input_size=neox_args.hidden_size,
-            output_size=3 * neox_args.hidden_size,
-            gather_output=False,
-            init_method=init_method,
-        )
+        #self.query_key_value = mpu.ColumnParallelLinear(
+        #    neox_args=neox_args,
+        #    input_size=neox_args.hidden_size,
+        #    output_size=3 * neox_args.hidden_size,
+        #    gather_output=False,
+        #    init_method=init_method,
+        #)
+        self.query_key_value = Tensor_Parallel_Linear(
+            in_features=neox_args.hidden_size,
+            out_features=3 * neox_args.hidden_size,
+            bias=False,
+            )
 
         coeff = None
         self.norm_factor = math.sqrt(self.hidden_size_per_attention_head)
@@ -238,6 +265,7 @@ class ParallelSelfAttention(nn.Module):
         self.rpe = rpe
 
         if self.pos_emb == "alibi":
+            raise NotImplementedError
             self.alibi_embed = AliBi(
                 neox_args.num_attention_heads,
                 neox_args.model_parallel_size,
@@ -246,6 +274,7 @@ class ParallelSelfAttention(nn.Module):
 
         # TODO: this arg shouldn't need to be passed in - get from neox_args
         if rotary:
+            raise NotImplementedError
             if neox_args.rotary_pct == 1:
                 self.rotary_ndims = None
             else:
@@ -269,6 +298,7 @@ class ParallelSelfAttention(nn.Module):
         self.sparse = self.attention_type not in ("global", "flash")
         self.sparse = self.attention_type != "global" and not self.use_flash_attention
         if self.sparse:
+            raise NotImplementedError
             self.sparse_attn = configure_sparse_attention(
                 neox_args,
                 self.attention_type,
@@ -277,6 +307,7 @@ class ParallelSelfAttention(nn.Module):
             )
         else:
             if self.use_flash_attention:
+                raise NotImplementedError
                 from megatron.model.flash_attention import (
                     flash_attn_unpadded_qkvpacked_func,
                 )
@@ -307,15 +338,22 @@ class ParallelSelfAttention(nn.Module):
             self.attention_dropout = nn.Dropout(self.dropout_p)
 
         # Output.
-        self.dense = mpu.RowParallelLinear(
-            neox_args=neox_args,
-            input_size=neox_args.hidden_size,
-            output_size=neox_args.hidden_size,
-            input_is_parallel=True,
-            init_method=output_layer_init_method,
-            skip_bias_add=True,
-            parallel_output=parallel_output,
-        )
+        #self.dense = mpu.RowParallelLinear(
+        #    neox_args=neox_args,
+        #    input_size=neox_args.hidden_size,
+        #    output_size=neox_args.hidden_size,
+        #    input_is_parallel=True,
+        #    init_method=output_layer_init_method,
+        #    skip_bias_add=True,
+        #    parallel_output=parallel_output,
+        #)
+        self.dense = Tensor_Parallel_Linear(
+                in_features=neox_args.hidden_size,
+                out_features=neox_args.hidden_size,
+                bias=False,
+                transpose=True
+            )
+        self.dense_bias = nn.Parameter(torch.zeros( mpu.divide(neox_args.hidden_size, neox_args.inner_model_parallel_size)))
 
     def attention(
         self, query_layer, key_layer, value_layer, layer_past, attention_mask
@@ -498,7 +536,7 @@ class ParallelSelfAttention(nn.Module):
         # =====================
 
         # Attention heads [sq, b, h] --> [sq, b, (np * 3 * hn)]
-        mixed_x_layer, _ = self.query_key_value(hidden_states)
+        mixed_x_layer = self.query_key_value(hidden_states)
 
         # [sq, b, (np * 3 * hn)] --> [sq, b, np, 3 * hn]
         new_tensor_shape = mixed_x_layer.size()[:-1] + (
@@ -582,7 +620,8 @@ class ParallelSelfAttention(nn.Module):
         # Output. [sq, b, h]
         # =================
 
-        output, bias = self.dense(context_layer)
+        output = self.dense(context_layer)
+        bias = self.dense_bias
 
         if self.use_cache:
             output = [output, present]
@@ -611,11 +650,11 @@ class ParallelTransformerLayer(nn.Module):
 
         super().__init__()
         self.layer_number = layer_number
-
+        self.is_last_layer = (layer_number == (neox_args.num_layers - 1))
         norm, eps = get_norm(neox_args)
 
         # Layernorm on the input data.
-        self.input_layernorm = norm(neox_args.hidden_size, eps=eps)
+        self.input_layernorm = norm(mpu.divide(neox_args.hidden_size, neox_args.inner_model_parallel_size), eps=eps)
         self.use_cache = use_cache
 
         self.hidden_dropout = neox_args.hidden_dropout
@@ -624,6 +663,7 @@ class ParallelTransformerLayer(nn.Module):
         self.gpt_j_tied = neox_args.gpt_j_tied
 
         if self.gpt_j_residual:
+            raise NotImplementedError
             self.reduce = mpu.mappings.reduce_from_model_parallel_region
 
         # Self attention.
@@ -642,7 +682,7 @@ class ParallelTransformerLayer(nn.Module):
         # Layernorm on the output of the attention layer.
         # If GPT-J residuals are used, this is surpurfulous but leaving it in
         # leads to cleaner code
-        self.post_attention_layernorm = norm(neox_args.hidden_size, eps=eps)
+        self.post_attention_layernorm = norm(mpu.divide(neox_args.hidden_size, neox_args.inner_model_parallel_size), eps=eps)
 
         # MLP
         self.mlp = ParallelMLP(
@@ -666,6 +706,8 @@ class ParallelTransformerLayer(nn.Module):
         return fn
 
     def forward(self, x, attention_mask, layer_past=None):
+        if self.layer_number == 0:
+            x = drop(x) 
         layer_past = layer_past if layer_past is not None else self.layer_past
         bias_dropout_fn = self._get_bias_dropout()
         # x: [b, s, h]
@@ -724,6 +766,7 @@ class ParallelTransformerLayer(nn.Module):
             attention_output, attention_bias = self.attention(
                 self.input_layernorm(x), attention_mask, layer_past=layer_past
             )
+            #print(f'Layer {self.layer_number}: Applied input layernorm and self attention')
             if self.use_cache:
                 attention_output, presents = attention_output
                 self.layer_past = presents
@@ -734,11 +777,12 @@ class ParallelTransformerLayer(nn.Module):
                     residual=residual,
                     prob=self.hidden_dropout,
                 )
-
+            #print(f'Layer {self.layer_number}: Added bias, applied residual, applied dropout')
             # output = x + mlp(ln2(x))
             mlp_output, mlp_bias = self.mlp(
                 self.post_attention_layernorm(attention_output)
             )
+            #print(f'Layer {self.layer_number}: Applied post attention layer norm and MLP')
             with torch.enable_grad():
                 output = bias_dropout_fn(
                     mlp_output,
@@ -746,7 +790,10 @@ class ParallelTransformerLayer(nn.Module):
                     residual=attention_output,
                     prob=self.hidden_dropout,
                 )
+            #print(f'Layer {self.layer_number}: Added bias, applied residual, applied dropout')
 
+        if self.is_last_layer:
+            output = gather(output) 
         return output
 
 

--- a/megatron/neox_arguments/neox_args.py
+++ b/megatron/neox_arguments/neox_args.py
@@ -61,6 +61,9 @@ class NeoXArgsParallelism(NeoXArgsTemplate):
     """
 
     model_parallel_size: int = 1
+    inner_model_parallel_size: int = 1
+    outer_model_parallel_size: int = 1
+    
     """
     Size of the model parallelism.
     """

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -618,7 +618,7 @@ def setup_model_and_optimizer(neox_args, use_cache=False, iteration=None):
             lr_scheduler=_lr_scheduler,
             dist_init_required=False,
             model_parameters=_model_params,
-            config_params=neox_args.deepspeed_config,
+            config_params=None,#neox_args.deepspeed_config,
             mpu=mpu if not neox_args.is_pipe_parallel else None,
         )
         model.total_params = get_total_params(model.module)


### PR DESCRIPTION
Algorithm Reference: https://arxiv.org/abs/2305.13525

Steps to run

1. Install AxoNN
`git clone https://github.com/axonn-ai/axonn; cd axonn; git checkout neo-x; pip install -e .`

2. Run neo-x as you normally do with two new arguments in the config files 
` "inner-model-parallel-size":  <some number>,
  "outer-model-parallel-size": <some number>,`

These two arguments define the 2D grid of GPUs over which our tensor parallelism functions. For now, `model-parallel-size` should also be manually set to the product of these two. An example config file with these arguments is in `configs/125M-json.yml`


Todos:

- [ ] Weight initialization - should be same as megatron-lm
- [ ] Backward compatibility - option to fall back to megatron-lm
- [ ] Saving and loading weights - merging checkpoints etc
- [ ] ax.intra_layer.Tensor_Parallel_Linear should create bias within itself. 
- [ ] I have left several `NotImplementedErrors` for code paths I was unsure about. Need to resolve them.