### PR TITLE
Turn remaining hyphens into underscores in merge20b.py

### DIFF
--- a/tools/merge20b.py
+++ b/tools/merge20b.py
@@ -36,16 +36,16 @@ def modify_config(input_config_path, output_config_path, output_dir):
         loaded_config = yaml.full_load(f)
 
     # replace model/pipeline parallel
-    loaded_config["model-parallel-size"] = 1
-    loaded_config["pipe-parallel-size"] = 1
+    loaded_config["model_parallel_size"] = 1
+    loaded_config["pipe_parallel_size"] = 1
 
     # replace load / save directories:
     loaded_config["load"] = output_dir
     loaded_config["save"] = output_dir
 
     # replace some other paths
-    loaded_config["vocab-file"] = os.path.join(output_dir, "20B_tokenizer.json")
-    loaded_config["log-dir"] = "./logs"
+    loaded_config["vocab_file"] = os.path.join(output_dir, "20B_tokenizer.json")
+    loaded_config["log_dir"] = "./logs"
 
     # we need to make sure the resulting vocab size is correct
     # do this by modifying the 'make_vocab_size_divisible_by' argument to be


### PR DESCRIPTION
I've noticed that gpt-neox has moved towards addressing config items using `_` rather than `-` to separate words (see e.g. #928).

The old way is still used in one script, and it bugged me... and it also seems risky: This script modifies fields, so if they already exist with `_` as should be expected, it will not overwrite as intended, but add additional fields with `-`, causing clashes down the line.

According to my regex (`\[['"][a-zA-Z]+-[a-zA-Z-]+['"]\]`), this is the only remaining occurrence of hyphens addressing config items in the code.

Also, this is my first contribution to gpt-neox. I did not find the contribution guidelines and apologise in advance if I'm trampling all over them; I'd be grateful if you let me know if I am.