### PR TITLE
default tokenizer_type should be string

### DIFF
--- a/megatron/tokenizer/train_tokenizer.py
+++ b/megatron/tokenizer/train_tokenizer.py
@@ -102,7 +102,7 @@ def parse_args():
         type=str,
         help="type of tokenizer to train, currently only BPE is supported",
         choices=["BPE"],
-        default=["BPE"],
+        default="BPE",
     )
     parser.add_argument(
         "-v",


### PR DESCRIPTION
For BPE tokenization, `tokenizer_type` argument should be a string instead of the list.