### PR TITLE
Replaced all torch.concat with torch.cat

### DIFF
--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -531,7 +531,7 @@ class ParallelSelfAttention(nn.Module):
                 )
 
                 # Combined k/v into [b * sk, 2, np, hn].
-                kv = torch.concat([key_layer, value_layer], dim=1)
+                kv = torch.cat([key_layer, value_layer], dim=1)
 
                 output = self.flash_kv_fn(
                     query_layer,
@@ -553,7 +553,7 @@ class ParallelSelfAttention(nn.Module):
                 )
 
                 # Combined q/k/v into [b * s, 3, np, hn].
-                qkv = torch.concat([query_layer, key_layer, value_layer], dim=1)
+                qkv = torch.cat([query_layer, key_layer, value_layer], dim=1)
 
                 output = self.flash_qkv_fn(
                     qkv,


### PR DESCRIPTION
* Received "AttributeError: module 'torch' has no attribute 'concat'" on torch 1.8.1+cu111
* `torch.concat` is an alias for `torch.cat` and there are four other instances of `torch.cat `already being used in this file