### PR TITLE
Add RoPE scaling 

### DIFF
--- a/megatron/neox_arguments/arguments.py
+++ b/megatron/neox_arguments/arguments.py
@@ -1113,10 +1113,14 @@ class NeoXArgs(*BASE_CLASSES):
             return False
 
         if self.seq_length is not None:
-            if not (self.max_position_embeddings >= self.seq_length):
+            if self.rope_scaling is not None:
+                scaled_max_position_embeddings = self.max_position_embeddings * self.rope_scaling["factor"]
+            else:
+                scaled_max_position_embeddings = self.max_position_embeddings
+            if not (scaled_max_position_embeddings >= self.seq_length):
                 error_message = (
                     self.__class__.__name__
-                    + ".validate_values() max_position_embeddings must be bigger or equal seq_length"
+                    + ".validate_values() scaled max_position_embeddings must be bigger or equal seq_length"
                 )
                 logging.error(error_message)
                 raise ValueError(error_message)

--- a/megatron/neox_arguments/neox_args.py
+++ b/megatron/neox_arguments/neox_args.py
@@ -290,6 +290,17 @@ class NeoXArgsModel(NeoXArgsTemplate):
     Base for rotary positional embedding
     """
 
+    rope_scaling: dict = None
+    """
+    Rotary positional embedding scaling options.
+    Dictionary containing the scaling configuration for the RoPE embeddings. Currently supports three scaling
+            strategies: linear and dynamic. Their scaling factor must be an float greater than 1. The expected format
+            is `{"type": strategy name, "factor": scaling factor}`. When using this flag, don't update
+            `max_position_embeddings` to the expected new maximum. See the following thread for more information on how
+            these scaling strategies behave:
+            https://www.reddit.com/r/LocalLLaMA/comments/14mrgpr/dynamically_scaled_rope_further_increases/.
+    """
+
     init_method: Literal[
         "normal",
         "scaled_normal",


### PR DESCRIPTION
This PR basically syncs gpt-neox with [this HF PR #24653](https://github.com/huggingface/transformers/pull/24653).

Linear scaling and dynamic NTK scaling are provided as an alternative to the original RoPE.
It enables extending a pre-trained model's max input length (e.g. 2k -> 8k) by fine-tuning on longer sequences for only a few steps. More descriptions can be found in the HF PR.

Modifications:
* Modifications in `megatron/model/positional_embeddings.py` are almost identical to the HF PR and provide two new RoPE classes in addition to the original one.
* A new argument `rope_scaling` is added in `megatron/neox_arguments/neox_args.py` to select the wanted RoPE. It defaults to `rope_scaling=None` and corresponds to the original RoPE.
* The different rotary embedding classes are now loaded in `megatron/model/transformer.py` according to the selected scaling strategy.
* The check of`self.max_position_embeddings >= self.seq_length` in `megatron/neox_arguments/arguments.py` now takes into account the RoPE scaling options.