### PR TITLE
format docs/s and MB/s

### DIFF
--- a/tools/preprocess_data.py
+++ b/tools/preprocess_data.py
@@ -230,7 +230,7 @@ def main():
             elapsed = current - proc_start
             mbs = total_bytes_processed / elapsed / 1024 / 1024
             pbar.set_description(
-                f"Processed {i}{'' if args.num_docs is None else '/' + str(args.num_docs)} documents ({i / elapsed} docs/s, {mbs} MB/s)."
+                f"Processed {i}{'' if args.num_docs is None else '/' + str(args.num_docs)} documents ({i / elapsed :.2f} docs/s, {mbs:.2f} MB/s)."
             )
             if i != 0:
                 pbar.update(args.log_interval)


### PR DESCRIPTION

old log
```
Processed 521000 documents (24077.20811125894 docs/s, 5.05394863005669 MB/s).: : 520000it [00:21, 24642.85it/s] 
```

new log
```
Processed 521000 documents (24077.21 docs/s, 5.05 MB/s).: : 520000it [00:21, 24642.85it/s] 
```
