### PR TITLE
fix rope precision bug

### DIFF
--- a/megatron/model/positional_embeddings.py
+++ b/megatron/model/positional_embeddings.py
@@ -50,8 +50,8 @@ class RotaryEmbedding(torch.nn.Module):
             seq_len = x.shape[seq_dim]
         if seq_len != self.seq_len_cached:
             self.seq_len_cached = seq_len
-            t = torch.arange(seq_len, device=x.device).type_as(self.inv_freq)
-            freqs = torch.einsum("i,j->ij", t, self.inv_freq)
+            t = torch.arange(seq_len, device=x.device, dtype=torch.float32)
+            freqs = torch.einsum("i,j->ij", t, self.inv_freq.float())
             emb = torch.cat((freqs, freqs), dim=-1).to(x.device)
             if self.precision == torch.bfloat16:
                 emb = emb.float()


### PR DESCRIPTION
When we use `model.bfloat16().cuda()`, `inv_freq` will be converted to bfloat16 even we defined it in `dtype=float32`. In bfloat16, position would not be represented right.

For example, we cannot distinguish the difference between `256.0` and `257.0`, so when we create position embedding, we forced convert `inv_freq` and `t` to fp32.