### PR TITLE
Fixed final value of linear decay lr

### DIFF
--- a/megatron/learning_rates.py
+++ b/megatron/learning_rates.py
@@ -71,7 +71,8 @@ class AnnealingLR(object):
 
         num_iters_ = num_iters_ - self.warmup_iter
         if self.decay_style == "linear":
-            lr = self.start_lr * (self.end_iter - num_iters_) / self.end_iter
+            end_iter_ = self.end_iter - self.warmup_iter
+            lr = self.start_lr * (end_iter_ - num_iters_) / end_iter_
         elif self.decay_style == "cosine":
             end_iter_ = self.end_iter - self.warmup_iter
             lr = self.min_lr + (


### PR DESCRIPTION
I found that the current linear decay scheduler is incorrect. When `self.num_iters` reached `self.end_iter`, the learning rate `lr` is not 0