### PR TITLE
LR scheduler fix no longer breaks inference

### DIFF
--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -111,7 +111,7 @@ Logging Arguments
 
 - **git_hash**: str
 
-    Default = ec71f71
+    Default = a97bd1f
 
     current git hash of repository
 

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -686,7 +686,9 @@ def setup_model_and_optimizer(neox_args, use_cache=False, iteration=None):
         neox_args.iteration = 0
 
     # need this for correct lr scheduling resume from ckpt
-    lr_scheduler.optimizer = model.optimizer
+    # but it will not exist if this is being called for inference
+    if lr_scheduler is not None:
+        lr_scheduler.optimizer = model.optimizer
 
     return model, optimizer, lr_scheduler
 


### PR DESCRIPTION
Failed to test previous PR for inference mode, this adds a check so that `setup_model_and_optimizer` works when there is no optimizer (e.g. when using it to initialize DeepSpeed for inference)