### PR TITLE
Edge-casing for multi-GPU HF-to-NeoX conversion

### DIFF
--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -111,7 +111,7 @@ Logging Arguments
 
 - **git_hash**: str
 
-    Default = a97bd1f
+    Default = 4579a33
 
     current git hash of repository
 
@@ -605,7 +605,7 @@ Optimizer Arguments
 
     Default = adam
 
-    Type of optimizer to use. Choose from ['adam', 'onebitadam', 'cpu_adam', 'cpu_torch_adam', 'sm3', 'madgrad_wd', 'sgd', 'lion']
+    Type of optimizer to use. Choose from ['adam', 'onebitadam', 'cpu_adam', 'cpu_torch_adam', 'sm3', 'madgrad_wd', 'sgd']
     NOTE: sgd will use MuSGD from Mup. Mup must be enabled for this optimizer.
 
 

--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -111,7 +111,7 @@ Logging Arguments
 
 - **git_hash**: str
 
-    Default = 2ff807d
+    Default = 7c50e77
 
     current git hash of repository
 
@@ -605,7 +605,7 @@ Optimizer Arguments
 
     Default = adam
 
-    Type of optimizer to use. Choose from ['adam', 'onebitadam', 'cpu_adam', 'cpu_torch_adam', 'sm3', 'madgrad_wd', 'sgd']
+    Type of optimizer to use. Choose from ['adam', 'onebitadam', 'cpu_adam', 'cpu_torch_adam', 'sm3', 'madgrad_wd', 'sgd', 'lion']
     NOTE: sgd will use MuSGD from Mup. Mup must be enabled for this optimizer.
 
 

--- a/tools/ckpts/convert_hf_to_sequential.py
+++ b/tools/ckpts/convert_hf_to_sequential.py
@@ -57,7 +57,7 @@ MULTI_GPU_ARGS = " ".join(
         "--output-dir checkpoints/neox_converted/pythia/70m",
         "--cache-dir checkpoints/HF",
         "--config configs/pythia/70M.yml configs/local_setup.yml",
-        "--test", 
+        "--test",
     ]
 )
 

--- a/tools/ckpts/convert_hf_to_sequential.py
+++ b/tools/ckpts/convert_hf_to_sequential.py
@@ -57,7 +57,7 @@ MULTI_GPU_ARGS = " ".join(
         "--output-dir checkpoints/neox_converted/pythia/70m",
         "--cache-dir checkpoints/HF",
         "--config configs/pythia/70M.yml configs/local_setup.yml",
-        "--test",
+        "--test", 
     ]
 )
 
@@ -519,7 +519,7 @@ if __name__ == "__main__":
     model, optimizer, _, lr_scheduler = deepspeed.initialize(
         model=model,
         optimizer=optimizer,
-        args=neox_args,
+        # args=neox_args,
         lr_scheduler=lr_scheduler,
         dist_init_required=False,
         model_parameters=None,
@@ -527,7 +527,7 @@ if __name__ == "__main__":
         mpu=mpu if not neox_args.is_pipe_parallel else None,
     )
 
-    if os.environ["OMPI_COMM_WORLD_RANK"] == "0":
+    if os.environ.get("OMPI_COMM_WORLD_RANK", "1") == "0":
         os.makedirs(f"{tmp_cache_dir}", exist_ok=True)
 
     torch.distributed.barrier()
@@ -566,7 +566,7 @@ if __name__ == "__main__":
         print("==========================================")
         convert(hf_model, ckpt_dir=ckpt_dir, output_dir=args.output_dir)
 
-        if os.environ["OMPI_COMM_WORLD_RANK"] == "0":
+        if os.environ.get("OMPI_COMM_WORLD_RANK", "1") == "0":
             # cleanup temp dir
             os.system(f"rm -r {tmp_cache_dir}")
 


### PR DESCRIPTION
This PR fixes a few bugs encountered when attempting to convert from HF to NeoX checkpoint format, via the invocation of the script through `deepy.py` in the multi-GPU case. 

After fixing these, and using `"launcher": "slurm", "deepspeed_slurm": true` in the config file I passed, conversion works for this distributed case. The distributed case can be always used if desired, even on a single GPU, and whether or not MP/PP are > 1.