### PR TITLE
fixed case when ntasks_per_node is used, leading to missing SLURM_NTASKS env var

### DIFF
--- a/megatron/neox_arguments/arguments.py
+++ b/megatron/neox_arguments/arguments.py
@@ -732,7 +732,8 @@ class NeoXArgs(*BASE_CLASSES):
         if self.deepspeed_slurm:
             os.environ["LOCAL_RANK"] = os.environ["SLURM_LOCALID"]
             os.environ["RANK"] = os.environ["SLURM_PROCID"]
-            os.environ["WORLD_SIZE"] = os.environ["SLURM_NTASKS"]
+            os.environ["WORLD_SIZE"] = os.environ["SLURM_NTASKS"] if os.environ.get("SLURM_NTASKS") is not None \
+                                        else str(int(os.environ["SLURM_NNODES"]) * int(os.environ["SLURM_NTASKS_PER_NODE"]))
 
         self.update_value("local_rank", int(os.getenv("LOCAL_RANK", "0")))
         self.update_value("rank", int(os.getenv("RANK", "0")))


### PR DESCRIPTION
On some clusters, it appears that a script specifying `#SBATCH --ntasks_per_node` instead of `#SBATCH --ntasks` will fail to build the environment variable `os.environ["SLURM_NTASKS"]`. This leads to an error in `arguments.py`, due to accessing a non-existing key of `os.environ`. A simple fix is to note that NTASKS = NNODES x SLURM_NTASKS_PER_NODE and use the right handside if the `SLURM_NTASKS` key does not exist in `os.environ`.