### PR TITLE
Pin version of `lm_eval`

### DIFF
--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -111,7 +111,7 @@ Logging Arguments
 
 - **git_hash**: str
 
-    Default = 5304f15
+    Default = c0fd5d9
 
     current git hash of repository
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,7 +3,7 @@ git+https://github.com/EleutherAI/DeeperSpeed.git#egg=deepspeed
 ftfy>=6.0.1
 git+https://github.com/EleutherAI/lm_dataformat.git@4eec05349977071bf67fc072290b95e31c8dd836
 huggingface_hub>=0.11.0
-lm_eval>=0.3.0
+lm_eval==0.3.0
 mpi4py>=3.0.3
 numpy>=1.22.0
 pybind11>=2.6.2


### PR DESCRIPTION
This PR pins the version of the lm-evaluation-harness used for the integration for the time being, until v0.4.0 and up are both released and support is added to GPT-NeoX for them.