### PR TITLE
Fixing convert neox to huggingface bug

### DIFF
--- a/tools/ckpts/convert_module_to_hf.py
+++ b/tools/ckpts/convert_module_to_hf.py
@@ -225,7 +225,9 @@ def convert(input_checkpoint_path, loaded_config, output_checkpoint_path):
             "mlp.dense_4h_to_h.bias",
             "attention.dense.bias",
         ]:
-            state_dict[key] = sum([t[key] for t in loaded_tp_ranks])
+            state_dict[key] = sum([t[key] for t in loaded_tp_ranks]) / len(
+                loaded_tp_ranks
+            )
 
         # Just take one
         state_dict["attention.rotary_emb.inv_freq"] = loaded_tp_ranks[0][

--- a/tools/ckpts/convert_sequential_to_hf.py
+++ b/tools/ckpts/convert_sequential_to_hf.py
@@ -238,7 +238,9 @@ def convert(input_checkpoint_path, loaded_config, output_checkpoint_path):
             "mlp.dense_4h_to_h.bias",
             "attention.dense.bias",
         ]:
-            state_dict[key] = sum(get_state(loaded_tp_ranks, key, layer_i + 2))
+            state_dict[key] = sum(get_state(loaded_tp_ranks, key, layer_i + 2)) / len(
+                loaded_tp_ranks
+            )
 
         # Just take one
         state_dict["attention.rotary_emb.inv_freq"] = get_state(


### PR DESCRIPTION
When processing mlp.dense_4h_to_h.bias and attention.dense.bias, tp_ranks are not reflected, so strange results always appear when tp_ranks is greater than 1.

When changing the code, we confirmed that the hugging face model (model_parallel_size 4 was applied) was converted to a neox model using convert_hf_to_sequential.py and converted to a huggingface model using convert_sequential_to_hf.py, making it the same as the original model.