### PR TITLE
Resolve existing CPU unit test errors

### DIFF
--- a/tests/neox_args/test_neoxargs_usage.py
+++ b/tests/neox_args/test_neoxargs_usage.py
@@ -51,6 +51,7 @@ def test_neoxargs_usage():
             "build_tokenizer",
             "attention_config[i]",
             "print",
+            "update"
         ]
     )
 


### PR DESCRIPTION
Fixes #1025 

`test_neoxargs_usage` does a regex search for patterns of the form "args.*" and verifies that such used args are defined in `NeoXArgs`. In this case it picks up a false positive from 
https://github.com/EleutherAI/gpt-neox/blob/f214358baea68c1631e650e073371010b4b9b60e/megatron/neox_arguments/arguments.py#L938-L940