### PR TITLE
Pins old DeeperSpeed until bug is fixed

### DIFF
--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -111,7 +111,7 @@ Logging Arguments
 
 - **git_hash**: str
 
-    Default = bb1b145
+    Default = a279fc8
 
     current git hash of repository
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,5 @@
 best_download
-git+https://github.com/EleutherAI/DeeperSpeed.git#egg=deepspeed
+git+https://github.com/EleutherAI/DeeperSpeed.git@b9260436e7da3e297fc6bedfd27d9e69fbba6f5c#egg=deepspeed
 ftfy>=6.0.1
 git+https://github.com/EleutherAI/lm_dataformat.git@4eec05349977071bf67fc072290b95e31c8dd836
 huggingface_hub>=0.11.0


### PR DESCRIPTION
There is a bug in upstream DeepSpeed detailed [here](https://github.com/microsoft/DeepSpeed/issues/4781) that we didn't catch before synching with main. This pins the prior commit so the bug doesn't impact users.