### PR TITLE
Better run_eval_harness import

### DIFF
--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -976,7 +976,7 @@ Text Generation arguments
 
 - **prompt_end**: str
 
-    Default = 
+    Default =
 
 
     a single prompt's end. Defaults to newline
@@ -1018,7 +1018,7 @@ Text Generation arguments
 
 - **eval_results_prefix**: str
 
-    Default = 
+    Default =
 
     prefix to which to save evaluation results - final fp will be {eval_results_prefix}_eval_results_yy-mm-dd-HH-MM.json
 
@@ -1029,6 +1029,8 @@ Text Generation arguments
     Default = None
 
     Tasks to evaluate on using lm_eval_harness
+
+    NOTE: Requires internet connection
 
 
 
@@ -1768,7 +1770,7 @@ Args for deepspeed config
 
     Default = None
 
-    
+
 
 
 
@@ -2068,4 +2070,3 @@ Args for deepspeed runner (deepspeed.launcher.runner).
     Default = None
 
     Adds a `--account` to the DeepSpeed launch command. In DeeperSpeed this is passed on to the SlurmLauncher as well. Sometimes necessary for cluster rules, or so I've heard.
-

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -55,7 +55,6 @@ from megatron.utils import (
     CharCounter,
 )
 from megatron.model.gpt2_model import cross_entropy
-from eval_tasks import run_eval_harness
 
 
 def mup_weights_reinit(neox_args, model):
@@ -967,6 +966,8 @@ def evaluate(
         )
 
     if neox_args.eval_tasks:
+        from eval_tasks import run_eval_harness
+
         eval_results.update(
             run_eval_harness(
                 model, forward_step_fn, neox_args, eval_tasks=neox_args.eval_tasks


### PR DESCRIPTION
1. Trigger `run_eval_harness` import only when `eval_tasks` is specified since this requires internet connection. (Times out on network-restricted clusters)
2. Add notes to the docs