### PR TITLE
Update lm_eval v0.4 to PyPI dependencies

### DIFF
--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -111,7 +111,7 @@ Logging Arguments
 
 - **git_hash**: str
 
-    Default = d6e3789
+    Default = 78b8466
 
     current git hash of repository
 
@@ -976,7 +976,7 @@ Text Generation arguments
 
 - **prompt_end**: str
 
-    Default =
+    Default = 
 
 
     a single prompt's end. Defaults to newline
@@ -1018,7 +1018,7 @@ Text Generation arguments
 
 - **eval_results_prefix**: str
 
-    Default =
+    Default = 
 
     prefix to which to save evaluation results - final fp will be {eval_results_prefix}_eval_results_yy-mm-dd-HH-MM.json
 
@@ -1029,6 +1029,8 @@ Text Generation arguments
     Default = None
 
     Tasks to evaluate on using lm_eval_harness
+
+    NOTE: Requires internet connection
 
 
 
@@ -1768,7 +1770,7 @@ Args for deepspeed config
 
     Default = None
 
-
+    
 
 
 
@@ -2068,3 +2070,4 @@ Args for deepspeed runner (deepspeed.launcher.runner).
     Default = None
 
     Adds a `--account` to the DeepSpeed launch command. In DeeperSpeed this is passed on to the SlurmLauncher as well. Sometimes necessary for cluster rules, or so I've heard.
+

--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -976,7 +976,7 @@ Text Generation arguments
 
 - **prompt_end**: str
 
-    Default = 
+    Default =
 
 
     a single prompt's end. Defaults to newline
@@ -1018,7 +1018,7 @@ Text Generation arguments
 
 - **eval_results_prefix**: str
 
-    Default = 
+    Default =
 
     prefix to which to save evaluation results - final fp will be {eval_results_prefix}_eval_results_yy-mm-dd-HH-MM.json
 
@@ -1768,7 +1768,7 @@ Args for deepspeed config
 
     Default = None
 
-    
+
 
 
 
@@ -2068,4 +2068,3 @@ Args for deepspeed runner (deepspeed.launcher.runner).
     Default = None
 
     Adds a `--account` to the DeepSpeed launch command. In DeeperSpeed this is passed on to the SlurmLauncher as well. Sometimes necessary for cluster rules, or so I've heard.
-

--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -111,7 +111,7 @@ Logging Arguments
 
 - **git_hash**: str
 
-    Default = cd9a8ea
+    Default = d6e3789
 
     current git hash of repository
 
@@ -976,7 +976,7 @@ Text Generation arguments
 
 - **prompt_end**: str
 
-    Default =
+    Default = 
 
 
     a single prompt's end. Defaults to newline
@@ -1018,7 +1018,7 @@ Text Generation arguments
 
 - **eval_results_prefix**: str
 
-    Default =
+    Default = 
 
     prefix to which to save evaluation results - final fp will be {eval_results_prefix}_eval_results_yy-mm-dd-HH-MM.json
 
@@ -1029,8 +1029,6 @@ Text Generation arguments
     Default = None
 
     Tasks to evaluate on using lm_eval_harness
-
-    NOTE: Requires internet connection
 
 
 
@@ -1770,7 +1768,7 @@ Args for deepspeed config
 
     Default = None
 
-
+    
 
 
 
@@ -2070,3 +2068,4 @@ Args for deepspeed runner (deepspeed.launcher.runner).
     Default = None
 
     Adds a `--account` to the DeepSpeed launch command. In DeeperSpeed this is passed on to the SlurmLauncher as well. Sometimes necessary for cluster rules, or so I've heard.
+

--- a/megatron/neox_arguments/neox_args.py
+++ b/megatron/neox_arguments/neox_args.py
@@ -1158,4 +1158,6 @@ class NeoXArgsTextgen(NeoXArgsTemplate):
     eval_tasks: list = None
     """
     Tasks to evaluate on using lm_eval_harness
+
+    NOTE: Requires internet connection
     """

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,7 +4,7 @@ ftfy>=6.0.1
 git+https://github.com/EleutherAI/lm_dataformat.git@4eec05349977071bf67fc072290b95e31c8dd836
 huggingface_hub>=0.11.0
 jinja2==3.1.3
-git+https://github.com/EleutherAI/lm-evaluation-harness.git@main#egg=lm_eval
+lm_eval==0.4.1
 mpi4py>=3.0.3
 numpy>=1.22.0
 pybind11>=2.6.2

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,7 +4,7 @@ ftfy>=6.0.1
 git+https://github.com/EleutherAI/lm_dataformat.git@4eec05349977071bf67fc072290b95e31c8dd836
 huggingface_hub>=0.11.0
 jinja2==3.1.3
-lm_eval==0.4.1
+lm_eval>=0.4.0,<=0.4.1
 mpi4py>=3.0.3
 numpy>=1.22.0
 pybind11>=2.6.2


### PR DESCRIPTION
We now have released v0.4.1 and v0.4.0 of lm-eval on PyPI.

This PR makes requirements.txt reflect that, instead of using the git repo (though users who want the newest code version can choose to install from the repo.)


