### PR TITLE
Remove gas (beano)

### DIFF
--- a/configs/19M.yml
+++ b/configs/19M.yml
@@ -44,7 +44,7 @@
   },
 
   "train_micro_batch_size_per_gpu": 4, #32,
-  "gas": 1,
+  "gradient_accumulation_steps": 1,
   "data_impl": "mmap",
   "num_workers": 1,
 

--- a/configs/49M.yml
+++ b/configs/49M.yml
@@ -49,7 +49,7 @@
 
   # batch / data settings
   "train_micro_batch_size_per_gpu": 32,
-  "gas": 1,
+  "gradient_accumulation_steps": 1,
   "data_impl": "mmap",
   "num_workers": 1,
 

--- a/configs/800M.yml
+++ b/configs/800M.yml
@@ -44,7 +44,7 @@
   },
 
   "train_micro_batch_size_per_gpu": 16,
-  "gas": 1,
+  "gradient_accumulation_steps": 1,
   "data_impl": "mmap",
   "num_workers": 1,
 

--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -976,7 +976,7 @@ Text Generation arguments
 
 - **prompt_end**: str
 
-    Default = 
+    Default =
 
 
     a single prompt's end. Defaults to newline
@@ -1018,7 +1018,7 @@ Text Generation arguments
 
 - **eval_results_prefix**: str
 
-    Default = 
+    Default =
 
     prefix to which to save evaluation results - final fp will be {eval_results_prefix}_eval_results_yy-mm-dd-HH-MM.json
 
@@ -1478,14 +1478,6 @@ Training Arguments
 
 
 
-- **gas**: int
-
-    Default = None
-
-    gradient_accumulation_steps
-
-
-
 - **clip_grad**: float
 
     Default = 1.0
@@ -1770,7 +1762,7 @@ Args for deepspeed config
 
     Default = None
 
-    
+
 
 
 
@@ -2070,4 +2062,3 @@ Args for deepspeed runner (deepspeed.launcher.runner).
     Default = None
 
     Adds a `--account` to the DeepSpeed launch command. In DeeperSpeed this is passed on to the SlurmLauncher as well. Sometimes necessary for cluster rules, or so I've heard.
-

--- a/megatron/neox_arguments/arguments.py
+++ b/megatron/neox_arguments/arguments.py
@@ -896,7 +896,6 @@ class NeoXArgs(*BASE_CLASSES):
                 "gradient_accumulation_steps": gradient_accumulation_steps,
                 "batch_size": train_micro_batch_size_per_gpu,
                 # duplicate items
-                "gas": self.gradient_accumulation_steps,
                 "clip_grad": self.gradient_clipping,
             }
         )

--- a/megatron/neox_arguments/neox_args.py
+++ b/megatron/neox_arguments/neox_args.py
@@ -996,9 +996,6 @@ class NeoXArgsTraining(NeoXArgsTemplate):
     Partition Activations across GPUs before checkpointing.
     """
 
-    gas: int = None
-    """gradient_accumulation_steps"""  # TODO this is a duplicate, remove?
-
     clip_grad: float = 1.0
     """
     Gradient clipping based on global L2 norm.

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -927,7 +927,7 @@ def evaluate(
 
             # although we're not accumulating gradients here, we count one iter as train_batch_size_per_gpu * g.a.s
             # to be consistent with deepspeed's pipe parallel engine
-            # since pipe parallel already takes graduent_accumulation_steps into account - default to 1 here if pipe parallel is true
+            # since pipe parallel already takes gradient_accumulation_steps into account - default to 1 here if pipe parallel is true
             for _ in range(
                 1
                 if neox_args.is_pipe_parallel

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -927,7 +927,7 @@ def evaluate(
 
             # although we're not accumulating gradients here, we count one iter as train_batch_size_per_gpu * g.a.s
             # to be consistent with deepspeed's pipe parallel engine
-            # since pipe parallel already takes gas into account - default to 1 here if pipe parallel is true
+            # since pipe parallel already takes graduent_accumulation_steps into account - default to 1 here if pipe parallel is true
             for _ in range(
                 1
                 if neox_args.is_pipe_parallel

--- a/tests/config/test_setup.yml
+++ b/tests/config/test_setup.yml
@@ -44,7 +44,7 @@
   "output_layer_init_method": "wang_init",
 
   "train_micro_batch_size_per_gpu": 4,
-  "gas": 1,
+  "gradient_accumulation_steps": 1,
   "data_impl": "mmap",
   "num_workers": 1,
 


### PR DESCRIPTION
per code being removed:

```gas: int = None
    """gradient_accumulation_steps"""  # TODO this is a duplicate, remove?
```

This is set in many configs and [never assigned from](https://github.com/search?q=repo%3AEleutherAI%2Fgpt-neox%20gas&type=code). Its continued existence in neox only encourages people to set ```gas```, which does apparently nothing, instead of setting ```gradient_accumulation_steps```, which is probably what they intended to do.

Pythia configs left alone because the source of truth for those configs is the pythia repo.