### PR TITLE
Copy pythia configs

### DIFF
--- a/configs/pythia/1-4B.yml
+++ b/configs/pythia/1-4B.yml
@@ -1,23 +1,26 @@
 {
-  "pipe_parallel_size": 1,
-  "model_parallel_size": 1,
+  # parallelism
+  "pipe-parallel-size": 1,
+  "model-parallel-size": 1,
 
-  "num_layers": 24,
-  "hidden_size": 2048,
-  "num_attention_heads": 16,
-  "seq_length": 2048,
-  "max_position_embeddings": 2048,
-  "pos_emb": "rotary",
-  "rotary_pct": 0.25,
-  "no_weight_tying": true,
-  "gpt_j_residual": true,
-  "output_layer_parallelism": "column",
+  # model settings
+  "num-layers": 24,
+  "hidden-size": 2048,
+  "num-attention-heads": 16,
+  "seq-length": 2048,
+  "max-position-embeddings": 2048,
+  "pos-emb": "rotary",
+  "rotary-pct": 0.25,
+  "no-weight-tying": true,
+  "gpt-j-residual": true,
+  "output-layer-parallelism": "column",
 
-  "attention_config": [[["flash"], 24]],
+  "attention-config": [[["flash"], 24]],
 
-  "scaled_upper_triang_masked_softmax_fusion": true,
-  "bias_gelu_fusion": true,
+  "scaled-upper-triang-masked-softmax-fusion": true,
+  "bias-gelu-fusion": true,
 
+  # init methods
   "init_method": "small_init",
   "output_layer_init_method": "wang_init",
 
@@ -42,21 +45,25 @@
     "cpu_offload": false
   },
 
+  # batch size (trained on 64 gpus)
   "train_micro_batch_size_per_gpu": 16,
   "gas": 1,
-  "data_impl": "mmap",
+  "data-impl": "mmap",
   "num_workers": 1,
 
-  "checkpoint_activations": true,
-  "checkpoint_num_layers": 1,
-  "partition_activations": true,
-  "synchronize_each_layer": true,
+  # activation checkpointing
+  "checkpoint-activations": true,
+  "checkpoint-num-layers": 1,
+  "partition-activations": true,
+  "synchronize-each-layer": true,
 
+  # regularization
   "gradient_clipping": 1.0,
-  "weight_decay": 0.1,
-  "hidden_dropout": 0,
-  "attention_dropout": 0,
+  "weight-decay": 0.1,
+  "hidden-dropout": 0,
+  "attention-dropout": 0,
 
+  # precision settings
   "fp16": {
     "fp16": true,
     "enabled": true,
@@ -67,19 +74,19 @@
     "min_loss_scale": 1
   },
 
-  "train_iters": 143000,
-  "lr_decay_iters": 143000,
-  "distributed_backend": "nccl",
-  "lr_decay_style": "cosine",
+  "train-iters": 143000,
+  "lr-decay-iters": 143000,
+  "distributed-backend": "nccl",
+  "lr-decay-style": "cosine",
   "warmup": 0.01,
-  "checkpoint_factor": 1000,
-  "extra_save_iters": [0,1,2,4,8,16,32,64,128,256,512],
-  "eval_interval": 143000,
-  "eval_iters": 10,
+  "checkpoint-factor": 1000,
+  "extra-save-iters": [0,1,2,4,8,16,32,64,128,256,512],
+  "eval-interval": 40000,
+  "eval-iters": 10,
 
-
-  "log_interval": 10,
+  "log-interval": 10,
   "steps_per_print": 10,
   "wall_clock_breakdown": true,
-  "tokenizer_type": "HFTokenizer"
-  }
+
+  "tokenizer-type": "HFTokenizer",
+}

--- a/configs/pythia/12B.yml
+++ b/configs/pythia/12B.yml
@@ -1,24 +1,27 @@
 {
-   "pipe_parallel_size": 1,
-   "model_parallel_size": 4,
+   # parallelism settings
+   "pipe-parallel-size": 1,
+   "model-parallel-size": 4,
 
-   "num_layers": 36,
-   "hidden_size": 5120,
-   "num_attention_heads": 40,
-   "seq_length": 2048,
-   "max_position_embeddings": 2048,
+   # model settings
+   "num-layers": 40,
+   "hidden-size": 5120,
+   "num-attention-heads": 40,
+   "seq-length": 2048,
+   "max-position-embeddings": 2048,
    "norm": "layernorm",
-   "pos_emb": "rotary",
+   "pos-emb": "rotary",
    "rotary_pct": 0.25,
-   "no_weight_tying": true,
+   "no-weight-tying": true,
    "gpt_j_residual": true,
    "output_layer_parallelism": "column",
 
-   "attention_config": [[["flash"], 36]],
+   "attention-config": [[["flash"], 40]],
 
-   "scaled_upper_triang_masked_softmax_fusion": true,
-   "bias_gelu_fusion": true,
+   "scaled-upper-triang-masked-softmax-fusion": true,
+   "bias-gelu-fusion": true,
 
+   # optimizer settings
    "optimizer": {
      "type": "Adam",
      "params": {
@@ -40,20 +43,24 @@
     "cpu_offload": false
   },
 
+   # batch size (trained on 256 gpus)
    "train_micro_batch_size_per_gpu": 8,
    "gradient_accumulation_steps": 2,
-   "data_impl": "mmap",
+   "data-impl": "mmap",
 
-   "checkpoint_activations": true,
-   "checkpoint_num_layers": 1,
-   "partition_activations": true,
-   "synchronize_each_layer": true,
+   # activation checkpointing
+   "checkpoint-activations": true,
+   "checkpoint-num-layers": 1,
+   "partition-activations": true,
+   "synchronize-each-layer": true,
 
+   # regularization
    "gradient_clipping": 1.0,
-   "weight_decay": 0.1,
-   "hidden_dropout": 0,
-   "attention_dropout": 0,
+   "weight-decay": 0.1,
+   "hidden-dropout": 0,
+   "attention-dropout": 0,
 
+   # precision settings
    "fp16": {
      "fp16": true,
      "enabled": true,
@@ -64,21 +71,20 @@
      "min_loss_scale": 1
    },
 
-   "train_iters": 143000,
-   "lr_decay_iters": 143000,
-   "distributed_backend": "nccl",
-   "lr_decay_style": "cosine",
+   "train-iters": 143000,
+   "lr-decay-iters": 143000,
+   "distributed-backend": "nccl",
+   "lr-decay-style": "cosine",
    "warmup": 0.01,
-   "checkpoint_factor": 1000,
-   "extra_save_iters": [0,1,2,4,8,16,32,64,128,256,512],
-   "eval_interval": 143000,
-   "eval_iters": 10,
+   "checkpoint-factor": 1000,
+   "extra-save-iters": [0,1,2,4,8,16,32,64,128,256,512],
+   "eval-interval": 1000,
+   "eval-iters": 10,
 
-   "log_interval": 10,
+   # logging
+   "log-interval": 10,
    "steps_per_print": 10,
    "wall_clock_breakdown": true,
 
-   "log_grad_norm": true,
-
-   "tokenizer_type": "HFTokenizer"
+   "tokenizer_type": "HFTokenizer",
 }

--- a/configs/pythia/14M.yml
+++ b/configs/pythia/14M.yml
@@ -88,11 +88,5 @@
   "steps_per_print": 10,
   "wall_clock_breakdown": true,
 
-  "train-data-paths": ["/mnt/ssd-2/pile_deduped/pile_20B_tokenizer_text_document"],
-  "valid-data-paths": ["/mnt/ssd-2/pile_deduped/pile_20B_tokenizer_text_document"],
-  "test-data-paths": ["/mnt/ssd-2/pile_deduped/pile_20B_tokenizer_text_document"],
-
   "tokenizer-type": "HFTokenizer",
-  "vocab-file": "/mnt/ssd-2/pile/20B_tokenizer.json"
-
 }

--- a/configs/pythia/160M.yml
+++ b/configs/pythia/160M.yml
@@ -1,23 +1,26 @@
 {
-  "pipe_parallel_size": 1,
-  "model_parallel_size": 1,
+  # parallelism settings
+  "pipe-parallel-size": 1,
+  "model-parallel-size": 1,
 
-  "num_layers": 12,
-  "hidden_size": 768,
-  "num_attention_heads": 12,
-  "seq_length": 2048,
-  "max_position_embeddings": 2048,
-  "pos_emb": "rotary",
-  "rotary_pct": 0.25,
-  "no_weight_tying": true,
-  "gpt_j_residual": true,
-  "output_layer_parallelism": "column",
+  # model settings
+  "num-layers": 12,
+  "hidden-size": 768,
+  "num-attention-heads": 12,
+  "seq-length": 2048,
+  "max-position-embeddings": 2048,
+  "pos-emb": "rotary",
+  "rotary-pct": 0.25,
+  "no-weight-tying": true,
+  "gpt-j-residual": true,
+  "output-layer-parallelism": "column",
 
-  "attention_config": [[["flash"], 12]],
+  "attention-config": [[["flash"], 12]],
 
-  "scaled_upper_triang_masked_softmax_fusion": true,
-  "bias_gelu_fusion": true,
+  "scaled-upper-triang-masked-softmax-fusion": true,
+  "bias-gelu-fusion": true,
 
+  # init methods
   "init_method": "small_init",
   "output_layer_init_method": "wang_init",
 
@@ -42,21 +45,25 @@
     "cpu_offload": false
   },
 
+  # batch size (trained on 32 gpus)
   "train_micro_batch_size_per_gpu": 32,
   "gas": 1,
-  "data_impl": "mmap",
+  "data-impl": "mmap",
   "num_workers": 1,
 
-  "checkpoint_activations": true,
-  "checkpoint_num_layers": 1,
-  "partition_activations": true,
-  "synchronize_each_layer": true,
+  # activation checkpointing
+  "checkpoint-activations": true,
+  "checkpoint-num-layers": 1,
+  "partition-activations": true,
+  "synchronize-each-layer": true,
 
+  # regularization
   "gradient_clipping": 1.0,
-  "weight_decay": 0.1,
-  "hidden_dropout": 0,
-  "attention_dropout": 0,
+  "weight-decay": 0.1,
+  "hidden-dropout": 0,
+  "attention-dropout": 0,
 
+  # precision settings
   "fp16": {
     "fp16": true,
     "enabled": true,
@@ -67,19 +74,19 @@
     "min_loss_scale": 1
   },
 
-  "train_iters": 143000,
-  "lr_decay_iters": 143000,
-  "distributed_backend": "nccl",
-  "lr_decay_style": "cosine",
+  "train-iters": 143000,
+  "lr-decay-iters": 143000,
+  "distributed-backend": "nccl",
+  "lr-decay-style": "cosine",
   "warmup": 0.01,
-  "checkpoint_factor": 1000,
-  "extra_save_iters": [0,1,2,4,8,16,32,64,128,256,512],
-  "eval_interval": 143000,
-  "eval_iters": 10,
+  "checkpoint-factor": 1000,
+  "extra-save-iters": [0,1,2,4,8,16,32,64,128,256,512],
+  "eval-interval": 40000,
+  "eval-iters": 10,
 
-  "log_interval": 10,
+  "log-interval": 10,
   "steps_per_print": 10,
   "wall_clock_breakdown": true,
 
-  "tokenizer_type": "HFTokenizer"
+  "tokenizer-type": "HFTokenizer",
 }

--- a/configs/pythia/1B.yml
+++ b/configs/pythia/1B.yml
@@ -1,21 +1,26 @@
 {
-  "pipe_parallel_size": 1,
-  "model_parallel_size": 1,
+  # parallelism
+  "pipe-parallel-size": 1,
+  "model-parallel-size": 1,
 
-  "num_layers": 16,
-  "hidden_size": 2048,
-  "num_attention_heads": 8,
-  "seq_length": 2048,
-  "max_position_embeddings": 2048,
-  "pos_emb": "rotary",
-  "rotary_pct": 0.25,
-  "no_weight_tying": true,
-  "gpt_j_residual": true,
-  "output_layer_parallelism": "column",
+  # model settings
+  "num-layers": 16,
+  "hidden-size": 2048,
+  "num-attention-heads": 8,
+  "seq-length": 2048,
+  "max-position-embeddings": 2048,
+  "pos-emb": "rotary",
+  "rotary-pct": 0.25,
+  "no-weight-tying": true,
+  "gpt-j-residual": true,
+  "output-layer-parallelism": "column",
 
-  "scaled_upper_triang_masked_softmax_fusion": true,
-  "bias_gelu_fusion": true,
+  "attention-config": [[["flash"], 16]],
 
+  "scaled-upper-triang-masked-softmax-fusion": true,
+  "bias-gelu-fusion": true,
+
+  # init methods
   "init_method": "small_init",
   "output_layer_init_method": "wang_init",
 
@@ -30,7 +35,7 @@
   "min_lr": 0.000025,
 
   "zero_optimization": {
-    "stage": 0,
+    "stage": 1,
     "allgather_partitions": true,
     "allgather_bucket_size": 500000000,
     "overlap_comm": true,
@@ -40,47 +45,48 @@
     "cpu_offload": false
   },
 
+  # batch size (trained on 64 gpus)
+  "train_micro_batch_size_per_gpu": 16,
+  "gas": 1,
+  "data-impl": "mmap",
+  "num_workers": 1,
+
+  # activation checkpointing
+  "checkpoint-activations": true,
+  "checkpoint-num-layers": 1,
+  "partition-activations": true,
+  "synchronize-each-layer": true,
+
+  # regularization
+  "gradient_clipping": 1.0,
+  "weight-decay": 0.1,
+  "hidden-dropout": 0,
+  "attention-dropout": 0,
+
+  # precision settings
   "fp16": {
+    "fp16": true,
     "enabled": true,
-    "type": "bfloat16",
-    "auto_cast": true,
     "loss_scale": 0,
     "loss_scale_window": 1000,
     "initial_scale_power": 12,
     "hysteresis": 2,
-    "min_loss_scale": 1
+    "min_loss_scale": 1,
   },
 
-  "fp32_allreduce": true,
-
-  "train_micro_batch_size_per_gpu": 4,
-  "gradient_accumulation_steps": 4,
-  "data_impl": "mmap",
-  "num_workers": 1,
-
-  "checkpoint_activations": true,
-  "checkpoint_num_layers": 1,
-  "partition_activations": true,
-  "synchronize_each_layer": true,
-
-  "gradient_clipping": 1.0,
-  "weight_decay": 0.1,
-  "hidden_dropout": 0,
-  "attention_dropout": 0,
-
-  "train_iters": 143000,
-  "lr_decay_iters": 143000,
-  "distributed_backend": "nccl",
-  "lr_decay_style": "cosine",
+  "train-iters": 143000,
+  "lr-decay-iters": 143000,
+  "distributed-backend": "nccl",
+  "lr-decay-style": "cosine",
   "warmup": 0.01,
-  "checkpoint_factor": 1000,
-  "extra_save_iters": [0,1,2,4,8,16,32,64,128,256,512],
-  "eval_interval": 143000,
-  "eval_iters": 10,
+  "checkpoint-factor": 1000,
+  "extra-save-iters": [0,1,2,4,8,16,32,64,128,256,512],
+  "eval-interval": 40000,
+  "eval-iters": 10,
 
-  "log_interval": 10,
+  "log-interval": 10,
   "steps_per_print": 10,
   "wall_clock_breakdown": true,
 
-  "tokenizer_type": "HFTokenizer"
+  "tokenizer-type": "HFTokenizer",
 }

--- a/configs/pythia/2-8B.yml
+++ b/configs/pythia/2-8B.yml
@@ -1,23 +1,26 @@
 {
-  "pipe_parallel_size": 1,
-  "model_parallel_size": 1,
+  # parallelism
+  "pipe-parallel-size": 1,
+  "model-parallel-size": 1,
 
-  "num_layers": 32,
-  "hidden_size": 2560,
-  "num_attention_heads": 32,
-  "seq_length": 2048,
-  "max_position_embeddings": 2048,
-  "pos_emb": "rotary",
-  "rotary_pct": 0.25,
-  "no_weight_tying": true,
-  "gpt_j_residual": true,
-  "output_layer_parallelism": "column",
+  # model settings
+  "num-layers": 32,
+  "hidden-size": 2560,
+  "num-attention-heads": 32,
+  "seq-length": 2048,
+  "max-position-embeddings": 2048,
+  "pos-emb": "rotary",
+  "rotary-pct": 0.25,
+  "no-weight-tying": true,
+  "gpt-j-residual": true,
+  "output-layer-parallelism": "column",
 
-  "attention_config": [[["flash"], 32]],
+  "attention-config": [[["flash"], 32]],
 
-  "scaled_upper_triang_masked_softmax_fusion": true,
-  "bias_gelu_fusion": true,
+  "scaled-upper-triang-masked-softmax-fusion": true,
+  "bias-gelu-fusion": true,
 
+  # init methods
   "init_method": "small_init",
   "output_layer_init_method": "wang_init",
 
@@ -42,21 +45,25 @@
     "cpu_offload": false
   },
 
-  "train_micro_batch_size_per_gpu": 8,
-  "gradient_accumulation_steps": 2,
-  "data_impl": "mmap",
+  # batch size (trained on 64 gpus)
+  "train_micro_batch_size_per_gpu": 16,
+  "gas": 1,
+  "data-impl": "mmap",
   "num_workers": 1,
 
-  "checkpoint_activations": true,
-  "checkpoint_num_layers": 1,
-  "partition_activations": true,
-  "synchronize_each_layer": true,
+  # activation checkpointing
+  "checkpoint-activations": true,
+  "checkpoint-num-layers": 1,
+  "partition-activations": true,
+  "synchronize-each-layer": true,
 
+  # regularization
   "gradient_clipping": 1.0,
-  "weight_decay": 0.1,
-  "hidden_dropout": 0,
-  "attention_dropout": 0,
+  "weight-decay": 0.1,
+  "hidden-dropout": 0,
+  "attention-dropout": 0,
 
+  # precision settings
   "fp16": {
     "fp16": true,
     "enabled": true,
@@ -67,21 +74,19 @@
     "min_loss_scale": 1
   },
 
-  "train_iters": 143000,
-  "lr_decay_iters": 143000,
-  "distributed_backend": "nccl",
-  "lr_decay_style": "cosine",
+  "train-iters": 143000,
+  "lr-decay-iters": 143000,
+  "distributed-backend": "nccl",
+  "lr-decay-style": "cosine",
   "warmup": 0.01,
-  "checkpoint_factor": 1000,
-  "extra_save_iters": [0,1,2,4,8,16,32,64,128,256,512],
-  "eval_interval": 40000,
-  "eval_iters": 10,
+  "checkpoint-factor": 1000,
+  "extra-save-iters": [0,1,2,4,8,16,32,64,128,256,512],
+  "eval-interval": 40000,
+  "eval-iters": 10,
 
-  "log_grad_norm": true,
-
-  "log_interval": 10,
+  "log-interval": 10,
   "steps_per_print": 10,
   "wall_clock_breakdown": true,
 
-  "tokenizer_type": "HFTokenizer"
+  "tokenizer-type": "HFTokenizer",
 }

--- a/configs/pythia/31M.yml
+++ b/configs/pythia/31M.yml
@@ -87,11 +87,5 @@
   "steps_per_print": 10,
   "wall_clock_breakdown": true,
 
-  "train-data-paths": ["/mnt/ssd-2/pile_deduped/pile_20B_tokenizer_text_document"],
-  "valid-data-paths": ["/mnt/ssd-2/pile_deduped/pile_20B_tokenizer_text_document"],
-  "test-data-paths": ["/mnt/ssd-2/pile_deduped/pile_20B_tokenizer_text_document"],
-
   "tokenizer-type": "HFTokenizer",
-  "vocab-file": "/mnt/ssd-2/pile/20B_tokenizer.json"
-
 }

--- a/configs/pythia/410M.yml
+++ b/configs/pythia/410M.yml
@@ -1,23 +1,26 @@
 {
-  "pipe_parallel_size": 1,
-  "model_parallel_size": 1,
+  # parallelism settings
+  "pipe-parallel-size": 1,
+  "model-parallel-size": 1,
 
-  "num_layers": 24,
-  "hidden_size": 1024,
-  "num_attention_heads": 16,
-  "seq_length": 2048,
-  "max_position_embeddings": 2048,
-  "pos_emb": "rotary",
-  "rotary_pct": 0.25,
-  "no_weight_tying": true,
-  "gpt_j_residual": true,
-  "output_layer_parallelism": "column",
+  # model settings
+  "num-layers": 24,
+  "hidden-size": 1024,
+  "num-attention-heads": 16,
+  "seq-length": 2048,
+  "max-position-embeddings": 2048,
+  "pos-emb": "rotary",
+  "rotary-pct": 0.25,
+  "no-weight-tying": true,
+  "gpt-j-residual": true,
+  "output-layer-parallelism": "column",
 
-  "attention_config": [[["flash"], 24]],
+  "attention-config": [[["flash"], 24]],
 
-  "scaled_upper_triang_masked_softmax_fusion": true,
-  "bias_gelu_fusion": true,
+  "scaled-upper-triang-masked-softmax-fusion": true,
+  "bias-gelu-fusion": true,
 
+  # init methods
   "init_method": "small_init",
   "output_layer_init_method": "wang_init",
 
@@ -42,21 +45,25 @@
     "cpu_offload": false
   },
 
+  # batch size (trained on 32 gpus)
   "train_micro_batch_size_per_gpu": 32,
   "gas": 1,
-  "data_impl": "mmap",
+  "data-impl": "mmap",
   "num_workers": 1,
 
-  "checkpoint_activations": true,
-  "checkpoint_num_layers": 1,
-  "partition_activations": true,
-  "synchronize_each_layer": true,
+  # activation checkpointing
+  "checkpoint-activations": true,
+  "checkpoint-num-layers": 1,
+  "partition-activations": true,
+  "synchronize-each-layer": true,
 
+  # regularization
   "gradient_clipping": 1.0,
-  "weight_decay": 0.1,
-  "hidden_dropout": 0,
-  "attention_dropout": 0,
+  "weight-decay": 0.1,
+  "hidden-dropout": 0,
+  "attention-dropout": 0,
 
+  # precision settings
   "fp16": {
     "fp16": true,
     "enabled": true,
@@ -64,22 +71,22 @@
     "loss_scale_window": 1000,
     "initial_scale_power": 12,
     "hysteresis": 2,
-    "min_loss_scale": 1
+    "min_loss_scale": 1,
   },
 
-  "train_iters": 143000,
-  "lr_decay_iters": 143000,
-  "distributed_backend": "nccl",
-  "lr_decay_style": "cosine",
+  "train-iters": 143000,
+  "lr-decay-iters": 143000,
+  "distributed-backend": "nccl",
+  "lr-decay-style": "cosine",
   "warmup": 0.01,
-  "checkpoint_factor": 1000,
-  "extra_save_iters": [0,1,2,4,8,16,32,64,128,256,512],
-  "eval_interval": 143000,
-  "eval_iters": 10,
+  "checkpoint-factor": 1000,
+  "extra-save-iters": [0,1,2,4,8,16,32,64,128,256,512],
+  "eval-interval": 40000,
+  "eval-iters": 10,
 
-  "log_interval": 10,
+  "log-interval": 10,
   "steps_per_print": 10,
   "wall_clock_breakdown": true,
 
-  "tokenizer_type": "HFTokenizer"
+  "tokenizer-type": "HFTokenizer",
 }

--- a/configs/pythia/6-9B.yml
+++ b/configs/pythia/6-9B.yml
@@ -1,25 +1,28 @@
 {
-   "pipe_parallel_size": 1,
-   "model_parallel_size": 2,
+   # parallelism settings
+   "pipe-parallel-size": 1,
+   "model-parallel-size": 2,
 
-   "num_layers": 32,
-   "hidden_size": 4096,
-   "num_attention_heads": 32,
-   "seq_length": 2048,
-   "max_position_embeddings": 2048,
+   # model settings
+   "num-layers": 32,
+   "hidden-size": 4096,
+   "num-attention-heads": 32,
+   "seq-length": 2048,
+   "max-position-embeddings": 2048,
    "norm": "layernorm",
-   "pos_emb": "rotary",
+   "pos-emb": "rotary",
    "rotary_pct": 0.25,
-   "no_weight_tying": true,
+   "no-weight-tying": true,
    "gpt_j_residual": true,
    "output_layer_parallelism": "column",
 
-   "attention_config": [[["flash"], 32]],
+   "attention-config": [[["flash"], 32]],
 
-   "scaled_upper_triang_masked_softmax_fusion": true,
-   "bias_gelu_fusion": true,
+   "scaled-upper-triang-masked-softmax-fusion": true,
+   "bias-gelu-fusion": true,
 
 
+   # optimizer settings
    "optimizer": {
      "type": "Adam",
      "params": {
@@ -42,20 +45,24 @@
     "cpu_offload": false
   },
 
+   # batch size (trained on 128 gpus)
    "train_micro_batch_size_per_gpu": 8,
    "gradient_accumulation_steps": 2,
-   "data_impl": "mmap",
+   "data-impl": "mmap",
 
-   "checkpoint_activations": true,
-   "checkpoint_num_layers": 1,
-   "partition_activations": true,
-   "synchronize_each_layer": true,
+   # activation checkpointing
+   "checkpoint-activations": true,
+   "checkpoint-num-layers": 1,
+   "partition-activations": true,
+   "synchronize-each-layer": true,
 
+   # regularization
    "gradient_clipping": 1.0,
-   "weight_decay": 0.1,
-   "hidden_dropout": 0,
-   "attention_dropout": 0,
+   "weight-decay": 0.1,
+   "hidden-dropout": 0,
+   "attention-dropout": 0,
 
+   # precision settings
    "fp16": {
      "fp16": true,
      "enabled": true,
@@ -66,19 +73,20 @@
      "min_loss_scale": 1
    },
 
-   "train_iters": 143000,
-   "lr_decay_iters": 143000,
-   "distributed_backend": "nccl",
-   "lr_decay_style": "cosine",
+   "train-iters": 143000,
+   "lr-decay-iters": 143000,
+   "distributed-backend": "nccl",
+   "lr-decay-style": "cosine",
    "warmup": 0.01,
-   "checkpoint_factor": 1000,
-   "extra_save_iters": [0,1,2,4,8,16,32,64,128,256,512],
-   "eval_interval": 143000,
-   "eval_iters": 10,
+   "checkpoint-factor": 1000,
+   "extra-save-iters": [0,1,2,4,8,16,32,64,128,256,512],
+   "eval-interval": 1000,
+   "eval-iters": 10,
 
-   "log_interval": 10,
+   # logging
+   "log-interval": 10,
    "steps_per_print": 10,
    "wall_clock_breakdown": true,
 
-   "tokenizer_type": "HFTokenizer"
+   "tokenizer_type": "HFTokenizer",
 }

--- a/configs/pythia/70M.yml
+++ b/configs/pythia/70M.yml
@@ -1,23 +1,26 @@
 {
-  "pipe_parallel_size": 1,
-  "model_parallel_size": 1,
+  # parallelism settings
+  "pipe-parallel-size": 1,
+  "model-parallel-size": 1,
 
-  "num_layers": 6,
-  "hidden_size": 512,
-  "num_attention_heads": 8,
-  "seq_length": 2048,
-  "max_position_embeddings": 2048,
-  "pos_emb": "rotary",
-  "rotary_pct": 0.25,
-  "no_weight_tying": true,
-  "gpt_j_residual": true,
-  "output_layer_parallelism": "column",
+  # model settings
+  "num-layers": 6,
+  "hidden-size": 512,
+  "num-attention-heads": 8,
+  "seq-length": 2048,
+  "max-position-embeddings": 2048,
+  "pos-emb": "rotary",
+  "rotary-pct": 0.25,
+  "no-weight-tying": true,
+  "gpt-j-residual": true,
+  "output-layer-parallelism": "column",
 
-  "attention_config": [[["flash"], 6]],
+  "attention-config": [[["flash"], 6]],
 
-  "scaled_upper_triang_masked_softmax_fusion": true,
-  "bias_gelu_fusion": true,
+  "scaled-upper-triang-masked-softmax-fusion": true,
+  "bias-gelu-fusion": true,
 
+  # init methods
   "init_method": "small_init",
   "output_layer_init_method": "wang_init",
 
@@ -42,21 +45,25 @@
     "cpu_offload": false
   },
 
+  # batch size (trained on 32 gpus)
   "train_micro_batch_size_per_gpu": 32,
   "gas": 1,
-  "data_impl": "mmap",
+  "data-impl": "mmap",
   "num_workers": 1,
 
-  "checkpoint_activations": true,
-  "checkpoint_num_layers": 1,
-  "partition_activations": true,
-  "synchronize_each_layer": true,
+  # activation checkpointing
+  "checkpoint-activations": true,
+  "checkpoint-num-layers": 1,
+  "partition-activations": true,
+  "synchronize-each-layer": true,
 
+  # regularization
   "gradient_clipping": 1.0,
-  "weight_decay": 0.1,
-  "hidden_dropout": 0,
-  "attention_dropout": 0,
+  "weight-decay": 0.1,
+  "hidden-dropout": 0,
+  "attention-dropout": 0,
 
+  # precision settings
   "fp16": {
     "fp16": true,
     "enabled": true,
@@ -67,19 +74,19 @@
     "min_loss_scale": 1
   },
 
-  "train_iters": 143000,
-  "lr_decay_iters": 143000,
-  "distributed_backend": "nccl",
-  "lr_decay_style": "cosine",
+  "train-iters": 143000,
+  "lr-decay-iters": 143000,
+  "distributed-backend": "nccl",
+  "lr-decay-style": "cosine",
   "warmup": 0.01,
-  "checkpoint_factor": 1000,
-  "extra_save_iters": [0,1,2,4,8,16,32,64,128,256,512],
-  "eval_interval": 100000,
-  "eval_iters": 10,
+  "checkpoint-factor": 1000,
+  "extra-save-iters": [0,1,2,4,8,16,32,64,128,256,512],
+  "eval-interval": 100000,
+  "eval-iters": 10,
 
-  "log_interval": 10,
+  "log-interval": 10,
   "steps_per_print": 10,
   "wall_clock_breakdown": true,
 
-  "tokenizer_type": "HFTokenizer"
+  "tokenizer-type": "HFTokenizer",
 }


### PR DESCRIPTION
1) This copies pythia configs directly from the pythia repo, which should remove all possibility for configuration drift
2) This was a real problem -- e.g., flashattention configuration existed in pythia but not in the neox copy of the 1b pythia config
3) Copying all the configs over exactly prevents this from ever happening again, prevents me from having to diff the files one by one to see if they are actually identical or differ at some value in the future, and makes it easier to keep up to date because we can just run a fresh copy from the pythia repo.
4) It might have slight differences in formatting because the pre-commit hook ran over it before I disabled the pre-commit hook for the configs/pythia directory
5) The pre-commit hook errors on one of the configs for no reason I can discern; I think it is probably actually a glitch in their yaml parser but I am not inclined to try to fix the yaml parser in check-yaml.
6) Even if that config is incorrect, which I do not think it is, it's better to have the same error in both repos than a mystery error that only exists in one of them.