### PR TITLE
Improve argument validation for Flash-attn + SWA

### DIFF
--- a/configs/mistral/7B.yml
+++ b/configs/mistral/7B.yml
@@ -11,7 +11,7 @@
   "num_kv_heads": 8,
   # per Mistral, Mistral-7B-v0.1 was pretrained with 8192 seqlen
   # and instruction tuned to 16384 seqlen, all with 4096 sliding window
-  "seq_length": 8192, 
+  "seq_length": 8192,
   "sliding_window_width": 4096,
   "max_position_embeddings": 131072,
   "pos_emb": "rotary",

--- a/configs/mistral/7B.yml
+++ b/configs/mistral/7B.yml
@@ -9,7 +9,9 @@
   "intermediate_size": 14336,
   "num_attention_heads": 32,
   "num_kv_heads": 8,
-  "seq_length": 4096,
+  # per Mistral, Mistral-7B-v0.1 was pretrained with 8192 seqlen
+  # and instruction tuned to 16384 seqlen, all with 4096 sliding window
+  "seq_length": 8192, 
   "sliding_window_width": 4096,
   "max_position_embeddings": 131072,
   "pos_emb": "rotary",

--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -111,7 +111,7 @@ Logging Arguments
 
 - **git_hash**: str
 
-    Default = d4a091a
+    Default = 11a2e9b
 
     current git hash of repository
 
@@ -1058,7 +1058,7 @@ Text Generation arguments
 
 - **prompt_end**: str
 
-    Default =
+    Default = 
 
 
     a single prompt's end. Defaults to newline
@@ -1100,7 +1100,7 @@ Text Generation arguments
 
 - **eval_results_prefix**: str
 
-    Default =
+    Default = 
 
     prefix to which to save evaluation results - final fp will be {eval_results_prefix}_eval_results_yy-mm-dd-HH-MM.json
 
@@ -1844,7 +1844,7 @@ Args for deepspeed config
 
     Default = None
 
-
+    
 
 
 
@@ -2144,3 +2144,4 @@ Args for deepspeed runner (deepspeed.launcher.runner).
     Default = None
 
     Adds a `--account` to the DeepSpeed launch command. In DeeperSpeed this is passed on to the SlurmLauncher as well. Sometimes necessary for cluster rules, or so I've heard.
+

--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -1058,7 +1058,7 @@ Text Generation arguments
 
 - **prompt_end**: str
 
-    Default = 
+    Default =
 
 
     a single prompt's end. Defaults to newline
@@ -1100,7 +1100,7 @@ Text Generation arguments
 
 - **eval_results_prefix**: str
 
-    Default = 
+    Default =
 
     prefix to which to save evaluation results - final fp will be {eval_results_prefix}_eval_results_yy-mm-dd-HH-MM.json
 
@@ -1844,7 +1844,7 @@ Args for deepspeed config
 
     Default = None
 
-    
+
 
 
 
@@ -2144,4 +2144,3 @@ Args for deepspeed runner (deepspeed.launcher.runner).
     Default = None
 
     Adds a `--account` to the DeepSpeed launch command. In DeeperSpeed this is passed on to the SlurmLauncher as well. Sometimes necessary for cluster rules, or so I've heard.
-

--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -111,7 +111,7 @@ Logging Arguments
 
 - **git_hash**: str
 
-    Default = a81ac3c
+    Default = c094c8c
 
     current git hash of repository
 

--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -111,7 +111,7 @@ Logging Arguments
 
 - **git_hash**: str
 
-    Default = 4ca9a8a
+    Default = a81ac3c
 
     current git hash of repository
 

--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -111,7 +111,7 @@ Logging Arguments
 
 - **git_hash**: str
 
-    Default = c094c8c
+    Default = d4a091a
 
     current git hash of repository
 

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -595,12 +595,10 @@ class ParallelSelfAttention(nn.Module):
 
             # only pass in window_size kwarg to flash-attn
             # if we use Sliding Window Attention.
-            # Flash attn defaults to (-1,-1), or 
+            # Flash attn defaults to (-1,-1), or
             # does not have this kwarg prior to v2.3.0
             extra_kwargs = (
-                {
-                    "window_size": (self.sliding_window_width, -1)
-                }    
+                {"window_size": (self.sliding_window_width, -1)}
                 if self.sliding_window_width is not None
                 else {}
             )

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -593,6 +593,17 @@ class ParallelSelfAttention(nn.Module):
                 output_size[0], output_size[2], output_size[1], -1
             )
 
+            # only pass in window_size kwarg to flash-attn
+            # if we use Sliding Window Attention.
+            # Flash attn defaults to (-1,-1), or 
+            # does not have this kwarg prior to v2.3.0
+            extra_kwargs = (
+                {
+                    "window_size": (self.sliding_window_width, -1)
+                }    
+                if self.sliding_window_width is not None
+                else {}
+            )
             if not self.training:
                 q_shape = query_layer.shape
                 k_shape = key_layer.shape
@@ -613,9 +624,7 @@ class ParallelSelfAttention(nn.Module):
                     max_seqlen_k,
                     softmax_scale=None,
                     causal=True,
-                    window_size=(self.sliding_window_width, -1)
-                    if self.sliding_window_width is not None
-                    else (-1, -1),
+                    **extra_kwargs,
                 )
                 output = output.reshape(q_shape)
             else:
@@ -626,9 +635,7 @@ class ParallelSelfAttention(nn.Module):
                     self.dropout_p if self.training else 0.0,
                     softmax_scale=None,
                     causal=True,
-                    window_size=(self.sliding_window_width, -1)
-                    if self.sliding_window_width is not None
-                    else (-1, -1),
+                    **extra_kwargs,
                 )
 
             matmul_result = output

--- a/megatron/neox_arguments/arguments.py
+++ b/megatron/neox_arguments/arguments.py
@@ -390,12 +390,6 @@ class NeoXArgs(*BASE_CLASSES):
 
             neox_args.wandb_group += "_" + wandb.util.generate_id()
 
-        if neox_args.sliding_window_width is not None:
-            _flash_version = packaging.version.Version(version("flash-attn"))
-            assert _flash_version >= packaging.version.Version(
-                "2.0.0"
-            ), f"Flash-Attention version ({str(_flash_version)}) must be >= 2.0.0 to support sliding window attention."
-
         neox_args.print()
 
         return neox_args
@@ -1080,10 +1074,16 @@ class NeoXArgs(*BASE_CLASSES):
                 assert all(
                     (attn_type == "flash") or (attn_type == "global")
                     for attn_type in self.attention_config
-                ), "GQA / MQA currently only compatible with Flash or standard global Attention"
+                ), "GQA / MQA currently only compatible with Flash or standard global/sliding window Attention"
                 assert (
                     self.num_kv_heads % self.model_parallel_size == 0
                 ), "Number of KV heads must be at least model_parallel_size for now!"
+        # Flash attention version >=2.3.0 required to combine Flash + Sliding Window Attention
+        if self.sliding_window_width is not None and "flash" in self.attention_config:
+            _flash_version = packaging.version.Version(version("flash-attn"))
+            assert _flash_version >= packaging.version.Version(
+                "2.3.0"
+            ), f"Flash-Attention version ({str(_flash_version)}) must be >= 2.3.0 to support sliding window attention."
 
         # Adding equal dataset weights if none are provided
         if self.train_data_paths and (self.train_data_weights is None):


### PR DESCRIPTION
As raised by @malteos , Flash attention requires not 2.0.0+ but version 2.3.0+ to support sliding_window_width. However also, sliding-window attention is supported in the absence of Flash.

This PR changes the argument validation to 1) check for version 2.3.0 and 2) only perform this check if "flash" type attention is used. Also, it doesn't pass window_size kwarg when not required, meaning we'll never give the invalid kwarg to flash versions < 2.3.0 .