### PR TITLE
Support Lion with Zero Optimizer

### DIFF
--- a/megatron/training.py
+++ b/megatron/training.py
@@ -538,9 +538,16 @@ def get_optimizer(model, neox_args):
             **neox_args.optimizer["params"],
         )
     elif neox_args.optimizer_type.lower() == "lion":
-        from .optimizers import Lion
+        # if we want the deepspeed zero lion...megatron lion will throw DeepSpeed Error
+        if neox_args.zero_optimization["stage"] != 0:
+            from deepspeed.ops.lion import FusedLion
+            lion_optimizer = FusedLion
+        # if not zero
+        else:
+            from .optimizers import Lion
+            lion_optimizer = Lion
 
-        optimizer = Lion(
+        optimizer = lion_optimizer(
             param_groups,
             weight_decay=neox_args.weight_decay,
             **neox_args.optimizer["params"],

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -541,10 +541,12 @@ def get_optimizer(model, neox_args):
         # if we want the deepspeed zero lion...megatron lion will throw DeepSpeed Error
         if neox_args.zero_optimization["stage"] != 0:
             from deepspeed.ops.lion import FusedLion
+
             lion_optimizer = FusedLion
         # if not zero
         else:
             from .optimizers import Lion
+
             lion_optimizer = Lion
 
         optimizer = lion_optimizer(

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,5 @@
 best_download
-git+https://github.com/EleutherAI/DeeperSpeed.git@a1af9e77fb690655aa4da35078c9a551e0aa2ba5#egg=deepspeed
+git+https://github.com/EleutherAI/DeeperSpeed.git@02e2ebf7dee6aaab3d89094ed470a4609763c742#egg=deepspeed
 ftfy>=6.0.1
 git+https://github.com/EleutherAI/lm_dataformat.git@4eec05349977071bf67fc072290b95e31c8dd836
 huggingface_hub>=0.11.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,5 @@
 best_download
-git+https://github.com/EleutherAI/DeeperSpeed.git@b9260436e7da3e297fc6bedfd27d9e69fbba6f5c#egg=deepspeed
+git+https://github.com/EleutherAI/DeeperSpeed.git@a1af9e77fb690655aa4da35078c9a551e0aa2ba5#egg=deepspeed
 ftfy>=6.0.1
 git+https://github.com/EleutherAI/lm_dataformat.git@4eec05349977071bf67fc072290b95e31c8dd836
 huggingface_hub>=0.11.0


### PR DESCRIPTION
Currently, if you try to use the following `optimizer` and `zero_optimizer` settings:

```yaml
   "optimizer": {
     "type": "Lion",
     "params": {
       "lr": 0.0006,
       "betas": [0.9, 0.999],
     }
   },
   "zero_optimization": {
    "stage": 1,
    "allgather_partitions": True,
    "allgather_bucket_size": 500000000,
    "overlap_comm": True,
    "reduce_scatter": True,
    "reduce_bucket_size": 500000000,
    "contiguous_gradients": True,
  },
```

You will encounter:

```shell
[2024-03-01 14:35:58,937] [INFO] [logging.py:96:log_dist] [Rank 0] DeepSpeed Basic Optimizer = Lion
    assert (
AssertionError: You are using an untested ZeRO Optimizer. Please add <"zero_allow_untested_optimizer": true> in the configuration file to use it.
[2024-03-01 14:35:58,937] [INFO] [utils.py:54:is_zero_supported_optimizer] Checking ZeRO support for optimizer=Lion type=<class 'megatron.optimizers.Lion'>
Traceback (most recent call last):
  File "/gpt-neox/train.py", line 34, in <module>
    main()
  File "/gpt-neox/train.py", line 30, in main
    pretrain(neox_args=neox_args)
  File "/gpt-neox/megatron/training.py", line 194, in pretrain
    model, optimizer, lr_scheduler = setup_model_and_optimizer(
  File "/gpt-neox/megatron/training.py", line 667, in setup_model_and_optimizer
    model, optimizer, _, lr_scheduler = deepspeed.initialize(
  File "/venv/lib64/python3.9/site-packages/deepspeed/__init__.py", line 180, in initialize
    engine = PipelineEngine(args=args,
  File "/venv/lib64/python3.9/site-packages/deepspeed/runtime/pipe/engine.py", line 55, in __init__
    super().__init__(*super_args, **super_kwargs)
  File "/venv/lib64/python3.9/site-packages/deepspeed/runtime/engine.py", line 309, in __init__
    self._configure_optimizer(optimizer, model_parameters)
  File "/venv/lib64/python3.9/site-packages/deepspeed/runtime/engine.py", line 1177, in _configure_optimizer
    optimizer_wrapper = self._do_optimizer_sanity_check(basic_optimizer)
  File "/venv/lib64/python3.9/site-packages/deepspeed/runtime/engine.py", line 1106, in _do_optimizer_sanity_check
    assert (
AssertionError: You are using an untested ZeRO Optimizer. Please add <"zero_allow_untested_optimizer": true> in the configuration file to use it.
```

This PR fixes that issue by selecting the correct version of Lion depending on whether zero is enabled.

The current version of DeeperSpeed that's pinned in `requirements.txt` doesn't incorporate the upstream DeepSpeed changes that include `FusedLion`, so a DeeperSpeed version bump is also necessary.  Recommend waiting to merge this until https://github.com/EleutherAI/DeeperSpeed/pull/60 is merged and the DeeperSpeed version in `requirements.txt` can be bumped to that merge commit.  That PR + this one have been tested for pipeline and tensor parallel training with FusedLion.  Verified original behavior (`megatron.optimizers.Lion`) in `zero_optimizer["stage"] = 0` case.

## `zero_optimizer["stage"] = 1` case

```shell
[2024-03-02 11:08:33,052] [INFO] [logging.py:96:log_dist] [Rank 0] DeepSpeed Basic Optimizer = FusedLion
[2024-03-02 11:08:33,052] [INFO] [utils.py:56:is_zero_supported_optimizer] Checking ZeRO support for optimizer=FusedLion type=<class 'deepspeed.ops.lion.fused_lion.FusedLion'>
[2024-03-02 11:08:33,052] [INFO] [logging.py:96:log_dist] [Rank 0]
```

## `zero_optimizer["stage"] = 0` case

```shell
[2024-03-02 11:19:04,115] [INFO] [logging.py:96:log_dist] [Rank 0] DeepSpeed Final Optimizer = Lion
```