### PR TITLE
Single node Pythia 14M training on ngc pytorch 24.02 container

### DIFF
--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -1058,7 +1058,7 @@ Text Generation arguments
 
 - **prompt_end**: str
 
-    Default = 
+    Default =
 
 
     a single prompt's end. Defaults to newline
@@ -1100,7 +1100,7 @@ Text Generation arguments
 
 - **eval_results_prefix**: str
 
-    Default = 
+    Default =
 
     prefix to which to save evaluation results - final fp will be {eval_results_prefix}_eval_results_yy-mm-dd-HH-MM.json
 
@@ -1844,7 +1844,7 @@ Args for deepspeed config
 
     Default = None
 
-    
+
 
 
 
@@ -2144,4 +2144,3 @@ Args for deepspeed runner (deepspeed.launcher.runner).
     Default = None
 
     Adds a `--account` to the DeepSpeed launch command. In DeeperSpeed this is passed on to the SlurmLauncher as well. Sometimes necessary for cluster rules, or so I've heard.
-

--- a/requirements/requirements-flashattention.txt
+++ b/requirements/requirements-flashattention.txt
@@ -1,1 +1,1 @@
-flash-attn==2.2.1
+flash-attn==2.5.6


### PR DESCRIPTION
Swapped the raw cuda container for the ngc pytorch 24.02 container.

This one has OpenMPI, PyTorch and Apex already installed, so those setup steps can be removed.

`flash-attn` was recently hotfixed for that container version, so 2.5.6 is a hard requirement.

To validate the setups, I ran a few training steps of Pythia 14M on 8xA100 and a 22B model on 8xA100 and 8xH100 w/ TP8.

The apt and pip install lists and requirements files could be cleaned up. E.g. trition is already present and gets downgraded. I will leave it like this for now in order to keep this PR small.

For multi node tests I will have to adapt the launcher first.