### PR TITLE
Cleaner dockerfile: Remove already installed deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,11 +26,11 @@ LABEL org.opencontainers.image.base.name="nvcr.io/nvidia/pytorch:24.02-py3"
 #### System package (uses default Python 3 version in Ubuntu 20.04)
 RUN apt-get update -y && \
     apt-get install -y \
-    git python3-dev libpython3-dev python3-pip sudo pdsh \
-    htop tmux zstd software-properties-common build-essential autotools-dev \
-    nfs-common pdsh cmake g++ gcc curl wget vim less unzip htop iftop iotop ca-certificates ssh \
-    rsync iputils-ping net-tools libcupti-dev libmlx4-1 infiniband-diags ibutils ibverbs-utils \
-    rdmacm-utils perftest rdma-core nano && \
+    python3-pip sudo pdsh \
+    htop tmux zstd software-properties-common \
+    nfs-common pdsh cmake htop iftop iotop ssh \
+    iputils-ping net-tools libcupti-dev libmlx4-1 infiniband-diags ibutils \
+    rdmacm-utils perftest rdma-core && \
     update-alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
     update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1 && \
     python -m pip install --upgrade pip && \
@@ -75,8 +75,6 @@ RUN mkdir -p /home/mchorse/.ssh /job && \
 #### Python packages
 COPY requirements/* ./
 RUN python -m pip install --no-cache-dir -r requirements.txt && pip install -r requirements-onebitadam.txt
-RUN python -m pip install -r requirements-sparseattention.txt
-RUN python -m pip install -r requirements-flashattention.txt
 RUN python -m pip install -r requirements-wandb.txt
 RUN python -m pip install protobuf==3.20.*
 


### PR DESCRIPTION
Cleaning up the Dockerfile after the ngc pytorch switch (#1170):

- Eliminate already installed apt packages
- sparse attn requirement lead to a triton downgrade
- flash attn is already part of the ngc container (in another version that is compatible with TE)

The flash-attn change might be required for TE, see the [TE setup script](https://github.com/NVIDIA/TransformerEngine/blob/b459ccc93549c13797f884271904e019ad7fa3db/setup.py#L268). The following error from the docker log was indicating so, too. I am not 100% sure if the version upper limit is a technological requirement, or just a precaution. In any case this is now resolved, plus there's no need to build flash-attn.

```
#14 10.98 Installing collected packages: flash-attn
#14 10.98   Attempting uninstall: flash-attn
#14 10.98     Found existing installation: flash-attn 2.4.2
#14 10.98     Uninstalling flash-attn-2.4.2:
#14 11.74       Successfully uninstalled flash-attn-2.4.2
#14 13.81 ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
#14 13.81 transformer-engine 1.3.0+5b90b7f requires flash-attn!=2.0.9,!=2.1.0,<=2.4.2,>=2.0.6, but you have flash-attn 2.5.6 which is incompatible.
#14 13.81 Successfully installed flash-attn-2.5.6
```

Training pythia14M works (with gpt-j-residual=false , see #1174)
Training a 20B model with TP8 works as well

Just a few steps on 8xH100, not to convergence :)