### PR TITLE
Fix documentation for --jsonl-keys argument of preprocess_data scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ optional arguments:
 input data:
   --input INPUT         Path to input jsonl files or lmd archive(s) - if using multiple archives, put them in a comma separated list
   --jsonl-keys JSONL_KEYS [JSONL_KEYS ...]
-                        space separate listed of keys to extract from jsonl. Defa
+                        space separate listed of keys to extract from jsonl. Default: text
   --num-docs NUM_DOCS   Optional: Number of documents in the input data (if known) for an accurate progress bar.
 
 tokenizer:

--- a/tools/datasets/README.md
+++ b/tools/datasets/README.md
@@ -18,7 +18,7 @@ input data:
   --input INPUT         Path to input jsonl files or lmd archive(s) - if using multiple archives, put them in a comma
                         separated list
   --jsonl-keys JSONL_KEYS [JSONL_KEYS ...]
-                        space separate listed of keys to extract from jsonl. Defa
+                        space separate listed of keys to extract from jsonl. Default: text
   --num-docs NUM_DOCS   Optional: Number of documents in the input data (if known) for an accurate progress bar.
 
 tokenizer:

--- a/tools/datasets/preprocess_data.py
+++ b/tools/datasets/preprocess_data.py
@@ -77,7 +77,7 @@ def get_args(input_args=None):
         "--jsonl-keys",
         nargs="+",
         default=["text"],
-        help="space separate listed of keys to extract from jsonl. Defa",
+        help="space separate listed of keys to extract from jsonl. Default: text",
     )
     group.add_argument(
         "--num-docs",

--- a/tools/datasets/preprocess_data_with_mask.py
+++ b/tools/datasets/preprocess_data_with_mask.py
@@ -166,7 +166,7 @@ def get_args():
         "--jsonl-keys",
         nargs="+",
         default=["text"],
-        help="space separate listed of keys to extract from jsonl. Defa",
+        help="space separate listed of keys to extract from jsonl. Default: text",
     )
     group.add_argument(
         "--mask-before-token",


### PR DESCRIPTION
This PR aims to fix a minor typo in documentation of `preprocess_data.py` and `preprocess_data_with_mask.py`.