### PR TITLE
Switch to using Cuda Flash Attn for Alibi

### DIFF
--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -111,7 +111,7 @@ Logging Arguments
 
 - **git_hash**: str
 
-    Default = 33f2842
+    Default = fdac107
 
     current git hash of repository
 

--- a/megatron/neox_arguments/arguments.py
+++ b/megatron/neox_arguments/arguments.py
@@ -1095,11 +1095,17 @@ class NeoXArgs(*BASE_CLASSES):
                     self.num_kv_heads % self.model_parallel_size == 0
                 ), "Number of KV heads must be at least model_parallel_size for now!"
         # Flash attention version >=2.3.0 required to combine Flash + Sliding Window Attention
-        if self.sliding_window_width is not None and "flash" in self.attention_config:
+        if "flash" in self.attention_config:
             _flash_version = packaging.version.Version(version("flash-attn"))
-            assert _flash_version >= packaging.version.Version(
-                "2.3.0"
-            ), f"Flash-Attention version ({str(_flash_version)}) must be >= 2.3.0 to support sliding window attention."
+            if self.sliding_window_width is not None:
+                assert _flash_version >= packaging.version.Version(
+                    "2.3.0"
+                ), f"Flash-Attention version ({str(_flash_version)}) must be >= 2.3.0 to support sliding window attention."
+            if self.pos_emb == "alibi":
+                if not _flash_version >= packaging.version.Version("2.4.0.post1"):
+                    print(
+                        f"Warning: Flash-Attention version ({str(_flash_version)}) must be >= 2.4.0.post1 to support AliBi. Falling back to flash-attn triton backend, but version 2.4.0.post1 or later will be required in future."
+                    )
 
         # Adding equal dataset weights if none are provided
         if self.train_data_paths and (self.train_data_weights is None):


### PR DESCRIPTION
Since 2.4.0.post1, Flash-attn has supported alibi_slopes in its cuda kernels, removing the need for using the triton backend. This PR switches over to using the cuda flash functions rather than triton for compatible flash versions, but retains compatibility for Alibi + flash<2.4.0 via triton for now with a warning.

Future PRs could potentially add the updated Triton implementation from the triton repo which could be faster on H100s, as this is distinct from the triton impl. in the flash attention repo. 