### PR TITLE
Mamba + Tensor Parallel Support

### DIFF
--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -111,7 +111,7 @@ Logging Arguments
 
 - **git_hash**: str
 
-    Default = 33f2842
+    Default = 696454f
 
     current git hash of repository
 

--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -111,7 +111,7 @@ Logging Arguments
 
 - **git_hash**: str
 
-    Default = fdac107
+    Default = f70c54d
 
     current git hash of repository
 

--- a/megatron/model/gpt2_model.py
+++ b/megatron/model/gpt2_model.py
@@ -37,7 +37,7 @@ from megatron.model.transformer import (
     ParallelLinear,
 )
 from megatron.model.gmlp import GMLPBlock
-from megatron.model.mamba import MambaResidualLayerPipe, ParallelMambaResidualLayerPipe
+from megatron.model.mamba import ParallelMambaResidualLayerPipe
 from megatron.model.word_embeddings import EmbeddingPipe, SoftEmbedding
 
 # Pipeline parallelism
@@ -138,7 +138,6 @@ class GPT2ModelPipe(PipelineModule, torch.nn.Module):
             checkpointable_layers=[
                 "GMLPBlock",
                 "ParallelTransformerLayerPipe",
-                "MambaResidualLayerPipe",
                 "ParallelMambaResidualLayerPipe",
             ],
         )
@@ -175,7 +174,7 @@ class GPT2ModelPipe(PipelineModule, torch.nn.Module):
             checkpointable_layers=[
                 "GMLPBlock",
                 "ParallelTransformerLayerPipe",
-                "MambaResidualLayerPipe",
+                "ParallelMambaResidualLayerPipe",
             ],
         )
 
@@ -254,13 +253,6 @@ class GPT2ModelPipe(PipelineModule, torch.nn.Module):
                 )
             elif layer_type in ["mamba"]:
                 self.specs.append(
-                    # (LayerSpec(
-                    #     MambaResidualLayerPipe,
-                    #     neox_args=self.neox_args,
-                    #     init_method=self.init_method,
-                    #     output_layer_init_method=self.output_layer_init_method,
-                    #     layer_number=i,
-                    # ) if self.neox_args.model_parallel_size == 1 else
                     LayerSpec(
                         ParallelMambaResidualLayerPipe,
                         neox_args=self.neox_args,
@@ -269,8 +261,6 @@ class GPT2ModelPipe(PipelineModule, torch.nn.Module):
                         layer_number=i,
                     )
                 )
-                if self.neox_args.model_parallel_size > 1:
-                    print("Using ParallelMambaLayer")
             else:
                 self.specs.append(
                     LayerSpec(

--- a/megatron/model/mamba/__init__.py
+++ b/megatron/model/mamba/__init__.py
@@ -1,6 +1,4 @@
 from .mamba import (
-    MambaResidualLayer,
-    MambaResidualLayerPipe,
     ParallelMambaResidualLayer,
     ParallelMambaResidualLayerPipe,
 )

--- a/megatron/model/mamba/__init__.py
+++ b/megatron/model/mamba/__init__.py
@@ -1,1 +1,6 @@
-from .mamba import MambaResidualLayer, MambaResidualLayerPipe
+from .mamba import (
+    MambaResidualLayer,
+    MambaResidualLayerPipe,
+    ParallelMambaResidualLayer,
+    ParallelMambaResidualLayerPipe,
+)

--- a/megatron/model/mamba/mamba.py
+++ b/megatron/model/mamba/mamba.py
@@ -58,22 +58,33 @@ class ParallelMambaBlock(nn.Module):
         self.dt_min, self.dt_max, self.dt_init_floor = 0.001, 0.1, 1e-4
         assert self.dt_init in ["constant", "random"]
 
-        # up-projection.
-        self.in_proj = nn.Linear(
-            self.d_model,
-            self.d_inner * 2,
-            bias=neox_args.mamba_use_bias_in_linears,
-            **factory_kwargs,
-        )
-        init_method(self.in_proj.weight)
+        # TP-specific setup
+        world_size = mpu.get_model_parallel_world_size()
+        self.d_inner_per_rank = mpu.divide(self.d_inner, world_size)
 
-        # convolution.
+        if neox_args.mamba_inner_func_fusion and world_size > 1:
+            # as with gpt-j residual, we must manually reduce output from final proj
+            # across TP ranks, since it is not done by fused mamba_inner_fn .
+            self.reduce = mpu.mappings.reduce_from_model_parallel_region
+
+        # up-projection.
+        self.in_proj = mpu.ColumnParallelLinear(
+            neox_args=neox_args,
+            input_size=self.d_model,
+            output_size=self.d_inner * 2,
+            gather_output=False,
+            init_method=init_method,
+            skip_bias_add=not neox_args.mamba_use_bias_in_linears,
+            bias=neox_args.mamba_use_bias_in_linears,
+        )
+
+        # convolution (parallelized across d_inner)
         self.conv1d = nn.Conv1d(
-            in_channels=self.d_inner,
-            out_channels=self.d_inner,
+            in_channels=self.d_inner_per_rank,
+            out_channels=self.d_inner_per_rank,
             bias=neox_args.mamba_use_bias_in_conv,
             kernel_size=self.d_conv,
-            groups=self.d_inner,
+            groups=self.d_inner_per_rank,
             padding=self.d_conv - 1,
             **factory_kwargs,
         )
@@ -81,21 +92,24 @@ class ParallelMambaBlock(nn.Module):
         # Uncertain why
         self.conv1d.to(self.precision)
 
-        self.act_fn = F.silu  # we do not allow for
+        self.act_fn = F.silu  # we do not allow for other activation fns
 
         # x_proj corresponds to s_B(x), s_C(x), s_Delta(x)
         # in https://arxiv.org/pdf/2312.00752.pdf Algorithm 2
         # (computes data-dependent B, C, Delta/dt)
-        self.x_proj = nn.Linear(
-            self.d_inner,
-            self.dt_rank + self.d_state * 2,
+        self.x_proj = mpu.RowParallelLinear(
+            neox_args=neox_args,
+            input_size=self.d_inner,
+            output_size=self.dt_rank + self.d_state * 2,
+            input_is_parallel=True,
+            init_method=init_method,
+            skip_bias_add=not neox_args.mamba_use_bias_in_linears,
+            parallel_output=True,
             bias=neox_args.mamba_use_bias_in_linears,
-            **factory_kwargs,
         )
-        init_method(self.x_proj.weight)
 
         # up-project dt / Delta from dt_rank to d_inner
-        # dt_proj 's bias is a special case and I believe we should keep it turned on -- Alg. 2 in the Mamba paper (https://arxiv.org/abs/2312.00752)
+        # dt_proj 's bias is a special case and should be kept always turned on -- Alg. 2 in the Mamba paper (https://arxiv.org/abs/2312.00752)
         # defines Delta as Delta = Tau_{Delta}(Parameter + s_{Delta}(x)) where s_{Delta}(x) = Broadcast_{D}(Linear_{1}(x))
         # or as they further explain in section 3.6 can be also s_{Delta}(x) = Linear_{D}(Linear_{R}(x)) where Linear_R
         # is the delta portion of x_proj and Linear_D is the dt_proj weight. Then, the Parameter term from Alg. 2 can
@@ -133,7 +147,7 @@ class ParallelMambaBlock(nn.Module):
                 device=torch.cuda.current_device(),
             ),
             "n -> d n",
-            d=self.d_inner,
+            d=self.d_inner_per_rank,
         ).contiguous()
         A_log = torch.log(A).to(
             torch.float32
@@ -150,7 +164,9 @@ class ParallelMambaBlock(nn.Module):
         # D parameter
         self.D = nn.Parameter(
             torch.ones(
-                self.d_inner, device=torch.cuda.current_device(), dtype=torch.float32
+                self.d_inner_per_rank,
+                device=torch.cuda.current_device(),
+                dtype=torch.float32,
             )
         ).to(
             torch.float32
@@ -163,14 +179,20 @@ class ParallelMambaBlock(nn.Module):
         if self.neox_args.mamba_selective_fp32_params:
             self.D._deepspeed_no_cast = True
 
-        # out down-projection
-        self.out_proj = nn.Linear(
-            self.d_inner,
-            self.d_model,
+        # out down-projection.
+        # use "single_residual_scaled_normal"
+        # for output_layer_init_method
+        # to perform gpt-2 style scaled init as done in Mamba paper.
+        self.out_proj = mpu.RowParallelLinear(
+            neox_args=neox_args,
+            input_size=self.d_inner,
+            output_size=self.d_model,
+            input_is_parallel=True,
+            init_method=output_layer_init_method,
+            skip_bias_add=not neox_args.mamba_use_bias_in_linears,
             bias=neox_args.mamba_use_bias_in_linears,
-            **factory_kwargs,
+            parallel_output=False,
         )
-        output_layer_init_method(self.out_proj.weight)
 
     def selective_scan(
         self,
@@ -224,14 +246,8 @@ class ParallelMambaBlock(nn.Module):
         seqlen, batch, dim = hidden_states.shape
 
         # first up: perform in_proj
-        xz = einops.rearrange(
-            self.in_proj.weight @ einops.rearrange(hidden_states, "l b d -> d (b l)"),
-            "d (b l) -> b d l",
-            l=seqlen,
-        )
-
-        if self.in_proj.bias is not None:
-            xz = xz + einops.rearrange(self.in_proj.bias.to(dtype=xz.dtype), "d -> d 1")
+        xz, _ = self.in_proj(hidden_states)
+        xz = einops.rearrange(xz, "l b d -> b d l")
 
         A = -torch.exp(self.A_log.float())  # (d_inner, d_state)
 
@@ -262,6 +278,12 @@ class ParallelMambaBlock(nn.Module):
                 delta_bias=self.dt_proj.bias.float(),
                 delta_softplus=True,
             )
+            if getattr(self, "reduce", None):
+                # manually reduce after mamba_inner_fn
+                # to collect outputs from different TP ranks.
+                # handled by running self.out_proj(y) below
+                # so only needed here.
+                out = self.reduce(out)
 
             out = einops.rearrange(out, "b l h -> l b h")
 
@@ -292,7 +314,7 @@ class ParallelMambaBlock(nn.Module):
         # ==============
 
         # project: perform s_B, s_C, s_Delta projections
-        x_dbl = self.x_proj(einops.rearrange(x, "b d l -> (b l) d"))
+        x_dbl, _ = self.x_proj(einops.rearrange(x, "b d l -> (b l) d"))
         # split into component dt, B, C
         dt, B, C = torch.split(
             x_dbl, [self.dt_rank, self.d_state, self.d_state], dim=-1
@@ -324,7 +346,7 @@ class ParallelMambaBlock(nn.Module):
         # ===============
         y = einops.rearrange(y, "b d l -> b l d")
 
-        out = self.out_proj(y)
+        out, _ = self.out_proj(y)
 
         out = einops.rearrange(out, "b l h -> l b h")
 

--- a/megatron/model/mamba/mamba.py
+++ b/megatron/model/mamba/mamba.py
@@ -21,7 +21,7 @@ except ModuleNotFoundError:
 from megatron.model.norms import get_norm
 from megatron import mpu
 
-# Mamba sublayer. supports TP, PP still not working
+# Mamba sublayer, with tensor parallelism
 class ParallelMambaBlock(nn.Module):
     def __init__(
         self,

--- a/megatron/model/mamba/mamba.py
+++ b/megatron/model/mamba/mamba.py
@@ -19,10 +19,10 @@ except ModuleNotFoundError:
     pass
 
 from megatron.model.norms import get_norm
+from megatron import mpu
 
-
-# Mamba layer, without parallelism.
-class MambaBlock(nn.Module):
+# Mamba sublayer. supports TP, PP still not working
+class ParallelMambaBlock(nn.Module):
     def __init__(
         self,
         neox_args,
@@ -376,6 +376,375 @@ class MambaResidualLayerPipe(MambaResidualLayer):
         assert (
             len(args) == 2
         ), "MambaResidualLayerPipe expects 2 arguments - hidden_states and attention_mask"
+        hidden_states, attention_mask = args
+        # we are returning just [hidden_states, mask]
+        return super().forward(hidden_states, attention_mask), attention_mask
+
+
+# Mamba layer, with parallelism.
+class ParallelMambaBlock(nn.Module):
+    def __init__(
+        self,
+        neox_args,
+        init_method,
+        output_layer_init_method,
+        # ...
+    ):
+        super().__init__()
+
+        self.neox_args = neox_args
+
+        dtype = (
+            torch.float16 if neox_args.precision == "fp16" else torch.bfloat16
+        )  # TODO: full fp32 support
+        factory_kwargs = {"device": torch.cuda.current_device(), "dtype": dtype}
+
+        # basic setup
+        self.d_model = neox_args.hidden_size
+        self.d_state = 16  # neox_args.mamba_state_dim
+        self.d_conv = 4  # neox_args.mamba_conv_dim
+        self.expand = 2
+        self.d_inner = int(self.expand * self.d_model)
+        self.dt_rank = math.ceil(
+            self.d_model / 16
+        )  # if not neox_args.mamba_dt_rank else neox_args.mamba_dt_rank
+        self.dt_scale = 1.0  # TODO: should this be configurable?
+
+        self.dt_init = "random"
+        self.dt_min, self.dt_max, self.dt_init_floor = 0.001, 0.1, 1e-4
+        assert self.dt_init in ["constant", "random"]
+
+        self.use_bias = False  # TODO: add arg for this
+
+        # TP-specific setup
+        world_size = mpu.get_model_parallel_world_size()
+        self.d_inner_per_rank = mpu.divide(self.d_inner, world_size)
+
+        if neox_args.mamba_inner_func_fusion and world_size > 1:
+            # as with gpt-j residual, we must manually reduce output from final proj
+            # but only in the TP and
+            self.reduce = mpu.mappings.reduce_from_model_parallel_region
+
+        # up-projection in MambaBlock.
+        self.in_proj = mpu.ColumnParallelLinear(
+            neox_args=neox_args,
+            input_size=self.d_model,
+            output_size=self.d_inner * 2,
+            gather_output=False,
+            init_method=init_method,
+            skip_bias_add=not self.use_bias,
+            bias=self.use_bias,
+            # **factory_kwargs,
+        )
+
+        # convolution (parallelized across d_inner)
+        self.conv1d = nn.Conv1d(
+            in_channels=self.d_inner_per_rank,
+            out_channels=self.d_inner_per_rank,
+            bias=True,
+            kernel_size=self.d_conv,
+            groups=self.d_inner_per_rank,
+            padding=self.d_conv - 1,
+            **factory_kwargs,
+        )
+        self.conv1d.to(
+            factory_kwargs["dtype"]
+        )  # Conv1d bias requires cast for some reason
+
+        self.act_fn = nn.SiLU()  # TODO: import from megatron.model.activations
+
+        # x_proj corresponds to s_B(x), s_C(x), s_Delta(x)
+        # in https://arxiv.org/pdf/2312.00752.pdf Algorithm 2
+        self.x_proj = mpu.RowParallelLinear(
+            neox_args=neox_args,
+            input_size=self.d_inner,
+            output_size=self.dt_rank + self.d_state * 2,
+            input_is_parallel=True,
+            init_method=init_method,
+            skip_bias_add=not self.use_bias,
+            parallel_output=True,
+            bias=False,
+        )
+
+        # up-project dt / Delta from dt_rank to d_inner
+        self.dt_proj = nn.Linear(
+            self.dt_rank, self.d_inner_per_rank, bias=True, **factory_kwargs
+        )
+
+        # special init for dt_proj
+        dt_init_std = (self.dt_rank**-0.5) * self.dt_scale
+        if self.dt_init == "constant":
+            nn.init.constant_(self.dt_proj.weight, dt_init_std)
+        elif self.dt_init == "random":
+            nn.init.uniform_(self.dt_proj.weight, -dt_init_std, dt_init_std)
+        else:
+            raise NotImplementedError
+
+        # more dt_proj init stuff. copied from https://github.com/state-spaces/mamba/blob/009bec5ee37f586844a3fc89c040a9c1a9d8badf/mamba_ssm/modules/mamba_simple.py#L91-L101
+        dt = torch.exp(
+            torch.rand(self.d_inner_per_rank, **factory_kwargs)
+            * (math.log(self.dt_max) - math.log(self.dt_min))
+            + math.log(self.dt_min)
+        ).clamp(min=self.dt_init_floor)
+        # Inverse of softplus: https://github.com/pytorch/pytorch/issues/72759
+        inv_dt = dt + torch.log(-torch.expm1(-dt))
+        with torch.no_grad():
+            self.dt_proj.bias.copy_(inv_dt)
+        # Our initialization would set all Linear.bias to zero, need to mark this one as _no_reinit
+        self.dt_proj.bias._no_reinit = True
+
+        # initialize A . uses S4D real initialization #TODO: add a flag controlling this
+        A = einops.repeat(
+            torch.arange(
+                1,
+                self.d_state + 1,
+                dtype=torch.float32,
+                device=torch.cuda.current_device(),
+            ),
+            "n -> d n",
+            d=self.d_inner_per_rank,
+        ).contiguous()
+        A_log = torch.log(A).to(
+            torch.float32
+        )  # important! # TODO: ensure DeepSpeed doesn't muck with A's dtype
+        self.A_log = nn.Parameter(A_log)
+        self.A_log._no_weight_decay = (
+            True  # TODO: ensure NeoX handles these weight decay properties right
+        )
+        self.A_log._deepspeed_no_cast = True
+
+        # D parameter
+        self.D = nn.Parameter(
+            torch.ones(
+                self.d_inner_per_rank,
+                device=torch.cuda.current_device(),
+                dtype=torch.float32,
+            )
+        ).to(
+            torch.float32
+        )  # Important? Keep in fp32
+        self.D._no_weight_decay = True  # TODO: same as A_log weight decay, see above
+        self.D._deepspeed_no_cast = True
+
+        self.out_proj = mpu.RowParallelLinear(
+            neox_args=neox_args,
+            input_size=self.d_inner,
+            output_size=self.d_model,
+            input_is_parallel=True,
+            init_method=output_layer_init_method,
+            skip_bias_add=not self.use_bias,
+            bias=self.use_bias,
+            parallel_output=False,
+        )
+
+        # TODO: init out_proj following https://github.com/state-spaces/mamba/blob/ce59daea3a090d011d6476c6e5b97f6d58ddad8b/mamba_ssm/models/mixer_seq_simple.py#L54
+
+    def selective_scan(
+        self,
+        x,
+        dt,
+        A,
+        B,
+        C,
+        D,
+        z=None,
+        delta_bias=None,
+        delta_softplus=True,
+    ):
+
+        if not self.neox_args.mamba_selective_scan_fusion:
+            y = selective_scan_ref(
+                u=x,
+                delta=dt,
+                A=A,
+                B=B,
+                C=C,
+                D=D,
+                z=z,
+                delta_bias=delta_bias,
+                delta_softplus=delta_softplus,
+                return_last_state=False,
+            )
+        else:
+            y = selective_scan_fn(
+                x,
+                dt,
+                A,
+                B,
+                C,
+                D=D,
+                z=z,
+                delta_bias=delta_bias,
+                delta_softplus=delta_softplus,
+                return_last_state=False,
+            )
+
+        return y
+
+    def forward(self, hidden_states):
+        """ """
+        assert self.training, "Mamba in NeoX does not support inference!"
+
+        # hidden_states: [sq, b, h]
+        seqlen, batch, dim = hidden_states.shape
+
+        # TODO: support inference in separate method
+        # For now, only handle training (parallel scan).
+
+        # first up: perform in_proj
+        xz, _ = self.in_proj(hidden_states)
+        xz = einops.rearrange(xz, "l b d -> b d l")
+
+        A = -torch.exp(
+            self.A_log.float()
+        )  # (d_inner, d_state) # TODO: move this to right before selective scan?
+
+        if self.neox_args.mamba_inner_func_fusion:
+            # mamba provides a mamba_inner fn that computes the entire (post-in_proj) Mamba block.
+            # we want to use it if we can.
+            out = mamba_inner_fn(
+                xz,
+                self.conv1d.weight,
+                self.conv1d.bias.to(
+                    torch.float16
+                ),  # for some bizarre reason this becomes fp32 sometime after init
+                self.x_proj.weight,  # TODO: need to pass the right portion of params?
+                self.dt_proj.weight,
+                self.out_proj.weight,
+                self.out_proj.bias,
+                A,
+                None,  # B is input-dependent, will compute from x_proj
+                None,  # C is input-dependent, will compute from x_proj
+                self.D.float(),
+                delta_bias=self.dt_proj.bias.float(),
+                delta_softplus=True,
+            )
+            if getattr(self, "reduce", None):
+                # manually reduce after mamba_inner_fn
+                # to collect outputs from different TP ranks.
+                # handled by running self.out_proj(y) below
+                # so only needed here.
+                out = self.reduce(out)
+
+            out = einops.rearrange(out, "b l h -> l b h")
+
+            return out
+
+        x, z = xz.chunk(2, dim=1)
+
+        # ===========
+        # Convolution
+        # ===========
+
+        if not self.neox_args.mamba_causal_conv_fusion:
+            self.conv1d.to(
+                torch.float16
+            )  # don't need if not hacking DeepSpeed to use fp32 A_log, D
+            x = self.act_fn(self.conv1d(x)[..., :seqlen])
+        else:
+            # Note: this requires silu to be used.
+            x = causal_conv1d_fn(
+                x=x,
+                weight=einops.rearrange(self.conv1d.weight, "d 1 w -> d w"),
+                bias=self.conv1d.bias.to(torch.float16),
+                activation="silu",
+            )
+
+        # ==============
+        # SSM Projection
+        # ==============
+
+        # project: perform s_B, s_C, s_Delta projections
+        x_dbl, _ = self.x_proj(einops.rearrange(x, "b d l -> (b l) d"))  # shape (bl d)
+
+        # split into component dt, B, C
+        dt, B, C = torch.split(
+            x_dbl, [self.dt_rank, self.d_state, self.d_state], dim=-1
+        )
+
+        # up-project Delta / dt
+        dt = self.dt_proj.weight @ dt.t()
+        dt = einops.rearrange(dt, "d (b l) -> b d l", l=seqlen)
+
+        # rearrange B, C
+        B = einops.rearrange(B, "(b l) d_state -> b d_state l", l=seqlen).contiguous()
+        C = einops.rearrange(C, "(b l) d_state -> b d_state l", l=seqlen).contiguous()
+
+        y = self.selective_scan(
+            x,
+            dt,
+            A,
+            B,
+            C,
+            self.D.float(),  # TODO: why's this cast here?
+            z=z,
+            delta_bias=self.dt_proj.bias.float(),
+            delta_softplus=True,
+            # return_last_state, #TODO: inference concerns
+        )
+
+        # ===============
+        # Down-Projection
+        # ===============
+        y = einops.rearrange(y, "b d l -> b l d")
+
+        out, _ = self.out_proj(y)
+
+        out = einops.rearrange(
+            out, "b l h -> l b h"
+        )  # TODO: cutting down on rearranges would be nice
+
+        return out
+
+
+class ParallelMambaResidualLayer(nn.Module):
+    """
+    Pre-norm Mamba Block with residual connection. No parallelism yet supported.
+    """
+
+    def __init__(
+        self,
+        neox_args,
+        init_method,
+        output_layer_init_method,
+        layer_number,
+    ):
+        super().__init__()
+        # TODO: allow for residual in fp32 if it helps?
+        self.layer_number = layer_number
+
+        norm, eps = get_norm(neox_args)
+
+        self.norm = norm(neox_args.hidden_size, eps=eps)
+
+        # TODO: dropout
+
+        self.mixer = ParallelMambaBlock(
+            neox_args=neox_args,
+            init_method=init_method,
+            output_layer_init_method=output_layer_init_method,
+        )
+
+    def forward(self, x, attention_mask=None, layer_past=None):
+
+        # pseudocode:
+        # x = x + mixer(norm(x))
+        residual = x
+
+        hidden_states = self.mixer(
+            self.norm(x)
+        )  # TODO: do norm in fp32? what is it by default
+
+        return hidden_states + residual
+
+
+class ParallelMambaResidualLayerPipe(ParallelMambaResidualLayer):
+    """Extends MambaResidualLayer to forward attention_mask through the pipeline. DeepSpeed requires this."""
+
+    def forward(self, args):
+        assert (
+            len(args) == 2
+        ), "ParallelMambaResidualLayerPipe expects 2 arguments - hidden_states and attention_mask"
         hidden_states, attention_mask = args
         # we are returning just [hidden_states, mask]
         return super().forward(hidden_states, attention_mask), attention_mask

--- a/megatron/model/mamba/mamba.py
+++ b/megatron/model/mamba/mamba.py
@@ -115,7 +115,7 @@ class ParallelMambaBlock(nn.Module):
         # is the delta portion of x_proj and Linear_D is the dt_proj weight. Then, the Parameter term from Alg. 2 can
         # be viewed as the bias term in dt_proj, with a special initialization from https://arxiv.org/abs/2206.12037
         self.dt_proj = nn.Linear(
-            self.dt_rank, self.d_inner, bias=True, **factory_kwargs
+            self.dt_rank, self.d_inner_per_rank, bias=True, **factory_kwargs
         )
 
         # special init for dt_proj
@@ -129,7 +129,7 @@ class ParallelMambaBlock(nn.Module):
 
         # more dt_proj init stuff. copied from https://github.com/state-spaces/mamba/blob/009bec5ee37f586844a3fc89c040a9c1a9d8badf/mamba_ssm/modules/mamba_simple.py#L91-L101
         dt = torch.exp(
-            torch.rand(self.d_inner, **factory_kwargs)
+            torch.rand(self.d_inner_per_rank, **factory_kwargs)
             * (math.log(self.dt_max) - math.log(self.dt_min))
             + math.log(self.dt_min)
         ).clamp(min=self.dt_init_floor)
@@ -353,7 +353,7 @@ class ParallelMambaBlock(nn.Module):
         return out
 
 
-class MambaResidualLayer(nn.Module):
+class ParallelMambaResidualLayer(nn.Module):
     """
     Pre-norm Mamba Block with residual connection. No parallelism yet supported.
     """
@@ -374,7 +374,7 @@ class MambaResidualLayer(nn.Module):
 
         self.norm = norm(neox_args.hidden_size, eps=eps)
 
-        self.mixer = MambaBlock(
+        self.mixer = ParallelMambaBlock(
             neox_args=neox_args,
             init_method=init_method,
             output_layer_init_method=output_layer_init_method,
@@ -391,382 +391,13 @@ class MambaResidualLayer(nn.Module):
         return hidden_states + residual
 
 
-class MambaResidualLayerPipe(MambaResidualLayer):
-    """Extends MambaResidualLayer to forward attention_mask through the pipeline. DeepSpeed requires this."""
-
-    def forward(self, args):
-        assert (
-            len(args) == 2
-        ), "MambaResidualLayerPipe expects 2 arguments - hidden_states and attention_mask"
-        hidden_states, attention_mask = args
-        # we are returning just [hidden_states, mask]
-        return super().forward(hidden_states, attention_mask), attention_mask
-
-
-# Mamba layer, with parallelism.
-class ParallelMambaBlock(nn.Module):
-    def __init__(
-        self,
-        neox_args,
-        init_method,
-        output_layer_init_method,
-        # ...
-    ):
-        super().__init__()
-
-        self.neox_args = neox_args
-
-        dtype = (
-            torch.float16 if neox_args.precision == "fp16" else torch.bfloat16
-        )  # TODO: full fp32 support
-        factory_kwargs = {"device": torch.cuda.current_device(), "dtype": dtype}
-
-        # basic setup
-        self.d_model = neox_args.hidden_size
-        self.d_state = 16  # neox_args.mamba_state_dim
-        self.d_conv = 4  # neox_args.mamba_conv_dim
-        self.expand = 2
-        self.d_inner = int(self.expand * self.d_model)
-        self.dt_rank = math.ceil(
-            self.d_model / 16
-        )  # if not neox_args.mamba_dt_rank else neox_args.mamba_dt_rank
-        self.dt_scale = 1.0  # TODO: should this be configurable?
-
-        self.dt_init = "random"
-        self.dt_min, self.dt_max, self.dt_init_floor = 0.001, 0.1, 1e-4
-        assert self.dt_init in ["constant", "random"]
-
-        self.use_bias = False  # TODO: add arg for this
-
-        # TP-specific setup
-        world_size = mpu.get_model_parallel_world_size()
-        self.d_inner_per_rank = mpu.divide(self.d_inner, world_size)
-
-        if neox_args.mamba_inner_func_fusion and world_size > 1:
-            # as with gpt-j residual, we must manually reduce output from final proj
-            # but only in the TP and
-            self.reduce = mpu.mappings.reduce_from_model_parallel_region
-
-        # up-projection in MambaBlock.
-        self.in_proj = mpu.ColumnParallelLinear(
-            neox_args=neox_args,
-            input_size=self.d_model,
-            output_size=self.d_inner * 2,
-            gather_output=False,
-            init_method=init_method,
-            skip_bias_add=not self.use_bias,
-            bias=self.use_bias,
-            # **factory_kwargs,
-        )
-
-        # convolution (parallelized across d_inner)
-        self.conv1d = nn.Conv1d(
-            in_channels=self.d_inner_per_rank,
-            out_channels=self.d_inner_per_rank,
-            bias=True,
-            kernel_size=self.d_conv,
-            groups=self.d_inner_per_rank,
-            padding=self.d_conv - 1,
-            **factory_kwargs,
-        )
-        self.conv1d.to(
-            factory_kwargs["dtype"]
-        )  # Conv1d bias requires cast for some reason
-
-        self.act_fn = nn.SiLU()  # TODO: import from megatron.model.activations
-
-        # x_proj corresponds to s_B(x), s_C(x), s_Delta(x)
-        # in https://arxiv.org/pdf/2312.00752.pdf Algorithm 2
-        self.x_proj = mpu.RowParallelLinear(
-            neox_args=neox_args,
-            input_size=self.d_inner,
-            output_size=self.dt_rank + self.d_state * 2,
-            input_is_parallel=True,
-            init_method=init_method,
-            skip_bias_add=not self.use_bias,
-            parallel_output=True,
-            bias=False,
-        )
-
-        # up-project dt / Delta from dt_rank to d_inner
-        self.dt_proj = nn.Linear(
-            self.dt_rank, self.d_inner_per_rank, bias=True, **factory_kwargs
-        )
-
-        # special init for dt_proj
-        dt_init_std = (self.dt_rank**-0.5) * self.dt_scale
-        if self.dt_init == "constant":
-            nn.init.constant_(self.dt_proj.weight, dt_init_std)
-        elif self.dt_init == "random":
-            nn.init.uniform_(self.dt_proj.weight, -dt_init_std, dt_init_std)
-        else:
-            raise NotImplementedError
-
-        # more dt_proj init stuff. copied from https://github.com/state-spaces/mamba/blob/009bec5ee37f586844a3fc89c040a9c1a9d8badf/mamba_ssm/modules/mamba_simple.py#L91-L101
-        dt = torch.exp(
-            torch.rand(self.d_inner_per_rank, **factory_kwargs)
-            * (math.log(self.dt_max) - math.log(self.dt_min))
-            + math.log(self.dt_min)
-        ).clamp(min=self.dt_init_floor)
-        # Inverse of softplus: https://github.com/pytorch/pytorch/issues/72759
-        inv_dt = dt + torch.log(-torch.expm1(-dt))
-        with torch.no_grad():
-            self.dt_proj.bias.copy_(inv_dt)
-        # Our initialization would set all Linear.bias to zero, need to mark this one as _no_reinit
-        self.dt_proj.bias._no_reinit = True
-
-        # initialize A . uses S4D real initialization #TODO: add a flag controlling this
-        A = einops.repeat(
-            torch.arange(
-                1,
-                self.d_state + 1,
-                dtype=torch.float32,
-                device=torch.cuda.current_device(),
-            ),
-            "n -> d n",
-            d=self.d_inner_per_rank,
-        ).contiguous()
-        A_log = torch.log(A).to(
-            torch.float32
-        )  # important! # TODO: ensure DeepSpeed doesn't muck with A's dtype
-        self.A_log = nn.Parameter(A_log)
-        self.A_log._no_weight_decay = (
-            True  # TODO: ensure NeoX handles these weight decay properties right
-        )
-        self.A_log._deepspeed_no_cast = True
-
-        # D parameter
-        self.D = nn.Parameter(
-            torch.ones(
-                self.d_inner_per_rank,
-                device=torch.cuda.current_device(),
-                dtype=torch.float32,
-            )
-        ).to(
-            torch.float32
-        )  # Important? Keep in fp32
-        self.D._no_weight_decay = True  # TODO: same as A_log weight decay, see above
-        self.D._deepspeed_no_cast = True
-
-        self.out_proj = mpu.RowParallelLinear(
-            neox_args=neox_args,
-            input_size=self.d_inner,
-            output_size=self.d_model,
-            input_is_parallel=True,
-            init_method=output_layer_init_method,
-            skip_bias_add=not self.use_bias,
-            bias=self.use_bias,
-            parallel_output=False,
-        )
-
-        # TODO: init out_proj following https://github.com/state-spaces/mamba/blob/ce59daea3a090d011d6476c6e5b97f6d58ddad8b/mamba_ssm/models/mixer_seq_simple.py#L54
-
-    def selective_scan(
-        self,
-        x,
-        dt,
-        A,
-        B,
-        C,
-        D,
-        z=None,
-        delta_bias=None,
-        delta_softplus=True,
-    ):
-
-        if not self.neox_args.mamba_selective_scan_fusion:
-            y = selective_scan_ref(
-                u=x,
-                delta=dt,
-                A=A,
-                B=B,
-                C=C,
-                D=D,
-                z=z,
-                delta_bias=delta_bias,
-                delta_softplus=delta_softplus,
-                return_last_state=False,
-            )
-        else:
-            y = selective_scan_fn(
-                x,
-                dt,
-                A,
-                B,
-                C,
-                D=D,
-                z=z,
-                delta_bias=delta_bias,
-                delta_softplus=delta_softplus,
-                return_last_state=False,
-            )
-
-        return y
-
-    def forward(self, hidden_states):
-        """ """
-        assert self.training, "Mamba in NeoX does not support inference!"
-
-        # hidden_states: [sq, b, h]
-        seqlen, batch, dim = hidden_states.shape
-
-        # TODO: support inference in separate method
-        # For now, only handle training (parallel scan).
-
-        # first up: perform in_proj
-        xz, _ = self.in_proj(hidden_states)
-        xz = einops.rearrange(xz, "l b d -> b d l")
-
-        A = -torch.exp(
-            self.A_log.float()
-        )  # (d_inner, d_state) # TODO: move this to right before selective scan?
-
-        if self.neox_args.mamba_inner_func_fusion:
-            # mamba provides a mamba_inner fn that computes the entire (post-in_proj) Mamba block.
-            # we want to use it if we can.
-            out = mamba_inner_fn(
-                xz,
-                self.conv1d.weight,
-                self.conv1d.bias.to(
-                    torch.float16
-                ),  # for some bizarre reason this becomes fp32 sometime after init
-                self.x_proj.weight,  # TODO: need to pass the right portion of params?
-                self.dt_proj.weight,
-                self.out_proj.weight,
-                self.out_proj.bias,
-                A,
-                None,  # B is input-dependent, will compute from x_proj
-                None,  # C is input-dependent, will compute from x_proj
-                self.D.float(),
-                delta_bias=self.dt_proj.bias.float(),
-                delta_softplus=True,
-            )
-            if getattr(self, "reduce", None):
-                # manually reduce after mamba_inner_fn
-                # to collect outputs from different TP ranks.
-                # handled by running self.out_proj(y) below
-                # so only needed here.
-                out = self.reduce(out)
-
-            out = einops.rearrange(out, "b l h -> l b h")
-
-            return out
-
-        x, z = xz.chunk(2, dim=1)
-
-        # ===========
-        # Convolution
-        # ===========
-
-        if not self.neox_args.mamba_causal_conv_fusion:
-            self.conv1d.to(
-                torch.float16
-            )  # don't need if not hacking DeepSpeed to use fp32 A_log, D
-            x = self.act_fn(self.conv1d(x)[..., :seqlen])
-        else:
-            # Note: this requires silu to be used.
-            x = causal_conv1d_fn(
-                x=x,
-                weight=einops.rearrange(self.conv1d.weight, "d 1 w -> d w"),
-                bias=self.conv1d.bias.to(torch.float16),
-                activation="silu",
-            )
-
-        # ==============
-        # SSM Projection
-        # ==============
-
-        # project: perform s_B, s_C, s_Delta projections
-        x_dbl, _ = self.x_proj(einops.rearrange(x, "b d l -> (b l) d"))  # shape (bl d)
-
-        # split into component dt, B, C
-        dt, B, C = torch.split(
-            x_dbl, [self.dt_rank, self.d_state, self.d_state], dim=-1
-        )
-
-        # up-project Delta / dt
-        dt = self.dt_proj.weight @ dt.t()
-        dt = einops.rearrange(dt, "d (b l) -> b d l", l=seqlen)
-
-        # rearrange B, C
-        B = einops.rearrange(B, "(b l) d_state -> b d_state l", l=seqlen).contiguous()
-        C = einops.rearrange(C, "(b l) d_state -> b d_state l", l=seqlen).contiguous()
-
-        y = self.selective_scan(
-            x,
-            dt,
-            A,
-            B,
-            C,
-            self.D.float(),  # TODO: why's this cast here?
-            z=z,
-            delta_bias=self.dt_proj.bias.float(),
-            delta_softplus=True,
-            # return_last_state, #TODO: inference concerns
-        )
-
-        # ===============
-        # Down-Projection
-        # ===============
-        y = einops.rearrange(y, "b d l -> b l d")
-
-        out, _ = self.out_proj(y)
-
-        out = einops.rearrange(
-            out, "b l h -> l b h"
-        )  # TODO: cutting down on rearranges would be nice
-
-        return out
-
-
-class ParallelMambaResidualLayer(nn.Module):
-    """
-    Pre-norm Mamba Block with residual connection. No parallelism yet supported.
-    """
-
-    def __init__(
-        self,
-        neox_args,
-        init_method,
-        output_layer_init_method,
-        layer_number,
-    ):
-        super().__init__()
-        # TODO: allow for residual in fp32 if it helps?
-        self.layer_number = layer_number
-
-        norm, eps = get_norm(neox_args)
-
-        self.norm = norm(neox_args.hidden_size, eps=eps)
-
-        # TODO: dropout
-
-        self.mixer = ParallelMambaBlock(
-            neox_args=neox_args,
-            init_method=init_method,
-            output_layer_init_method=output_layer_init_method,
-        )
-
-    def forward(self, x, attention_mask=None, layer_past=None):
-
-        # pseudocode:
-        # x = x + mixer(norm(x))
-        residual = x
-
-        hidden_states = self.mixer(
-            self.norm(x)
-        )  # TODO: do norm in fp32? what is it by default
-
-        return hidden_states + residual
-
-
 class ParallelMambaResidualLayerPipe(ParallelMambaResidualLayer):
     """Extends MambaResidualLayer to forward attention_mask through the pipeline. DeepSpeed requires this."""
 
     def forward(self, args):
         assert (
             len(args) == 2
-        ), "ParallelMambaResidualLayerPipe expects 2 arguments - hidden_states and attention_mask"
+        ), "MambaResidualLayerPipe expects 2 arguments - hidden_states and attention_mask"
         hidden_states, attention_mask = args
         # we are returning just [hidden_states, mask]
         return super().forward(hidden_states, attention_mask), attention_mask

--- a/megatron/neox_arguments/arguments.py
+++ b/megatron/neox_arguments/arguments.py
@@ -1061,9 +1061,6 @@ class NeoXArgs(*BASE_CLASSES):
                 not self.partition_activations
             ), "GMLP Blocks are not compatible with partition activations"
         if "mamba" in self.attention_config:
-            assert (
-                not self.is_pipe_parallel,
-            ), "Mamba not currently compatible with parallelism"
             if isinstance(self.zero_stage, int):
                 assert self.zero_stage <= 2, "Zero stage 3 not compatible with Mamba"
             assert (

--- a/megatron/neox_arguments/arguments.py
+++ b/megatron/neox_arguments/arguments.py
@@ -1062,7 +1062,7 @@ class NeoXArgs(*BASE_CLASSES):
             ), "GMLP Blocks are not compatible with partition activations"
         if "mamba" in self.attention_config:
             assert (
-                not self.is_pipe_parallel and self.model_parallel_size == 1
+                not self.is_pipe_parallel,
             ), "Mamba not currently compatible with parallelism"
             if isinstance(self.zero_stage, int):
                 assert self.zero_stage <= 2, "Zero stage 3 not compatible with Mamba"


### PR DESCRIPTION
This PR adds Mamba + TP support.

Loss curves comparing TP=2 to TP=1 with + without `mamba_inner_func_fusion`:

![image](https://github.com/EleutherAI/gpt-neox/assets/65563625/d491c072-9ea1-45ab-b30d-d4ff706190bb)

Versus when allreduce was missing with inner func fusion turned on:

![image](https://github.com/EleutherAI/gpt-neox/assets/65563625/99fee8b5-eb28-48da-99f2-9e48363e3759)

Also tested that PP seems to work. 