### PR TITLE
[ZeRO-3] Ensured passing neox deepspeed_config when using partitioned init

### DIFF
--- a/megatron/training.py
+++ b/megatron/training.py
@@ -24,6 +24,7 @@ from functools import partial
 
 import math
 import sys
+from contextlib import nullcontext
 
 import torch
 import deepspeed
@@ -427,16 +428,8 @@ def get_model(neox_args, use_cache=False):
     old_use_mup = neox_args.use_mup
     neox_args.use_mup = False
 
-    if neox_args.zero_stage == 3:
-        with deepspeed.zero.Init():
-            model = GPT2ModelPipe(
-                neox_args=neox_args,
-                num_tokentypes=0,
-                parallel_output=True,
-                topology=mpu.get_topology(),
-                use_cache=use_cache,
-            )
-    else: 
+
+    with deepspeed.zero.Init() if neox_args.zero_stage == 3 else nullcontext() as gs:
         model = GPT2ModelPipe(
             neox_args=neox_args,
             num_tokentypes=0,

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -426,13 +426,24 @@ def get_model(neox_args, use_cache=False):
     # If mup isn't being used anyways, this has no effect.
     old_use_mup = neox_args.use_mup
     neox_args.use_mup = False
-    model = GPT2ModelPipe(
-        neox_args=neox_args,
-        num_tokentypes=0,
-        parallel_output=True,
-        topology=mpu.get_topology(),
-        use_cache=use_cache,
-    )
+
+    if neox_args.zero_stage == 3:
+        with deepspeed.zero.Init():
+            model = GPT2ModelPipe(
+                neox_args=neox_args,
+                num_tokentypes=0,
+                parallel_output=True,
+                topology=mpu.get_topology(),
+                use_cache=use_cache,
+            )
+    else: 
+        model = GPT2ModelPipe(
+            neox_args=neox_args,
+            num_tokentypes=0,
+            parallel_output=True,
+            topology=mpu.get_topology(),
+            use_cache=use_cache,
+        )
 
     ### soft prompt tuning stuff ###
     if neox_args.soft_prompt_tuning is not None and neox_args.soft_prompt_tuning.get(

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -428,7 +428,6 @@ def get_model(neox_args, use_cache=False):
     old_use_mup = neox_args.use_mup
     neox_args.use_mup = False
 
-
     with deepspeed.zero.Init() if neox_args.zero_stage == 3 else nullcontext() as gs:
         model = GPT2ModelPipe(
             neox_args=neox_args,

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -428,7 +428,9 @@ def get_model(neox_args, use_cache=False):
     old_use_mup = neox_args.use_mup
     neox_args.use_mup = False
 
-    with deepspeed.zero.Init() if neox_args.zero_stage == 3 else nullcontext() as gs:
+    with deepspeed.zero.Init(
+        config_dict_or_path=neox_args.deespeed_config
+    ) if neox_args.zero_stage == 3 else nullcontext() as gs:
         model = GPT2ModelPipe(
             neox_args=neox_args,
             num_tokentypes=0,


### PR DESCRIPTION
This PR is a slight adjustment on #1190 , fixes scenarios if user need to pass in additional zero parameters (examples like `zero_hpz_partition_size`, `zero_quantized_weights` etc)
