### PR TITLE
Add `intermediate_size` to GPT-NeoX models

### DIFF
--- a/configs/1-3B.yml
+++ b/configs/1-3B.yml
@@ -3,7 +3,7 @@
    # parallelism settings ( you will want to change these based on your cluster setup, ideally scheduling pipeline stages
    # across the node boundaries )
    "pipe_parallel_size": 1,
-   "model_parallel_size": 1,
+   "model_parallel_size": 2,
 
    # model settings
    "num_layers": 24,
@@ -48,6 +48,7 @@
     "reduce_bucket_size": 500000000,
     "contiguous_gradients": True,
   },
+  "expansion_factor": 8,
 
    # batch / data settings
    "train_micro_batch_size_per_gpu": 4,
@@ -76,8 +77,8 @@
    },
 
    # misc. training settings
-   "train_iters": 320000,
-   "lr_decay_iters": 320000,
+   "train_iters": 10,
+   "lr_decay_iters": 10,
    "distributed_backend": "nccl",
    "lr_decay_style": "cosine",
    "warmup": 0.01,

--- a/configs/1-3B.yml
+++ b/configs/1-3B.yml
@@ -3,7 +3,7 @@
    # parallelism settings ( you will want to change these based on your cluster setup, ideally scheduling pipeline stages
    # across the node boundaries )
    "pipe_parallel_size": 1,
-   "model_parallel_size": 2,
+   "model_parallel_size": 1,
 
    # model settings
    "num_layers": 24,

--- a/configs/1-3B.yml
+++ b/configs/1-3B.yml
@@ -48,7 +48,6 @@
     "reduce_bucket_size": 500000000,
     "contiguous_gradients": True,
   },
-  "expansion_factor": 8,
 
    # batch / data settings
    "train_micro_batch_size_per_gpu": 4,
@@ -77,8 +76,8 @@
    },
 
    # misc. training settings
-   "train_iters": 10,
-   "lr_decay_iters": 10,
+   "train_iters": 320000,
+   "lr_decay_iters": 320000,
    "distributed_backend": "nccl",
    "lr_decay_style": "cosine",
    "warmup": 0.01,

--- a/configs/llama/13B.yml
+++ b/configs/llama/13B.yml
@@ -22,5 +22,5 @@
   "use_bias_in_norms": false,
   "use_bias_in_attn_linear": false,
   "mlp_type": "llama",
-  "activation": "silu",
+  "activation": "swiglu",
 }

--- a/configs/llama/30B.yml
+++ b/configs/llama/30B.yml
@@ -22,5 +22,5 @@
   "use_bias_in_norms": false,
   "use_bias_in_attn_linear": false,
   "mlp_type": "llama",
-  "activation": "silu",
+  "activation": "swiglu",
 }

--- a/configs/llama/65B.yml
+++ b/configs/llama/65B.yml
@@ -22,5 +22,5 @@
   "use_bias_in_norms": false,
   "use_bias_in_attn_linear": false,
   "mlp_type": "llama",
-  "activation": "silu",
+  "activation": "swiglu",
 }

--- a/configs/llama/7B.yml
+++ b/configs/llama/7B.yml
@@ -22,5 +22,5 @@
   "use_bias_in_norms": false,
   "use_bias_in_attn_linear": false,
   "mlp_type": "llama",
-  "activation": "silu",
+  "activation": "swiglu",
 }

--- a/megatron/data/helpers.cpp
+++ b/megatron/data/helpers.cpp
@@ -428,9 +428,9 @@ py::array build_mapping_impl(const py::array_t<int64_t>& docs_,
                         }
 
                     }  // for (auto sent_index=sent_index_first; ...
-                }  // if (num_remain_sent > 1) {
-            }  // for (int doc=0; doc < num_docs; ++doc) {
-        }  // for (int epoch=0; epoch < num_epochs; ++epoch) {
+                }      // if (num_remain_sent > 1) {
+            }          // for (int doc=0; doc < num_docs; ++doc) {
+        }              // for (int epoch=0; epoch < num_epochs; ++epoch) {
 
         if (!second) {
             if (verbose) {
@@ -660,9 +660,9 @@ py::array build_blocks_mapping_impl(const py::array_t<int64_t>& docs_,
                             num_sent = 0;
                         }
                     }  // for (auto sent_index=sent_index_first; ...
-                }  // if (num_remain_sent > 1) {
-            }  // for (int doc=0; doc < num_docs; ++doc) {
-        }  // for (int epoch=0; epoch < num_epochs; ++epoch) {
+                }      // if (num_remain_sent > 1) {
+            }          // for (int doc=0; doc < num_docs; ++doc) {
+        }              // for (int epoch=0; epoch < num_epochs; ++epoch) {
 
         if (!second) {
             if (verbose) {

--- a/megatron/model/activations.py
+++ b/megatron/model/activations.py
@@ -25,15 +25,30 @@ torch._C._jit_override_can_fuse_on_gpu(True)
 
 
 def get_activation(neox_args):
-    """retrieves the activation function specified in neox_args"""
+    """retrieves the activation function specified in neox_args and whether or not the activation is gated"""
+    is_gated = False
     if neox_args.activation == "geglu":
-        activation_func = GEGLU(neox_args=neox_args)
+        is_gated = True
+        activation_func = F.gelu
+    elif neox_args.activation == "reglu":
+        is_gated = True
+        activation_func = F.relu
+    elif neox_args.activation == "bilinear":
+        is_gated = True
+        activation_func = lambda x : x
+    elif neox_args.activation == "swiglu":
+        is_gated = True
+        activation_func = swish
+    elif neox_args.activation == "glu":
+        is_gated = True
+        activation_func = F.sigmoid
     elif neox_args.activation == "gelu":
         if neox_args.onnx_safe and neox_args.bias_gelu_fusion:
             raise ValueError("onnx_safe + bias_gelu_fusion not compatible")
         if neox_args.onnx_safe:
             activation_func = erf_gelu
         elif neox_args.bias_gelu_fusion:
+            is_gated = True
             activation_func = bias_gelu_impl
         else:
             activation_func = F.gelu
@@ -49,7 +64,7 @@ def get_activation(neox_args):
         activation_func = F.silu
     else:
         raise ValueError(f"Activation function {neox_args.activation} not recognized")
-    return activation_func
+    return activation_func, is_gated
 
 
 ###### BIAS GELU FUSION/ NO AUTOGRAD ################
@@ -119,21 +134,3 @@ def swish(x, beta: float = 1.0):
 @torch.jit.script
 def mish(x):
     return x * torch.tanh(F.softplus(x))
-
-
-class GEGLU(torch.nn.Module):
-    def __init__(self, neox_args):
-        super(GEGLU, self).__init__()
-        if neox_args.onnx_safe:
-            self.activation_func = erf_gelu
-        else:
-            self.activation_func = F.gelu
-
-    def forward(self, x, bias=None):
-        x, gate = x.chunk(2, dim=-1)
-        if bias is not None:
-            bias_1, bias_2 = bias.chunk(2, dim=-1)
-            x = x + bias_1
-            gate = gate + bias_2
-        intermediate_parallel = self.activation_func(gate)
-        return intermediate_parallel * x

--- a/megatron/model/activations.py
+++ b/megatron/model/activations.py
@@ -48,7 +48,6 @@ def get_activation(neox_args):
         if neox_args.onnx_safe:
             activation_func = erf_gelu
         elif neox_args.bias_gelu_fusion:
-            is_gated = True
             activation_func = bias_gelu_impl
         else:
             activation_func = F.gelu

--- a/megatron/model/activations.py
+++ b/megatron/model/activations.py
@@ -35,7 +35,7 @@ def get_activation(neox_args):
         activation_func = F.relu
     elif neox_args.activation == "bilinear":
         is_gated = True
-        activation_func = lambda x : x
+        activation_func = lambda x: x
     elif neox_args.activation == "swiglu":
         is_gated = True
         activation_func = swish

--- a/megatron/model/gmlp.py
+++ b/megatron/model/gmlp.py
@@ -112,7 +112,7 @@ class GMLPBlock(nn.Module):
             init_method=init_method,
             skip_bias_add=True,
         )
-        self.activation_func = get_activation(neox_args)
+        self.activation_func, _ = get_activation(neox_args)
         ff_dim_parallel = mpu.divide(ff_dim, mpu.get_model_parallel_world_size())
         if neox_args.attention_config[layer_number] == "amlp":
             d_attn = neox_args.gmlp_attn_dim

--- a/megatron/model/mamba/mamba.py
+++ b/megatron/model/mamba/mamba.py
@@ -50,7 +50,10 @@ class ParallelMambaBlock(nn.Module):
         self.d_state = 16  # state dimensions per channel
         self.d_conv = 4  # convolution width
         self.expand = 2  # linear projection expansion factors
-        self.d_inner = int(self.expand * self.d_model)
+        if neox_args.intermediate_size == None:
+            neox_args.d_inner = self.expand * self.d_model
+        else:
+            neox_args.d_inner = neox_args.intermediate_size
         self.dt_rank = math.ceil(self.d_model / 16)  # rank of dt / Delta parameter
         self.dt_scale = 1.0
 

--- a/megatron/model/mamba/mamba.py
+++ b/megatron/model/mamba/mamba.py
@@ -45,15 +45,18 @@ class ParallelMambaBlock(nn.Module):
             neox_args.mamba_use_bias_in_linears and neox_args.mamba_inner_func_fusion
         ), "Mamba fused inner fn and bias in x_proj not compatible!"
 
+        assert neox_args.intermediate_size == None or neox_args.expansion_factor == None
+
         # set variables, mostly following mamba defaults
         self.d_model = neox_args.hidden_size
         self.d_state = 16  # state dimensions per channel
         self.d_conv = 4  # convolution width
         self.expand = 2  # linear projection expansion factors
         if neox_args.intermediate_size == None:
-            neox_args.d_inner = self.expand * self.d_model
-        else:
             neox_args.d_inner = neox_args.intermediate_size
+        if neox_args.expansion_factor:
+            self.expand = neox_args.expansion_factor
+        neox_args.d_inner = neox_args.intermediate_size
         self.dt_rank = math.ceil(self.d_model / 16)  # rank of dt / Delta parameter
         self.dt_scale = 1.0
 

--- a/megatron/model/mamba/mamba.py
+++ b/megatron/model/mamba/mamba.py
@@ -45,7 +45,7 @@ class ParallelMambaBlock(nn.Module):
             neox_args.mamba_use_bias_in_linears and neox_args.mamba_inner_func_fusion
         ), "Mamba fused inner fn and bias in x_proj not compatible!"
 
-        assert neox_args.intermediate_size == None or neox_args.expansion_factor == None
+        assert neox_args.intermediate_size == None or neox_args.expansion_factor == None, "Must pass either the absolute intermediate size or the relative expansion factor for the mamba projections"
 
         # set variables, mostly following mamba defaults
         self.d_model = neox_args.hidden_size

--- a/megatron/model/mamba/mamba.py
+++ b/megatron/model/mamba/mamba.py
@@ -51,12 +51,11 @@ class ParallelMambaBlock(nn.Module):
         self.d_model = neox_args.hidden_size
         self.d_state = 16  # state dimensions per channel
         self.d_conv = 4  # convolution width
-        self.expand = 2  # linear projection expansion factors
-        if neox_args.intermediate_size == None:
-            neox_args.d_inner = neox_args.intermediate_size
-        if neox_args.expansion_factor:
-            self.expand = neox_args.expansion_factor
-        neox_args.d_inner = neox_args.intermediate_size
+        if neox_args.intermediate_size:
+            self.d_inner = neox_args.intermediate_size
+        else:
+            self.expand = neox_args.expansion_factor if neox_args.expansion_factor else 2 
+            self.d_inner = int(self.expand * self.d_model)
         self.dt_rank = math.ceil(self.d_model / 16)  # rank of dt / Delta parameter
         self.dt_scale = 1.0
 

--- a/megatron/model/rwkv/v6/rwkv.py
+++ b/megatron/model/rwkv/v6/rwkv.py
@@ -275,13 +275,16 @@ class RWKVResidualLayer(nn.Module):
         self.layer_number = layer_number
         self.fp16 = neox_args.precision == "fp16"
         self.bf16 = neox_args.precision == "bfloat16"
+        assert neox_args.intermediate_size == None or neox_args.expansion_factor == None
         if not hasattr(neox_args, "dim_att"):
             neox_args.dim_att = neox_args.hidden_size
-        if neox_args.intermediate_size == None:
-            # Make hidden size 3.5x. Round to nearest multiple of 32 until we add hdim rounding logic
-            neox_args.ff_dim = int((neox_args.hidden_size * 3.5) // 32 * 32)
-        else:
+        if neox_args.intermediate_size:
             neox_args.ff_dim = neox_args.intermediate_size
+        # Make hidden size 3.5x. Round to nearest multiple of 32 until we add hdim rounding logic
+        neox_args.expand = 3.5
+        if neox_args.expansion_factor:
+            self.expand = neox_args.expansion_factor
+        neox_args.ff_dim = int(neox_args.ff_dim // 32 * 32)
         assert neox_args.hidden_size % 32 == 0
         assert neox_args.dim_att % 32 == 0
         assert neox_args.ff_dim % 32 == 0

--- a/megatron/model/rwkv/v6/rwkv.py
+++ b/megatron/model/rwkv/v6/rwkv.py
@@ -247,11 +247,11 @@ class RWKV_ChannelMix(nn.Module):
             self.time_maa_k = nn.Parameter(1.0 - torch.pow(ddd, ratio_1_to_almost0))
             self.time_maa_r = nn.Parameter(1.0 - torch.pow(ddd, ratio_1_to_almost0))
 
-        self.key = nn.Linear(neox_args.hidden_size, neox_args.ff_dim, bias=False)
+        self.key = nn.Linear(neox_args.hidden_size, neox_args.ffn_dim, bias=False)
         self.receptance = nn.Linear(
             neox_args.hidden_size, neox_args.hidden_size, bias=False
         )
-        self.value = nn.Linear(neox_args.ff_dim, neox_args.hidden_size, bias=False)
+        self.value = nn.Linear(neox_args.ffn_dim, neox_args.hidden_size, bias=False)
 
     def forward(self, x):
         xx = self.time_shift(x) - x
@@ -275,19 +275,19 @@ class RWKVResidualLayer(nn.Module):
         self.layer_number = layer_number
         self.fp16 = neox_args.precision == "fp16"
         self.bf16 = neox_args.precision == "bfloat16"
-        assert neox_args.intermediate_size == None or neox_args.expansion_factor == None
+        assert neox_args.intermediate_size == None or neox_args.expansion_factor == None, "Must pass either the absolute intermediate size or the relative expansion factor for the mamba projections"
         if not hasattr(neox_args, "dim_att"):
             neox_args.dim_att = neox_args.hidden_size
         if neox_args.intermediate_size:
-            neox_args.ff_dim = neox_args.intermediate_size
-        # Make hidden size 3.5x. Round to nearest multiple of 32 until we add hdim rounding logic
-        neox_args.expand = 3.5
-        if neox_args.expansion_factor:
-            self.expand = neox_args.expansion_factor
-        neox_args.ff_dim = int(neox_args.ff_dim // 32 * 32)
+            neox_args.ffn_dim = neox_args.intermediate_size
+        else:
+            self.expand = neox_args.expansion_factor if neox_args.expansion_factor else 3.5
+            neox_args.ffn_dim = int(self.expand * neox_args.hidden_size)
+            # Make hidden size 3.5x by default. Round to nearest multiple of 32 until we add hdim rounding logic
+        neox_args.ffn_dim = int(neox_args.ffn_dim // 32 * 32)
         assert neox_args.hidden_size % 32 == 0
         assert neox_args.dim_att % 32 == 0
-        assert neox_args.ff_dim % 32 == 0
+        assert neox_args.ffn_dim % 32 == 0
         self.neox_args.head_size = neox_args.dim_att // neox_args.num_attention_heads
         self.head_size = self.neox_args.head_size
         self.num_attention_heads = neox_args.num_attention_heads

--- a/megatron/model/rwkv/v6/rwkv.py
+++ b/megatron/model/rwkv/v6/rwkv.py
@@ -247,11 +247,11 @@ class RWKV_ChannelMix(nn.Module):
             self.time_maa_k = nn.Parameter(1.0 - torch.pow(ddd, ratio_1_to_almost0))
             self.time_maa_r = nn.Parameter(1.0 - torch.pow(ddd, ratio_1_to_almost0))
 
-        self.key = nn.Linear(neox_args.hidden_size, neox_args.dim_ffn, bias=False)
+        self.key = nn.Linear(neox_args.hidden_size, neox_args.ff_dim, bias=False)
         self.receptance = nn.Linear(
             neox_args.hidden_size, neox_args.hidden_size, bias=False
         )
-        self.value = nn.Linear(neox_args.dim_ffn, neox_args.hidden_size, bias=False)
+        self.value = nn.Linear(neox_args.ff_dim, neox_args.hidden_size, bias=False)
 
     def forward(self, x):
         xx = self.time_shift(x) - x
@@ -277,12 +277,14 @@ class RWKVResidualLayer(nn.Module):
         self.bf16 = neox_args.precision == "bfloat16"
         if not hasattr(neox_args, "dim_att"):
             neox_args.dim_att = neox_args.hidden_size
-        if not hasattr(neox_args, "dim_ffn"):
+        if neox_args.intermediate_size == None:
             # Make hidden size 3.5x. Round to nearest multiple of 32 until we add hdim rounding logic
-            neox_args.dim_ffn = int((neox_args.hidden_size * 3.5) // 32 * 32)
+            neox_args.ff_dim = int((neox_args.hidden_size * 3.5) // 32 * 32)
+        else:
+            neox_args.ff_dim = neox_args.intermediate_size
         assert neox_args.hidden_size % 32 == 0
         assert neox_args.dim_att % 32 == 0
-        assert neox_args.dim_ffn % 32 == 0
+        assert neox_args.ff_dim % 32 == 0
         self.neox_args.head_size = neox_args.dim_att // neox_args.num_attention_heads
         self.head_size = self.neox_args.head_size
         self.num_attention_heads = neox_args.num_attention_heads

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -120,8 +120,13 @@ class ParallelMLP(nn.Module):
             ff_dim = int(ff_dim * 2 / 3)
             ff_dim_in = ff_dim // 2
         # set multiple
-        ff_dim = int((2 * self.multiple_of) * ((ff_dim + (2 * multiple_of) - 1) // (2 * multiple_of)))
-        ff_dim_in = int(self.multiple_of * ((ff_dim_in + multiple_of - 1) // multiple_of))
+        ff_dim = int(
+            (2 * self.multiple_of)
+            * ((ff_dim + (2 * multiple_of) - 1) // (2 * multiple_of))
+        )
+        ff_dim_in = int(
+            self.multiple_of * ((ff_dim_in + multiple_of - 1) // multiple_of)
+        )
 
         self.linear1 = mpu.ColumnParallelLinear(
             neox_args=neox_args,
@@ -163,6 +168,7 @@ class ParallelMLP(nn.Module):
         output, output_bias = self.linear2(intermediate_parallel)
         return output, output_bias
 
+
 class Gated_Activation(torch.nn.Module):
     def __init__(self, activation_func):
         super().__init__()
@@ -176,6 +182,7 @@ class Gated_Activation(torch.nn.Module):
             gate = gate + bias_2
         intermediate_parallel = self.activation_func(gate)
         return intermediate_parallel * x
+
 
 class ParallelLinear(nn.Module):
     """
@@ -1215,10 +1222,7 @@ class ParallelTransformerLayer(nn.Module):
                     raise KeyError(self.moe_type)
 
             with torch.enable_grad():
-                if (
-                    self.num_experts > 1
-                    and self.moe_type == "deepspeed"
-                ):
+                if self.num_experts > 1 and self.moe_type == "deepspeed":
                     # No dropout either
                     assert mlp_bias is None
                     output = mlp_output + attention_output

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -1222,7 +1222,7 @@ class ParallelTransformerLayer(nn.Module):
                     raise KeyError(self.moe_type)
 
             with torch.enable_grad():
-                if self.num_experts > 1 and self.moe_type == "deepspeed":
+                if self.activation == "swiglu" or self.num_experts > 1 and self.moe_type == "deepspeed":
                     # No dropout either
                     assert mlp_bias is None
                     output = mlp_output + attention_output

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -150,7 +150,7 @@ class ParallelMLP(nn.Module):
         # [s, b, intermediate_size]
         intermediate_parallel, bias_parallel = self.linear1(hidden_states)
 
-        if self.is_gated: 
+        if self.is_gated or (self.activation_type == "gelu" and self.bias_gelu_fusion):
             intermediate_parallel = self.activation_func(
                 intermediate_parallel, bias_parallel
             )

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -102,13 +102,19 @@ class ParallelMLP(nn.Module):
         self.activation_type = neox_args.activation
         self.bias_gelu_fusion = neox_args.bias_gelu_fusion
 
-        # auto scale so geglu has equal parameters
-        ff_mult = int(4 * 2 / 3) if self.activation_type == "geglu" else 4
-        ff_dim = (
-            int(ff_mult * neox_args.hidden_size) * 2
-            if self.activation_type == "geglu"
-            else ff_mult * neox_args.hidden_size
-        )
+        
+        if neox_args.intermediate_size:
+            ff_dim = neox_args.intermediate_size
+
+        else:
+            # auto scale so geglu has equal parameters
+            ff_mult = int(4 * 2 / 3) if self.activation_type == "geglu" else 4
+            ff_dim = (
+                int(ff_mult * neox_args.hidden_size) * 2
+                if self.activation_type == "geglu"
+                else int(ff_mult * neox_args.hidden_size)
+            )
+
         self.dense_h_to_4h = mpu.ColumnParallelLinear(
             neox_args=neox_args,
             input_size=neox_args.hidden_size,

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -102,7 +102,7 @@ class ParallelMLP(nn.Module):
         self.activation_type = neox_args.activation
         self.bias_gelu_fusion = neox_args.bias_gelu_fusion
 
-        
+        #TODO: revisit this when we add swiglu to make sure ff_dim is initialized correctly.
         if neox_args.intermediate_size:
             ff_dim = neox_args.intermediate_size
 

--- a/megatron/neox_arguments/neox_args.py
+++ b/megatron/neox_arguments/neox_args.py
@@ -114,9 +114,12 @@ class NeoXArgsModel(NeoXArgsTemplate):
 
     intermediate_size: int = None
     """
-    Transformer intermediate size. Currently only used for "mlp_type": "llama".
+    Transformer intermediate size. Default = 4h
+    """
 
-    If not passed, will be set to a reasonable default.
+    expansion_factor: float = None 
+    """
+    Transformer intermediate size. Default = 4
     """
 
     num_attention_heads: int = None
@@ -271,10 +274,10 @@ class NeoXArgsModel(NeoXArgsTemplate):
     """
 
     activation: Literal[
-        "gelu", "geglu", "relu", "softsign", "swish", "mish", "silu"
+        "gelu", "geglu", "relu", "softsign", "swish", "mish", "silu", "reglu", "swiglu", "bilinear", "glu"
     ] = "gelu"
     """
-    Activation function to use - choose from ["gelu", "geglu", "relu", "softsign", "swish", "mish", "silu"]
+    Activation function to use - choose from ["gelu", "geglu", "relu", "softsign", "swish", "mish", "silu", "reglu", "swiglu", "bilinear", "glu"]
     """
 
     scaled_upper_triang_masked_softmax_fusion: bool = False
@@ -414,9 +417,9 @@ class NeoXArgsModel(NeoXArgsTemplate):
 
     mlp_type: str = "regular"
     """
+    Currently, the only mlp_type is "regular." This behavior is currently deprecated.
     Types:
         regular: Megatron implementation
-        llama: LLaMA MLP (SiLU-gated MLP)
     """
 
     soft_prompt_tuning: dict = None

--- a/megatron/neox_arguments/neox_args.py
+++ b/megatron/neox_arguments/neox_args.py
@@ -117,7 +117,7 @@ class NeoXArgsModel(NeoXArgsTemplate):
     Transformer intermediate size. Default = 4h
     """
 
-    expansion_factor: float = None 
+    expansion_factor: float = None
     """
     Transformer intermediate size. Default = 4
     """
@@ -274,7 +274,17 @@ class NeoXArgsModel(NeoXArgsTemplate):
     """
 
     activation: Literal[
-        "gelu", "geglu", "relu", "softsign", "swish", "mish", "silu", "reglu", "swiglu", "bilinear", "glu"
+        "gelu",
+        "geglu",
+        "relu",
+        "softsign",
+        "swish",
+        "mish",
+        "silu",
+        "reglu",
+        "swiglu",
+        "bilinear",
+        "glu",
     ] = "gelu"
     """
     Activation function to use - choose from ["gelu", "geglu", "relu", "softsign", "swish", "mish", "silu", "reglu", "swiglu", "bilinear", "glu"]


### PR DESCRIPTION
The current implementation only allows to set `intermediate_size` for Llama models, but I would like to be capable to change the `intermediate_size` in GPT-NeoX models. 

I have tested this implementation under a quick training, inference and conversion and it seems that it doesn't give any bugs. I hope it helps!