### PR TITLE
fix pipeline parallelism detection

### DIFF
--- a/tools/ckpts/convert_neox_to_hf.py
+++ b/tools/ckpts/convert_neox_to_hf.py
@@ -674,7 +674,7 @@ def main(input_args=None, overwrite_values=None):
     # while Sequential model state dicts are saved all together in one mp_rank_xx_model_states.pt
     # file per tensor/model parallel shard.
     pipeline_world_size = get_key(loaded_config, "pipe-parallel-size", 1)
-    if pipeline_world_size == 0:
+    if pipeline_world_size <= 1:
         sequential = True
         print(
             f"Detected 'pipe-parallel-size' of {pipeline_world_size}, assuming model is saved as Sequential..."


### PR DESCRIPTION
All pythia configs come with pipe-parallel-size of 1 (e.g. [pythia-6.9b](https://github.com/EleutherAI/gpt-neox/blob/main/configs/pythia/6-9B.yml#L2)) and is also [set when it's greater than 1](https://github.com/EleutherAI/gpt-neox/blob/main/megatron/neox_arguments/arguments.py#L1036-L1039)

This fixes the detection to be in line with the is_pipe_parallel argument.



