### PR TITLE
fix conversion of hf -> neox for pythia in model parallel

### DIFF
--- a/tools/ckpts/convert_hf_to_sequential.py
+++ b/tools/ckpts/convert_hf_to_sequential.py
@@ -123,12 +123,23 @@ def shard_sequential_mp(num_mp_ranks, sequential):
             [
                 x in k
                 for x in [
+                    "dense_4h_to_h.bias",
+                    "attention.dense.bias",
+                ]
+            ],
+        ):
+            # Divide by tp_size since they get added together
+            for x in range(num_mp_ranks):
+                ranks[x][k] = v / num_mp_ranks
+        elif reduce(
+            np.logical_or,
+            [
+                x in k
+                for x in [
                     "layernorm",
                     "rotary_emb",
-                    "dense_4h_to_h.bias",
                     "norm.weight",
                     "norm.bias",
-                    "attention.dense.bias",
                 ]
             ],
         ):


### PR DESCRIPTION
Fixes the very high loss at start of training a split pythia/neox model

Matches it so that the summed biases [https://github.com/EleutherAI/gpt-neox/blob/main/tools/ckpts/convert_neox_to_hf.py#L520-L525](url) from the HF checkpoint are split appropriately in a tensor parallel case.

(For reference, magenta is pre-fix, blue is post-fix, grey is a 1.4b run without model parallelism for reference)
![image](https://github.com/EleutherAI/gpt-neox/assets/44207705/f954534b-488f-4c9e-9643-469422ab1417)
