### PR TITLE
Add Transformer Engine's version of RMSNorm and LayerNorm

### DIFF
--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -111,7 +111,7 @@ Logging Arguments
 
 - **git_hash**: str
 
-    Default = ad8417c
+    Default = 217b4c5
 
     current git hash of repository
 
@@ -335,11 +335,11 @@ Model Arguments
 
 
 
-- **norm**: typing.Literal['layernorm', 'rmsnorm', 'scalenorm']
+- **norm**: typing.Literal['layernorm', 'rmsnorm', 'scalenorm', 'te_rmsnorm', 'te_layernorm']
 
     Default = layernorm
 
-    Normalization layer to use. Choose from "layernorm", "rmsnorm", "scalenorm".
+    Normalization layer to use. Choose from "layernorm", "rmsnorm", "scalenorm", "te_rmsnorm", "te_layernorm".
 
 
 

--- a/megatron/model/norms.py
+++ b/megatron/model/norms.py
@@ -14,7 +14,7 @@
 
 import torch
 from torch.nn import LayerNorm as LayerNorm
-from .transformer_engine import TERMSNorm
+from .transformer_engine import TERMSNorm, TELayerNorm
 from .fused_layer_norm import MixedFusedLayerNorm
 
 
@@ -32,11 +32,8 @@ def get_norm(neox_args):
         norm = TERMSNorm
         eps = neox_args.rms_norm_epsilon
     elif neox_args.norm == "te_layernorm":
-        # norm = ...
+        norm = TELayerNorm
         eps = neox_args.layernorm_epsilon
-    elif neox_args.norm == "te_scalenorm":
-        # norm = ...
-        eps = neox_args.scalenorm_epsilon
     else:
         raise ValueError(f"norm {neox_args.norm} not recognized")
     return norm, eps

--- a/megatron/model/norms.py
+++ b/megatron/model/norms.py
@@ -27,6 +27,15 @@ def get_norm(neox_args):
     elif neox_args.norm == "scalenorm":
         eps = neox_args.scalenorm_epsilon
         norm = ScaleNorm
+    elif neox_args.norm == "te_rmsnorm":
+        # norm = ...
+        eps = neox_args.rms_norm_epsilon
+    elif neox_args.norm == "te_layernorm":
+        # norm = ...
+        eps = neox_args.layernorm_epsilon
+    elif neox_args.norm == "te_scalenorm":
+        # norm = ...
+        eps = neox_args.scalenorm_epsilon
     else:
         raise ValueError(f"norm {neox_args.norm} not recognized")
     return norm, eps

--- a/megatron/model/norms.py
+++ b/megatron/model/norms.py
@@ -14,6 +14,7 @@
 
 import torch
 from torch.nn import LayerNorm as LayerNorm
+from .transformer_engine import TERMSNorm
 from .fused_layer_norm import MixedFusedLayerNorm
 
 
@@ -28,7 +29,7 @@ def get_norm(neox_args):
         eps = neox_args.scalenorm_epsilon
         norm = ScaleNorm
     elif neox_args.norm == "te_rmsnorm":
-        # norm = ...
+        norm = TERMSNorm
         eps = neox_args.rms_norm_epsilon
     elif neox_args.norm == "te_layernorm":
         # norm = ...

--- a/megatron/model/transformer_engine.py
+++ b/megatron/model/transformer_engine.py
@@ -5,7 +5,7 @@ from pkg_resources import packaging
 _te_version = packaging.version.Version(version("transformer-engine"))
 
 
-class TENorm:
+class TERMSNorm:
     """
     A conditional wrapper to initialize an instance of Transformer-Engine's
     `LayerNorm` or `RMSNorm` based on input

--- a/megatron/model/transformer_engine.py
+++ b/megatron/model/transformer_engine.py
@@ -5,15 +5,48 @@ from pkg_resources import packaging
 _te_version = packaging.version.Version(version("transformer-engine"))
 
 
-class TERMSNorm:
+class TERMSNorm(torch.nn.Module):
+    def __init__(self, dim, eps=1e-8, **kwargs):
     """
-    A conditional wrapper to initialize an instance of Transformer-Engine's
-    `LayerNorm` or `RMSNorm` based on input
+        A conditional wrapper to initialize an instance of Transformer-Engine's
+        `RMSNorm` based on input
+    :param dim: model size
+    :param eps:  epsilon value, default 1e-8
     """
+    super(TERMSNorm, self).__init__()
 
-    def __new__():
-        return
-        # TODO ???
+        self.d = dim
+        self.eps = eps
+        self.norm = te.pytorch.RMSNorm(
+            hidden_size=self.d,
+            eps=self.eps,
+            **kwargs,
+        )
+
+    def forward(self, x):
+        return self.norm(x)
+
+
+class TELayerNorm(torch.nn.Module):
+    def __init__(self, dim, eps=1.0e-5, **kwargs):
+    """
+        A conditional wrapper to initialize an instance of Transformer-Engine's
+        `LayerNorm` based on input
+    :param dim: model size
+    :param eps:  epsilon value, default 1.0e-5
+    """
+    super(TELayerNorm, self).__init__()
+
+        self.d = dim
+        self.eps = eps
+        self.norm = te.pytorch.LayerNorm(
+            hidden_size=self.d,
+            eps=self.eps,
+            **kwargs,
+        )
+
+    def forward(self, x):
+        return self.norm(x)
 
 
 class TELinear(te.pytorch.Linear):

--- a/megatron/model/utils.py
+++ b/megatron/model/utils.py
@@ -19,6 +19,7 @@
 
 import torch
 from megatron.model.norms import LayerNorm, RMSNorm, ScaleNorm
+from megatron.model.transformer_engine import TELayerNorm, TERMSNorm
 from megatron.model.fused_softmax import SoftmaxFusionTypes
 from types import GeneratorType
 import torch.distributed as dist
@@ -39,6 +40,8 @@ def get_params_for_weight_decay_optimization(module, neox_args):
             [
                 isinstance(module_, LayerNorm),
                 isinstance(module_, RMSNorm),
+                isinstance(module_, TELayerNorm),
+                isinstance(module_, TERMSNorm),
                 isinstance(module_, ScaleNorm),
             ]
         ) or (

--- a/megatron/neox_arguments/neox_args.py
+++ b/megatron/neox_arguments/neox_args.py
@@ -152,7 +152,9 @@ class NeoXArgsModel(NeoXArgsTemplate):
     Maximum number of position embeddings to use. This is the size of position embedding.
     """
 
-    norm: Literal["layernorm", "rmsnorm", "scalenorm", "te_rmsnorm", "te_layernorm"] = "layernorm"
+    norm: Literal[
+        "layernorm", "rmsnorm", "scalenorm", "te_rmsnorm", "te_layernorm"
+    ] = "layernorm"
     """
     Normalization layer to use. Choose from "layernorm", "rmsnorm", "scalenorm", "te_rmsnorm", "te_layernorm".
     """

--- a/megatron/neox_arguments/neox_args.py
+++ b/megatron/neox_arguments/neox_args.py
@@ -152,9 +152,9 @@ class NeoXArgsModel(NeoXArgsTemplate):
     Maximum number of position embeddings to use. This is the size of position embedding.
     """
 
-    norm: Literal["layernorm", "rmsnorm", "scalenorm"] = "layernorm"
+    norm: Literal["layernorm", "rmsnorm", "scalenorm", "te_rmsnorm", "te_layernorm"] = "layernorm"
     """
-    Normalization layer to use. Choose from "layernorm", "rmsnorm", "scalenorm".
+    Normalization layer to use. Choose from "layernorm", "rmsnorm", "scalenorm", "te_rmsnorm", "te_layernorm".
     """
 
     layernorm_fusion: bool = False


### PR DESCRIPTION
Adds wrapper for running the Transformer Engine's version of RMSNorm and LayerNorm.

cc: @Quentin-Anthony 