### PR TITLE
Replace unsafe `pyyaml` loader with `SafeLoader` (#2)

### DIFF
--- a/megatron/neox_arguments/arguments.py
+++ b/megatron/neox_arguments/arguments.py
@@ -182,7 +182,7 @@ class NeoXArgs(*BASE_CLASSES):
         for conf_file_name in paths_to_yml_files:
             # load file
             with open(conf_file_name) as conf_file:
-                conf = yaml.load(conf_file, Loader=yaml.FullLoader)
+                conf = yaml.load(conf_file, Loader=yaml.SafeLoader)
 
             # check for key duplicates and load values
             for conf_key, conf_value in conf.items():


### PR DESCRIPTION
The default loaders in PyYAML are not safe to use with untrusted data. They potentially make your application vulnerable to arbitrary code execution attacks. If you open a YAML file from an untrusted source, and the file is loaded with the default loader, an attacker could execute arbitrary code on your machine.

This codemod hardens all [`yaml.load()`](https://pyyaml.org/wiki/PyYAMLDocumentation) calls against such attacks by replacing the default loader with `yaml.SafeLoader`. This is the recommended loader for loading untrusted data. For most use cases it functions as a drop-in replacement for the default loader.

Calling `yaml.load()` without an explicit loader argument is equivalent to calling it with `Loader=yaml.Loader`, which is unsafe. This usage [has been deprecated](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input\)-Deprecation) since PyYAML 5.1. This codemod will add an explicit `SafeLoader` argument to all `yaml.load()` calls that don't use an explicit loader.

The changes from this codemod look like the following:
```diff
  import yaml
  data = b'!!python/object/apply:subprocess.Popen \\n- ls'
- deserialized_data = yaml.load(data, yaml.Loader)
+ deserialized_data = yaml.load(data, Loader=yaml.SafeLoader)
```

<details>
  <summary>More reading</summary>

  * [https://owasp.org/www-community/vulnerabilities/Deserialization_of_untrusted_data](https://owasp.org/www-community/vulnerabilities/Deserialization_of_untrusted_data)
  * [https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation)
</details>

🧚🤖  Powered by Pixeebot  

[Feedback](https://ask.pixee.ai/feedback) | [Community](https://pixee-community.slack.com/signup#/domain-signup) | [Docs](https://docs.pixee.ai/) | Codemod ID: [pixee:python/harden-pyyaml](https://docs.pixee.ai/codemods/python/pixee_python_harden-pyyaml) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Python%2Feleutherai_gpt-neox%7Ca3ad902e03c7afc51c3b905774360b3b553f0361)


<!--{"type":"DRIP","codemod":"pixee:python/harden-pyyaml"}-->