### PR TITLE
Fix pylint warning `raise-missing-from`

### DIFF
--- a/megatron/model/init_functions.py
+++ b/megatron/model/init_functions.py
@@ -180,9 +180,9 @@ def get_init_methods(args):
     if args.use_mup:
         try:
             import mup
-        except ModuleNotFoundError:
+        except ModuleNotFoundError as exc:
             print("Please install mup https://github.com/microsoft/mup")
-            raise Exception
+            raise Exception from exc
 
     def _get(name):
         if name == "normal":

--- a/megatron/model/word_embeddings.py
+++ b/megatron/model/word_embeddings.py
@@ -68,11 +68,11 @@ class Embedding(torch.nn.Module):
                 import bitsandbytes as bnb
 
                 self.embedding_module = bnb.nn.StableEmbedding
-            except ModuleNotFoundError:
+            except ModuleNotFoundError as exc:
                 print(
                     "Please install bitsandbytes following https://github.com/facebookresearch/bitsandbytes."
                 )
-                raise Exception
+                raise Exception from exc
         else:
             self.embedding_module = torch.nn.Embedding
 

--- a/megatron/tokenizer/tokenizer.py
+++ b/megatron/tokenizer/tokenizer.py
@@ -352,18 +352,18 @@ class TiktokenTokenizer(AbstractTokenizer):
     """Tokenizer from OpenAI's tiktoken implementation"""
 
     def __init__(self, vocab_file):
-        try:
-            import tiktoken
-        except ModuleNotFoundError:
-            print("Please install tiktoken: (https://github.com/openai/tiktoken)")
-            raise Exception
+            try:
+                import tiktoken
+            except ModuleNotFoundError as exc:
+                print("Please install tiktoken: (https://github.com/openai/tiktoken)")
+                raise Exception from exc
 
-        name = "TiktokenTokenizer"
-        super().__init__(name)
+            name = "TiktokenTokenizer"
+            super().__init__(name)
 
-        self.tokenizer = tiktoken.get_encoding(vocab_file)
-        self.eod_id = self.tokenizer.eot_token
-        self.pad_id = None
+            self.tokenizer = tiktoken.get_encoding(vocab_file)
+            self.eod_id = self.tokenizer.eot_token
+            self.pad_id = None
 
     @property
     def vocab_size(self):


### PR DESCRIPTION
### Changes Made:

- Applied automated fixes for the pylint warning `raise-missing-from`.
"Python's exception chaining shows the traceback of the current exception, but also of the original exception. When you raise a new exception after another exception was caught it's likely that the second exception is a friendly re-wrapping of the first exception. In such cases `raise from` provides a better link between the two tracebacks in the final error. See [https://pylint.readthedocs.io/en/stable/user_guide/messages/warning/raise-missing-from.html](https://pylint.readthedocs.io/en/stable/user_guide/messages/warning/raise-missing-from.html)"

### Note:

This pull request is part of a research project conducted by researchers from TU Delft, titled "PyWarnFixer: Using ML to Fix Pylint Warnings." The goal of this study is to investigate the perceptions and practices of code quality among developers in Python open-source projects and to develop a tool that uses AI to automatically fix pylint warnings.

### Research Study Information:
This pull request is part of a research project. For more information about the study, please visit the [project's information page](https://github.com/RatishT/PyWarnFixer/blob/main/README.md).

### Consent to Participate:
If you review this pull request, you are invited to participate in our study. Your participation is voluntary. To provide your consent, just open an issue in our repository with the provided template using the following link: [consent issue template](https://github.com/RatishT/PyWarnFixer/issues/new/choose) .

---

Thank you for considering participation in our research. Your feedback is crucial and highly valued. If you have any questions or concerns, please contact the Responsible Researcher at R.K.Thakoersingh@student.tudelft.nl.