### PR TITLE
GitHub actions fix

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -27,8 +27,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.ref}}
       - run: |
           rm megatron/__init__.py
           pip install shortuuid

--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -111,7 +111,7 @@ Logging Arguments
 
 - **git_hash**: str
 
-    Default = 455446c
+    Default = 9f3a8d7
 
     current git hash of repository
 


### PR DESCRIPTION
For some reason the GitHub actions documentation update failed with a 403 error. This seems to fix it.