### PR TITLE
Fix LayerNorm all reduce gradient hook

### DIFF
--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -111,7 +111,7 @@ Logging Arguments
 
 - **git_hash**: str
 
-    Default = c93c1b4
+    Default = 9a43318
 
     current git hash of repository
 

--- a/megatron/model/utils.py
+++ b/megatron/model/utils.py
@@ -370,8 +370,6 @@ def reduce_weight_grads_from_model_parallel_region(input_):
 
     # All-reduce.
     torch.distributed.all_reduce(input_, group=mpu.get_model_parallel_group())
-    # average grads
-    input_ = input_ / mpu.get_model_parallel_world_size()
 
     # Bf16 convert
     if dt == torch.bfloat16 and mpu.get_fp32_allreduce():


### PR DESCRIPTION
Fix the all reduce gradient hook for LayerNorm, by moving hook registration for gradient all reduce for the LayerNorm parameters to after `deepspeed.initialize`. Update the gradient hook to sum in the LayerNorm gradient in the sequence dimension instead of average.

Test Plan
- [x]  Printed gradients and verified they're now synced across GPUs
- [x]  Printed LayerNorm parameters after 10 steps and verified they're now in sync

This PR does not fix the convergence issue, since the loss still ends up flat-lining around 7.5 for enwiki8. When printing out LayerNorm parameters, I observed that in the current `sequence_parallel=True` implementation, the LayerNorm weight parameters change much slower than when `sequence_parallel=False`.