### PR TITLE
Improve performance of sequence parallel gather, scatter, and reduce

### DIFF
--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -111,7 +111,7 @@ Logging Arguments
 
 - **git_hash**: str
 
-    Default = 28a5a62
+    Default = 53d0ae8
 
     current git hash of repository
 
@@ -1060,9 +1060,9 @@ Parallelism Arguments
 
     Default = False
 
-    flag to determine whether Megatron-style (https://arxiv.org/abs/2205.05198) Sequence-Parallelism 
-    (sharding acts along seq. dim among TP group for LNs) will be used. Has no effect when model_parallel_size is 1.
-    **Set by user.**
+    flag to determine whether Megatron-style Sequence Parallelism (https://arxiv.org/abs/2205.05198)
+    (Layernorm inputs and activations are sharded across model parallel group) will be used. Has no effect when model_parallel_size is 1.
+    **Set by user, in contrast to neox_args.is_pipe_parallel.**
 
 
 

--- a/megatron/mpu/mappings.py
+++ b/megatron/mpu/mappings.py
@@ -108,6 +108,7 @@ def _reduce_scatter_along_seq_dim(input_, seq_dim):
     assert dim_size[seq_dim] % world_size == 0
 
     if seq_dim == 0:
+        # reduce_scatter_tensor is faster but only works correctly on dimension 0
         dim_size[seq_dim] = dim_size[seq_dim] // world_size
         output = torch.empty(
             dim_size, dtype=input_.dtype, device=torch.cuda.current_device()
@@ -144,6 +145,7 @@ def _gather_along_seq_dim(input_, seq_dim):
     dim_size[seq_dim] = dim_size[seq_dim] * world_size
 
     if seq_dim == 0:
+        # reduce_gather_tensor is faster but only works correctly on dimension 0
         output = torch.empty(
             dim_size, dtype=input_.dtype, device=torch.cuda.current_device()
         )


### PR DESCRIPTION
Improve the performance of sequence parallel gather, scatter, and reduce by using `reduce_scatter_tensor` and `all_gather_into_tensor` when possible.

WandB before: https://wandb.ai/brandony/neox/runs/wcim8pf6?nw=nwuserbrandony
WandB after: https://wandb.ai/brandony/neox/runs/gkaoomq5?nw=nwuserbrandony

From the plot, goes from 15.7e12 flops to 17.3e12 flops, with baseline at 18e12 flops.
![image](https://github.com/user-attachments/assets/de8bd83b-66fc-4c75-8222-7e021e5b45b9)
