### PR TITLE
Add initial ring flash attention support

### DIFF
--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -464,6 +464,7 @@ class ParallelSelfAttention(nn.Module):
         self.rope_fusion = neox_args.rope_fusion
         self.attention_type = neox_args.attention_config[layer_number]
         self.use_flash_attention = self.attention_type == "flash"
+        self.use_ring_attention = self.attention_type == "ring"
         self.use_triton = (
             self.use_flash_attention
             and self.pos_emb == "alibi"
@@ -472,7 +473,7 @@ class ParallelSelfAttention(nn.Module):
                 >= packaging.version.Version("2.4.0.post1")
             )
         )
-        self.sparse = self.attention_type not in ("global", "flash")
+        self.sparse = self.attention_type not in ("global", "flash", "ring")
 
         if self.gqa:
             assert not self.sparse
@@ -501,6 +502,12 @@ class ParallelSelfAttention(nn.Module):
                 self.flash_triton_fn = flash_attn_unpadded_unpacked_func_triton
                 self.flash_qkv_fn = flash_attn_func
                 self.flash_varlen_qkv_fn = flash_attn_varlen_func
+            elif self.use_ring_attention:
+                from ring_flash_attn.zigzag_ring_flash_attn import (
+                    zigzag_ring_flash_attn_func,
+                )
+
+                self.ring_attn_fn = zigzag_ring_flash_attn_func
             else:
                 self.scale_mask_softmax = FusedScaleMaskSoftmax(
                     input_in_fp16=self.fp16,
@@ -748,6 +755,96 @@ class ParallelSelfAttention(nn.Module):
 
         return matmul_result
 
+    def ring_attention(self, query_layer, key_layer, value_layer):
+        # [b, np, sq, sk]
+        output_size = (
+            query_layer.size(1),
+            query_layer.size(2),
+            query_layer.size(0),
+            key_layer.size(0),
+        )
+
+        # [sk, b, np, hn] -> [b, sk, np, hn] -> [b * sk, 1, np, hn]
+        key_layer = key_layer.transpose(0, 1).reshape(
+            output_size[0], output_size[3], self.num_kv_heads_per_partition, -1
+        )
+        value_layer = value_layer.transpose(0, 1).reshape(
+            output_size[0], output_size[3], self.num_kv_heads_per_partition, -1
+        )
+
+        # [sq, b, np, hn] -> [b, sq, np, hn]
+        query_layer = query_layer.transpose(0, 1).reshape(
+            output_size[0], output_size[2], output_size[1], -1
+        )
+
+        # only pass in window_size or alibi_slopes kwarg
+        # if we use Sliding Window Attention / AliBi.
+        # Flash attn defaults to (-1,-1), or
+        # does not have this kwarg prior to v2.3.0
+        extra_kwargs = (
+            {"window_size": (self.sliding_window_width, -1)}
+            if self.sliding_window_width is not None
+            else {}
+        )
+        if self.pos_emb == "alibi":
+            extra_kwargs["alibi_slopes"] = self.alibi_embed.slopes.to(
+                query_layer.device
+            ).to(torch.float32)
+
+        if not self.training:
+            batch_size = output_size[0]
+            max_seqlen_q = output_size[2]
+            max_seqlen_k = output_size[3]
+
+            cu_seqlens_q = torch.arange(
+                0,
+                (batch_size + 1) * max_seqlen_q,
+                step=max_seqlen_q,
+                dtype=torch.int32,
+                device=query_layer.device,
+            )
+
+            cu_seqlens_k = torch.arange(
+                0,
+                (batch_size + 1) * max_seqlen_k,
+                step=max_seqlen_k,
+                dtype=torch.int32,
+                device=key_layer.device,
+            )
+
+            q_shape = query_layer.shape
+            k_shape = key_layer.shape
+            v_shape = value_layer.shape
+            is_causal = max_seqlen_q == max_seqlen_k
+            output = self.ring_attn_fn(
+                query_layer,
+                key_layer,
+                value_layer,
+                0.0,
+                softmax_scale=None,
+                causal=is_causal,
+                group=mpu.get_seq_parallel_group(),
+                **extra_kwargs,
+            )
+            output = output.reshape(q_shape)
+        else:
+            output = self.ring_attn_fn(
+                query_layer,
+                key_layer,
+                value_layer,
+                self.dropout_p if self.training else 0.0,
+                softmax_scale=None,
+                causal=True,
+                group=mpu.get_seq_parallel_group(),
+                **extra_kwargs,
+            )
+
+        matmul_result = output
+        # [b, sq, np, hn] -> [b, np, sq, hn]
+        matmul_result = matmul_result.transpose(1, 2)
+
+        return matmul_result
+
     def sparse_attention(self, query_layer, key_layer, value_layer, attention_mask):
         # TODO: sparse attn dropout?
         # TODO: pad to block size
@@ -843,7 +940,7 @@ class ParallelSelfAttention(nn.Module):
         value_layer = value_layer.view(*new_kv_shape)
 
         # if not using Flash attention, we repeat K/V heads to match Q head counts
-        if not self.use_flash_attention:
+        if not (self.use_flash_attention or self.use_ring_attention):
             key_layer = torch.repeat_interleave(
                 key_layer,
                 repeats=int(
@@ -957,6 +1054,8 @@ class ParallelSelfAttention(nn.Module):
 
         if self.use_flash_attention:
             context_layer = self.flash_attention(query_layer, key_layer, value_layer)
+        elif self.use_ring_attention:
+            context_layer = self.ring_attention(query_layer, key_layer, value_layer)
         elif not self.sparse:
             context_layer = self.attention(
                 query_layer, key_layer, value_layer, layer_past, attention_mask

--- a/megatron/model/utils.py
+++ b/megatron/model/utils.py
@@ -22,6 +22,16 @@ from megatron.model.norms import LayerNorm, RMSNorm, ScaleNorm
 from megatron.model.fused_softmax import SoftmaxFusionTypes
 from types import GeneratorType
 import torch.distributed as dist
+from megatron.mpu import (
+    get_seq_parallel_group,
+    get_seq_parallel_src_rank,
+    get_seq_parallel_rank,
+    get_seq_parallel_world_size,
+)
+from megatron.mpu.mappings import (
+    _GatherFromSeqParallelRegion,
+    _ScatterToSeqParallelRegion,
+)
 
 
 def get_params_for_weight_decay_optimization(module, neox_args):

--- a/megatron/monkeypatcher.py
+++ b/megatron/monkeypatcher.py
@@ -1,0 +1,109 @@
+from deepspeed import comm as dist
+
+try:
+    from torch._six import inf
+except ModuleNotFoundError:
+    from torch import inf
+import torch
+from collections.abc import Iterable
+from deepspeed.accelerator import get_accelerator
+from deepspeed.runtime.utils import clip_tensors_by_global_norm
+
+
+def get_global_norm_of_tensors(input_tensors, norm_type=2, mpu=None):
+    # Overwrite of https://github.com/EleutherAI/DeeperSpeed/blob/main/deepspeed/runtime/utils.py#L866-L901
+    # To support sequence parallel
+    """Get norm of an iterable of tensors.
+    This is adapted from torch.nn.utils.clip_grad.clip_grad_norm_ and
+    added functionality to handle model parallel parameters. Taken from Nvidia Megatron.
+    Arguments:
+        input_tensors (Iterable[Tensor]): an iterable of Tensors will have norm computed
+        norm_type (float or int): type of the used p-norm. Can be ``'inf'`` for
+            infinity norm.
+    Returns:
+        Total norm of the tensors (viewed as a single vector).
+    """
+
+    assert isinstance(
+        input_tensors, Iterable
+    ), f"expected Iterable type not {type(input_tensors)}"
+    assert all(
+        [torch.is_tensor(t) for t in input_tensors]
+    ), f"expected list of only tensors"
+
+    norm_type = float(norm_type)
+    if norm_type == inf:
+        total_norm = max(t.data.abs().max() for t in input_tensors)
+        total_norm_cuda = get_accelerator().FloatTensor([float(total_norm)])
+        if mpu is not None:
+            dist.all_reduce(
+                total_norm_cuda,
+                op=dist.ReduceOp.MAX,
+                group=mpu.get_model_parallel_group(),
+            )
+            dist.all_reduce(
+                total_norm_cuda,
+                op=dist.ReduceOp.MAX,
+                group=mpu.get_seq_parallel_group(),
+            )
+            total_norm = total_norm_cuda[0].item()
+    else:
+        total_norm = sum(
+            [t.data.float().norm(norm_type).item() ** norm_type for t in input_tensors]
+        )
+        total_norm_cuda = get_accelerator().FloatTensor([float(total_norm)])
+        if mpu is not None:
+            dist.all_reduce(
+                total_norm_cuda,
+                op=dist.ReduceOp.SUM,
+                group=mpu.get_model_parallel_group(),
+            )
+            dist.all_reduce(
+                total_norm_cuda,
+                op=dist.ReduceOp.SUM,
+                group=mpu.get_seq_parallel_group(),
+            )
+        total_norm = total_norm_cuda[0].item() ** (1.0 / norm_type)
+
+    if (
+        total_norm == float("inf")
+        or total_norm == -float("inf")
+        or total_norm != total_norm
+    ):
+        total_norm = -1
+
+    return total_norm
+
+
+def replace_engine_get_global_norm(engine):
+    @torch.no_grad()
+    def step(closure=None):
+        # to monkeypatch https://github.com/EleutherAI/DeeperSpeed/blob/main/deepspeed/runtime/bf16_optimizer.py#L233-L253
+        self = engine.optimizer
+        if closure is not None:
+            raise NotImplementedError(f"{self.__class__} does not support closure.")
+
+        all_groups_norm = get_global_norm_of_tensors(
+            input_tensors=self.get_grads_for_norm(),
+            mpu=self.mpu,
+            norm_type=self.norm_type,
+        )
+        self._global_grad_norm = all_groups_norm
+
+        assert all_groups_norm > 0.0
+        if self.clip_grad > 0.0:
+            clip_tensors_by_global_norm(
+                input_tensors=self.get_grads_for_norm(for_clipping=True),
+                max_norm=self.clip_grad,
+                global_norm=all_groups_norm,
+                mpu=self.mpu,
+            )
+
+        self.optimizer.step()
+
+        self.update_lp_params()
+
+        self.clear_hp_grads()
+
+    engine.optimizer.step = step
+    return engine

--- a/megatron/mpu/__init__.py
+++ b/megatron/mpu/__init__.py
@@ -54,3 +54,10 @@ from .random import model_parallel_cuda_manual_seed
 
 from .utils import divide
 from .utils import split_tensor_along_last_dim
+from .data import zigzag_data
+from .initialize import (
+    get_seq_parallel_group,
+    get_seq_parallel_rank,
+    get_seq_parallel_world_size,
+    get_seq_parallel_src_rank,
+)

--- a/megatron/mpu/data.py
+++ b/megatron/mpu/data.py
@@ -17,6 +17,10 @@ import torch
 from .initialize import get_model_parallel_group
 from .initialize import get_model_parallel_rank
 from .initialize import get_model_parallel_src_rank
+from .initialize import get_seq_parallel_src_rank
+from .initialize import get_seq_parallel_group
+from .initialize import get_seq_parallel_rank
+from .initialize import get_seq_parallel_world_size
 
 
 _MAX_DATA_DIM = 4
@@ -38,7 +42,7 @@ def _build_key_size_numel_dictionaries(keys, data):
     sizes = [0 for _ in range(max_dim) for _ in keys]
 
     # Pack the sizes on rank zero.
-    if get_model_parallel_rank() == 0:
+    if (get_model_parallel_rank() == 0) and (get_seq_parallel_rank() == 0):
         offset = 0
         for key in keys:
             assert data[key].dim() < max_dim, "you should increase MAX_DATA_DIM"
@@ -51,6 +55,9 @@ def _build_key_size_numel_dictionaries(keys, data):
     sizes_cuda = torch.cuda.LongTensor(sizes)
     torch.distributed.broadcast(
         sizes_cuda, get_model_parallel_src_rank(), group=get_model_parallel_group()
+    )
+    torch.distributed.broadcast(
+        sizes_cuda, get_seq_parallel_src_rank(), group=get_seq_parallel_group()
     )
 
     # Move back to cpu and unpack.
@@ -76,7 +83,7 @@ def _build_key_size_numel_dictionaries(keys, data):
     return key_size, key_numel, total_numel
 
 
-def broadcast_data(keys, data, datatype):
+def broadcast_data(keys, data, datatype, zigzag=False):
     """Broadcast data from rank zero of each model parallel group to the
     members of the same model parallel group.
 
@@ -91,7 +98,7 @@ def broadcast_data(keys, data, datatype):
     key_size, key_numel, total_numel = _build_key_size_numel_dictionaries(keys, data)
 
     # Pack on rank zero.
-    if get_model_parallel_rank() == 0:
+    if (get_model_parallel_rank() == 0) and (get_seq_parallel_rank() == 0):
         # Check that all keys have the same data type.
         _check_data_types(keys, data, datatype)
         # Flatten the data associated with the keys
@@ -107,6 +114,9 @@ def broadcast_data(keys, data, datatype):
     torch.distributed.broadcast(
         flatten_data, get_model_parallel_src_rank(), group=get_model_parallel_group()
     )
+    torch.distributed.broadcast(
+        flatten_data, get_seq_parallel_src_rank(), group=get_seq_parallel_group()
+    )
 
     # Unpack
     output = {}
@@ -117,4 +127,23 @@ def broadcast_data(keys, data, datatype):
         output[key] = flatten_data.narrow(0, offset, numel).view(size)
         offset += numel
 
-    return output
+    return output if not zigzag else {key: zigzag_data(output[key]) for key in keys}
+
+
+def zigzag_data(data, seq_dim=1):
+    """Zigzag the data along the seq dimension.
+    Arguments:
+        data: data dictionary of string keys and cpu tensor values.
+        seq_dim: the sequence dimension to zigzag.
+    """
+    worldsize = get_seq_parallel_world_size()
+    # first check if we can just skip it...
+    if worldsize == 1:
+        return data
+    # otherwise prepare for zigzagging
+    seq_chunks = torch.chunk(data, 2 * worldsize, dim=seq_dim)
+    data = [
+        torch.cat((seq_chunks[i], seq_chunks[-(i + 1)]), dim=seq_dim)
+        for i in range(worldsize)
+    ]
+    return data[get_seq_parallel_rank()].contiguous()

--- a/megatron/neox_arguments/arguments.py
+++ b/megatron/neox_arguments/arguments.py
@@ -753,8 +753,11 @@ class NeoXArgs(*BASE_CLASSES):
         if self.rank == 0:
             print(
                 self.__class__.__name__
-                + ".configure_distributed_args() using world size: {} and model-parallel size: {} ".format(
-                    self.world_size, self.model_parallel_size
+                + ".configure_distributed_args() using world size: {}, pipe-parallel size: {}, sequence-parallel size: {}, and model-parallel size: {} ".format(
+                    self.world_size,
+                    self.pipe_parallel_size,
+                    self.sequence_parallel_size,
+                    self.model_parallel_size,
                 ),
                 flush=True,
             )
@@ -794,7 +797,9 @@ class NeoXArgs(*BASE_CLASSES):
 
         # either none of the three parameters are provided or just gradient_accumulation_step is provided
         else:
-            assert False, "Either train_batch_size or train_micro_batch_size_per_gpu needs to be provided"
+            assert (
+                False
+            ), "Either train_batch_size or train_micro_batch_size_per_gpu needs to be provided"
         return int(train_batch), int(micro_batch), int(grad_acc)
 
     @staticmethod
@@ -855,10 +860,13 @@ class NeoXArgs(*BASE_CLASSES):
         pp_size = pp_size if pp_size >= 1 else 1
         mp_size = self.model_parallel_size
         mp_size = mp_size if mp_size >= 1 else 1
+        sp_size = self.sequence_parallel_size
+        sp_size = sp_size if sp_size >= 1 else 1
         self.update_value("model_parallel_size", mp_size)
+        self.update_value("sequence_parallel_size", sp_size)
 
-        # pp_size and mp_size are only used here to compute dp world size and nowhere else.
-        dp_world_size = (global_num_gpus / pp_size) / mp_size
+        # pp_size, mp_size, and sp_size are only used here to compute dp world size and nowhere else.
+        dp_world_size = (global_num_gpus / pp_size) / (mp_size * sp_size)
         if not (dp_world_size % 1 == 0):
             error_message = (
                 self.__class__.__name__
@@ -1029,6 +1037,11 @@ class NeoXArgs(*BASE_CLASSES):
         # if we set pipe_parallel_size to 0 or 1, GPT2ModelPipe.to_sequential() is called, and we run training with
         # the sequential model without the PipelineModule wrapper to avoid the overhead it incurs
         self.update_value("is_pipe_parallel", self.pipe_parallel_size >= 1)
+        # update 'is sequence parallel' flag
+        self.update_value(
+            "is_sequence_parallel",
+            self.sequence_parallel_size > 1 and self.num_experts == 1,
+        )
         if self.moe_num_experts > 1:
             assert not (
                 self.is_pipe_parallel or self.pipe_parallel_size > 1
@@ -1043,6 +1056,13 @@ class NeoXArgs(*BASE_CLASSES):
             "attention_config",
             expand_attention_types(self.attention_config, self.num_layers),
         )
+        self.update_value(
+            "requires_attention_mask",
+            not all([item in ["ring", "flash"] for item in self.attention_config]),
+        )
+        assert all([item == "ring" for item in self.attention_config]) or (
+            not self.is_sequence_parallel
+        ), "Sequence parallel requires ring attention!"
         assert (
             len(self.attention_config) == self.num_layers
         ), "Length of attention config list must equal num_layers"
@@ -1088,7 +1108,9 @@ class NeoXArgs(*BASE_CLASSES):
                     not self.sparsity_config
                 ), "Sparse attention not compatible with GQA or MQA"
                 assert all(
-                    (attn_type == "flash") or (attn_type == "global")
+                    (attn_type == "flash")
+                    or (attn_type == "global")
+                    or (attn_type == "ring")
                     for attn_type in self.attention_config
                 ), "GQA / MQA currently only compatible with Flash or standard global/sliding window Attention"
                 assert (
@@ -1098,8 +1120,8 @@ class NeoXArgs(*BASE_CLASSES):
         if "flash" in self.attention_config:
             _flash_version = packaging.version.Version(version("flash-attn"))
             if self.sliding_window_width is not None:
-                assert (
-                    _flash_version >= packaging.version.Version("2.3.0")
+                assert _flash_version >= packaging.version.Version(
+                    "2.3.0"
                 ), f"Flash-Attention version ({str(_flash_version)}) must be >= 2.3.0 to support sliding window attention."
             if self.pos_emb == "alibi":
                 if not _flash_version >= packaging.version.Version("2.4.0.post1"):

--- a/megatron/neox_arguments/neox_args.py
+++ b/megatron/neox_arguments/neox_args.py
@@ -38,6 +38,7 @@ ATTENTION_TYPE_CHOICES = [
     "flash",
     "rwkv",
     "mamba",
+    "ring",
 ]
 
 
@@ -67,6 +68,11 @@ class NeoXArgsParallelism(NeoXArgsTemplate):
     Size of the model parallelism.
     """
 
+    sequence_parallel_size: int = 1
+    """
+    Size of the sequence parallelism.
+    """
+
     pipe_partition_method: str = "type:transformer|mlp"
     """
     method used to distribute model layers across pipeline stages. Choose from "parameters", which balances the number
@@ -83,6 +89,12 @@ class NeoXArgsParallelism(NeoXArgsTemplate):
     """
     flag to determine whether pipeline parallelism is on - shouldn't be set by user, is automatically determined
     according to pipeline parallel size.
+    """
+
+    is_sequence_parallel: bool = False
+    """
+    flag to determine whether sequence parallelism is on - shouldn't be set by user, is automatically determined
+    according to sequence parallel size.
     """
 
     expert_interval: int = 2
@@ -217,7 +229,7 @@ class NeoXArgsModel(NeoXArgsTemplate):
     The first item in the list specifies the attention type(s), and should be a list of strings. The second item
     specifies the number of times to repeat those attention types in the full list.
 
-    attention type choices:  [global, local, sparse_fixed, sparse_variable, bslongformer, bigbird, "gmlp", "amlp", "flash", "mamba", "rwkv"]
+    attention type choices:  [global, local, sparse_fixed, sparse_variable, bslongformer, bigbird, "gmlp", "amlp", "flash", "mamba", "rwkv", "ring"]
 
     So a 12 layer network with only global attention could be specified like:
         [[[`global`], 12]]
@@ -227,6 +239,12 @@ class NeoXArgsModel(NeoXArgsTemplate):
 
     If none is specified, this defaults to
         [[[`global`], n_layers]]
+    """
+
+    requires_attention_mask: bool = True
+    """
+    If true, the model requires an attention mask to be passed in.
+    Automatically configured based on attention type.
     """
 
     sparsity_config: dict = None

--- a/megatron/utils.py
+++ b/megatron/utils.py
@@ -81,22 +81,29 @@ def get_attn_mask(seq_length, device, sliding_window_width):
 
 
 def get_ltor_masks_and_position_ids(
-    data,
-    eod_token,
-    eod_mask_loss=False,
-    sliding_window_width=None,
+    data, eod_token, eod_mask_loss=False, sliding_window_width=None, requires_mask=True
 ):
     """Build masks and position id for left to right model."""
 
     # Extract batch size and sequence length.
     batch_size, seq_length = data.size()
 
-    # Attention mask (lower triangular).
-    attention_mask = get_attn_mask(
-        seq_length=seq_length,
-        device=data.device,
-        sliding_window_width=sliding_window_width,
-    )
+    if requires_mask:
+        # Attention mask (lower triangular).
+        attention_mask = get_attn_mask(
+            seq_length=seq_length,
+            device=data.device,
+            sliding_window_width=sliding_window_width,
+        )
+    else:
+        # Need this to actually do long context, 128k**2 is v big.
+        # Give it a dummy value
+        # Surely there is a better way to do this...
+        attention_mask = get_attn_mask(
+            seq_length=64,
+            device=data.device,
+            sliding_window_width=sliding_window_width,
+        )
 
     # Loss mask.
     loss_mask = torch.ones(data.size(), dtype=torch.float, device=data.device)

--- a/requirements/requirements-ringattention.txt
+++ b/requirements/requirements-ringattention.txt
@@ -1,0 +1,1 @@
+git+https://github.com/zhuzilin/ring-flash-attention.git@0.1


### PR DESCRIPTION
- Only tested with BF16 Zero2 (on a separate repo, so beware copy/paste errors)
- Made an assumption that SP should have preference over TP to be on the same node in the topology, but happy to revisit that
- Only supports the zigzag convention of ring attention
- The attention mask stuff is v important, it lets you do 128k context on 1 node even without ring attention