### PR TITLE
Fix off by 1 error on masked tokens for RM training

### DIFF
--- a/tools/datasets/preprocess_data_with_chat_template.py
+++ b/tools/datasets/preprocess_data_with_chat_template.py
@@ -103,6 +103,9 @@ def build_chat(
         tokens = tokenizer.apply_chat_template(chat)
         mask = [-100] * len(tokens)
         if tokenizer.eos_token_id is not None:
+            # since this is processed in a causal format (input[:-1], mask[1:], we need to put two here...
+            mask.append(-100)
+            tokens.append(tokenizer.eos_token_id)
             mask.append(tokenizer.eos_token_id)
             tokens.append(tokenizer.eos_token_id)
         else:


### PR DESCRIPTION
since the mask is assumed to be causal, previously we were doing the reward value on the last token in the sequence, not the EOS token. Did not affect llama-3 models much, since the EOS token is double applied in this instance (the chat has an EOS token already), but would be potentially problematic for other models.