### PR TITLE
Fix dataset bug

### DIFF
--- a/megatron/data/gpt2_dataset.py
+++ b/megatron/data/gpt2_dataset.py
@@ -123,7 +123,7 @@ class GPT2Dataset(torch.utils.data.Dataset):
                         samples.append(
                             dataset.get(
                                 self.doc_idx[doc_index_f],
-                                offset=offset_l,
+                                offset=offset_f,
                                 length=offset_l - offset_f + 1,
                             )
                         )


### PR DESCRIPTION
There was a typo from https://github.com/EleutherAI/gpt-neox/pull/1244/files#diff-383134de6f3512484e20625419bd5fb6b1675a922f47aeb1a6bd3cff6185a754R126 that snuck in. 

Only showed up after several hundred iterations.

FYI -- @aurelion-source @dmahan93 