### PR TITLE
TE integration via full TransformerLayer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
 # Copyright (c) 2024, EleutherAI
+# This file is based on code by the authors denoted below and has been modified from its original version.
+#
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM nvcr.io/nvidia/pytorch:24.02-py3
+FROM nvcr.io/nvidia/pytorch:24.06-py3
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -21,7 +24,7 @@ LABEL org.opencontainers.image.version = "2.0"
 LABEL org.opencontainers.image.authors = "contact@eleuther.ai"
 LABEL org.opencontainers.image.source = "https://www.github.com/eleutherai/gpt-neox"
 LABEL org.opencontainers.image.licenses = " Apache-2.0"
-LABEL org.opencontainers.image.base.name="nvcr.io/nvidia/pytorch:24.02-py3"
+LABEL org.opencontainers.image.base.name="nvcr.io/nvidia/pytorch:24.06-py3"
 
 #### System package (uses default Python 3 version in Ubuntu 20.04)
 RUN apt-get update -y && \
@@ -81,6 +84,12 @@ RUN python -m pip install protobuf==3.20.*
 COPY megatron/fused_kernels/ /megatron/fused_kernels
 WORKDIR /megatron/fused_kernels
 RUN python setup.py install
+
+SHELL ["/bin/bash", "-c"]
+
+RUN DS_BUILD_FUSED_LAMB=1 DS_BUILD_FUSED_ADAM=1 DS_BUILD_TRANSFORMER=1 DS_BUILD_STOCHASTIC_TRANSFORMER=1  DS_BUILD_UTILS=1 \
+    TORCH_CUDA_ARCH_LIST="8.0 9.0+PTX" \
+    python -m pip install git+https://github.com/microsoft/DeepSpeed.git@v0.14.4
 
 # Clear staging
 RUN mkdir -p /tmp && chmod 0777 /tmp

--- a/megatron/model/gpt2_model.py
+++ b/megatron/model/gpt2_model.py
@@ -30,6 +30,7 @@ from megatron.model.init_functions import get_init_methods
 from megatron import mpu
 from megatron.mpu import ParallelRelativePositionBias
 from megatron.model.transformer import (
+    ParallelTETransformerLayerPipe,
     ParallelTransformerLayerPipe,
     NormPipe,
     ParallelLinearPipe,
@@ -269,6 +270,24 @@ class GPT2ModelPipe(PipelineModule, torch.nn.Module):
                         init_method=self.init_method,
                         output_layer_init_method=self.output_layer_init_method,
                         layer_number=i,
+                    )
+                )
+            elif layer_type in ["TE"]:
+                self.specs.append(
+                    LayerSpec(
+                        ParallelTETransformerLayerPipe,
+                        hidden_size=self.neox_args.hidden_size,
+                        ffn_hidden_size=self.neox_args.hidden_size * 4,
+                        num_attention_heads=self.neox_args.num_attention_heads,
+                        hidden_dropout=self.neox_args.hidden_dropout,
+                        attention_dropout=self.neox_args.attention_dropout,
+                        init_method=self.init_method,
+                        output_layer_init_method=self.output_layer_init_method,
+                        layer_number=i + 1,
+                        params_dtype=self.neox_args.params_dtype,
+                        attn_input_format="sbhd",
+                        seq_length=self.neox_args.seq_length,
+                        set_parallel_mode=True
                     )
                 )
             else:

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -38,6 +38,14 @@ from megatron.model.positional_embeddings import (
     apply_rotary_pos_emb,
     AliBi,
 )
+
+from transformer_engine.pytorch import TransformerLayer
+from transformer_engine.pytorch.attention import RotaryPositionEmbedding
+from transformer_engine.pytorch import checkpoint
+
+import transformer_engine.pytorch as te
+from transformer_engine.common.recipe import Format, DelayedScaling
+
 from megatron.model.fused_rope import (
     FusedRoPEFunc,
     fused_apply_rotary_pos_emb_cached,
@@ -460,7 +468,7 @@ class ParallelSelfAttention(nn.Module):
                 >= packaging.version.Version("2.4.0.post1")
             )
         )
-        self.sparse = self.attention_type not in ("global", "flash")
+        self.sparse = self.attention_type not in ("global", "flash", "TE")
 
         if self.gqa:
             assert not self.sparse
@@ -1299,6 +1307,38 @@ class ParallelTransformerLayerPipe(ParallelTransformerLayer):
         output, moe_loss = super().forward(hidden_states, attention_mask)
         # auxiliary output
         self.last_moe_loss = moe_loss
+        return output, attention_mask
+
+class ParallelTETransformerLayerPipe(TransformerLayer):
+    """
+    Layer in the spirit of ParallelTransformerLayerPipe, but with the TE transformer layer.
+    """
+    def __init__(self, *args, **kwargs):
+
+        self.tp_group = mpu.get_tensor_model_parallel_group()
+
+        super().__init__(
+            *args,
+            **kwargs,
+            tp_group=self.tp_group
+        )
+
+        hidden_size_per_attention_head = mpu.divide(
+            kwargs["hidden_size"], kwargs["num_attention_heads"]
+        )
+        PE = RotaryPositionEmbedding(dim=hidden_size_per_attention_head)
+        self.rotary_pos_emb = PE(kwargs["seq_length"]).to(device="cuda")
+
+    def forward(self, args):
+        assert len(args) == 2, ("TE transformer layer pipe must have two args, hidden_states and the attention mask. "
+                                "The mask will be discarded")
+        hidden_states, attention_mask = args
+
+        fp8_format = Format.HYBRID  # E4M3 during forward pass, E5M2 during backward pass
+        fp8_recipe = DelayedScaling(fp8_format=fp8_format, amax_history_len=1024, amax_compute_algo="max")
+        with te.fp8_autocast(enabled=False, fp8_recipe=fp8_recipe, fp8_group=self.tp_group):
+            output = checkpoint(super().forward, hidden_states, distribute_saved_activations=True, tp_group=self.tp_group, rotary_pos_emb=self.rotary_pos_emb)
+
         return output, attention_mask
 
 

--- a/megatron/neox_arguments/neox_args.py
+++ b/megatron/neox_arguments/neox_args.py
@@ -28,6 +28,7 @@ except ImportError:
 
 ATTENTION_TYPE_CHOICES = [
     "global",
+    "TE",
     "local",
     "sparse_fixed",
     "sparse_variable",


### PR DESCRIPTION
This is a sketch of using the attention picking mechanism ("global", "flash", NEW: "TE") to use the high level TransformerLayer from TransformerEngine. This is more of a prototype to show that integration with deepspeed is possible and what perf to expect.

Things that work:
1. TE attention TFLOPS are 5% higher than flash attention in BF16, and 70% higher in FP8
2. Training an 22B model on multiple DGXH100 with zero 1 and TP2 (BF16)
3. Activation checkpointing from TE

Many aspects are hardcoded, e.g. RoPE and activation checkpointing can not be reconfigured from the config files. #1282 is much more elaborate in that it exposes TE layers on a much lower level. Meanwhile this PR could serve as a benchmark, showing what is possible with TE on a classic GPT2 style network.

I kept the implementation as minimal as possible, there is room for further performance depending on the workload. There is e.g. sequence parallelism and different memory layouts.

The dockerfile now uses a later ngc pytorch container and installs a later deepspeed tag from source for compatibility.