### PR TITLE
Add ERROR logging prefix and sort the prefixes alphabetically

### DIFF
--- a/megatron/neox_arguments/arguments.py
+++ b/megatron/neox_arguments/arguments.py
@@ -50,16 +50,19 @@ from .neox_args import (
     ATTENTION_TYPE_CHOICES,
 )
 
-### Logging colors ###
+### Base logging colors ###
+END = "\033[0m"
 GREEN = "\033[92m"
 RED = "\033[91m"
 YELLOW = "\033[93m"
-END = "\033[0m"
-SUCCESS = f"{GREEN} [SUCCESS] {END}"
-OKAY = f"{GREEN}[OKAY]{END}"
-WARNING = f"{YELLOW}[WARNING]{END}"
+
+### Formatted logging prefixes ###
+ERROR = f"{RED}[ERROR]{END} "
 FAIL = f"{RED}[FAIL]{END}"
 INFO = "[INFO]"
+OKAY = f"{GREEN}[OKAY]{END}"
+SUCCESS = f"{GREEN} [SUCCESS] {END}"
+WARNING = f"{YELLOW}[WARNING]{END}"
 
 # ZERO defaults by deespeed
 # These values should not be changed unless defaults in deepspeed are changed

--- a/megatron/neox_arguments/arguments.py
+++ b/megatron/neox_arguments/arguments.py
@@ -50,7 +50,7 @@ from .neox_args import (
     ATTENTION_TYPE_CHOICES,
 )
 
-### Base logging colors ###
+### ANSI escape codes ###
 END = "\033[0m"
 GREEN = "\033[92m"
 RED = "\033[91m"


### PR DESCRIPTION
When trying to run `./deepy.py train.py ...` I got the following error:

> `NameError: name 'ERROR' is not defined`

I tracked this down and found that we have a number of formatted logging prefixes with colors, but `ERROR` was missing. I added that (with the color red, same as for `FAIL`), sorted the prefixes alphabetically, and grouped them a bit for clearer organization. Tested and got an actual error message after the change.