### PR TITLE
fix 'intermediate_size' in Llama configuration files after the 'mlp_type' option was removed

### DIFF
--- a/configs/llama/13B.yml
+++ b/configs/llama/13B.yml
@@ -6,6 +6,7 @@
   # model settings
   "num_layers": 40,
   "hidden_size": 5120,
+  "intermediate_size": 40960,
   "num_attention_heads": 40,
   "seq_length": 2048,
   "max_position_embeddings": 2048,

--- a/configs/llama/13B.yml
+++ b/configs/llama/13B.yml
@@ -17,6 +17,7 @@
   "output_layer_parallelism": "column",
   "norm": "rmsnorm",
   "rms_norm_epsilon": 1.0e-6,
+  "use_bias_in_mlp": False,
 
   "scaled_upper_triang_masked_softmax_fusion": true,
   "bias_gelu_fusion": false,

--- a/configs/llama/30B.yml
+++ b/configs/llama/30B.yml
@@ -17,6 +17,7 @@
   "output_layer_parallelism": "column",
   "norm": "rmsnorm",
   "rms_norm_epsilon": 1.0e-6,
+  "use_bias_in_mlp": False,
 
   "scaled_upper_triang_masked_softmax_fusion": true,
   "bias_gelu_fusion": false,

--- a/configs/llama/30B.yml
+++ b/configs/llama/30B.yml
@@ -6,6 +6,7 @@
   # model settings
   "num_layers": 60,
   "hidden_size": 6656,
+  "intermediate_size": 53248,
   "num_attention_heads": 52,
   "seq_length": 2048,
   "max_position_embeddings": 2048,

--- a/configs/llama/65B.yml
+++ b/configs/llama/65B.yml
@@ -6,6 +6,7 @@
   # model settings
   "num_layers": 80,
   "hidden_size": 8192,
+  "intermediate_size": 65536,
   "num_attention_heads": 64,
   "seq_length": 2048,
   "max_position_embeddings": 2048,

--- a/configs/llama/65B.yml
+++ b/configs/llama/65B.yml
@@ -17,6 +17,7 @@
   "output_layer_parallelism": "column",
   "norm": "rmsnorm",
   "rms_norm_epsilon": 1.0e-6,
+  "use_bias_in_mlp": False,
 
   "scaled_upper_triang_masked_softmax_fusion": true,
   "bias_gelu_fusion": false,

--- a/configs/llama/7B.yml
+++ b/configs/llama/7B.yml
@@ -17,6 +17,7 @@
   "output_layer_parallelism": "column",
   "norm": "rmsnorm",
   "rms_norm_epsilon": 1.0e-6,
+  "use_bias_in_mlp": False,
 
   "scaled_upper_triang_masked_softmax_fusion": true,
   "bias_gelu_fusion": false,

--- a/configs/llama/7B.yml
+++ b/configs/llama/7B.yml
@@ -6,6 +6,7 @@
   # model settings
   "num_layers": 32,
   "hidden_size": 4096,
+  "intermediate_size": 32768,
   "num_attention_heads": 32,
   "seq_length": 2048,
   "max_position_embeddings": 2048,

--- a/configs/llama/train_config.yml
+++ b/configs/llama/train_config.yml
@@ -70,5 +70,5 @@
   "steps_per_print": 10,
   "keep_last_n_checkpoints": 4,
   "wall_clock_breakdown": true,
-  "mlp_multiple_of": 256,
+  
 }

--- a/configs/llama/train_config.yml
+++ b/configs/llama/train_config.yml
@@ -70,5 +70,5 @@
   "steps_per_print": 10,
   "keep_last_n_checkpoints": 4,
   "wall_clock_breakdown": true,
-  
+
 }

--- a/configs/llama2/13B.yml
+++ b/configs/llama2/13B.yml
@@ -6,6 +6,7 @@
   # model settings
   "num_layers": 40,
   "hidden_size": 5120,
+  "intermediate_size": 41472,
   "num_attention_heads": 40,
   "seq_length": 4096,
   "max_position_embeddings": 4096,

--- a/configs/llama2/70B.yml
+++ b/configs/llama2/70B.yml
@@ -6,7 +6,7 @@
   # model settings
   "num_layers": 80,
   "hidden_size": 8192,
-  "intermediate_size": 28672,
+  "intermediate_size": 86016,
   "num_attention_heads": 64,
   "num_kv_heads": 8,
   "seq_length": 4096,

--- a/configs/llama2/7B.yml
+++ b/configs/llama2/7B.yml
@@ -6,6 +6,7 @@
   # model settings
   "num_layers": 32,
   "hidden_size": 4096,
+  "intermediate_size": 32768,
   "num_attention_heads": 32,
   "seq_length": 4096,
   "max_position_embeddings": 4096,

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -1269,8 +1269,8 @@ class ParallelTransformerLayer(nn.Module):
 
             with torch.enable_grad() if not self.eval else nullcontext():
                 if (
-                    self.activation == "swiglu"
-                    or self.num_experts > 1
+                    mlp_bias == None,
+                    self.num_experts > 1
                     and self.moe_type == "deepspeed"
                 ):
                     # No dropout either

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -1270,8 +1270,7 @@ class ParallelTransformerLayer(nn.Module):
             with torch.enable_grad() if not self.eval else nullcontext():
                 if (
                     mlp_bias == None,
-                    self.num_experts > 1
-                    and self.moe_type == "deepspeed"
+                    self.num_experts > 1 and self.moe_type == "deepspeed",
                 ):
                     # No dropout either
                     assert mlp_bias is None


### PR DESCRIPTION
After the 'mlp_type' option was removed, the regular-type and the llama-type of MLP share the same implementation, and the "mlp_type" is now specified by whether the activation is gated or not.
However, this changes the meaning of the 'intermediate_size' option in llama configuration files. The code (megatron/model/transformer.py) now treats 'intermediate_size' as the size of the output tensor of the first linear layer in the MLP, which includes the first layer and the gated layer of llama-type MLP. This means that the code actually halves the 'intermediate_size' of llama-type MLP. Meanwhile, the code multiplies the 'intermediate_size' by (2/3), which means the actual 'intermediate_size' is only (1/3) of the intended size in the configuration file.

To fix this problem, I revised the llama configuation files, and set the 'intermediate_size' to 3 times as its intended value.
