### PR TITLE
Add Additional Logging Metrics

### DIFF
--- a/configs/eleutherai_cluster.yml
+++ b/configs/eleutherai_cluster.yml
@@ -24,6 +24,7 @@
   "tensorboard_dir": "/mnt/ssd-1/tensorboard",
   "log_dir": "/mnt/ssd-1/logs",
   "wandb_team": "eleutherai",
+  #"wandb_run_name": "experiment"
   "wandb_project": "neox",
   "wandb_group": "example"
 }

--- a/megatron/neox_arguments/__init__.py
+++ b/megatron/neox_arguments/__init__.py
@@ -18,7 +18,7 @@ NeoX args can be instantiated with the following options
 * NeoXArgs.from_ymls(["path_to_yaml1", "path_to_yaml2", ...]): load yaml configuration files and instantiate with the values provided; checks for duplications and unknown arguments are performed
 * NeoXArgs.from_dict({"num_layers": 12, ...}): load attribute values from dict; checks unknown arguments are performed
 
-* NeoXArgs.consume_deepy_args(): entry point for deepy.py configuring and consuming command line arguments (i.e. user_script, conf_dir, conf_file, wandb_group, wandb_team); neox_args.get_deepspeed_main_args() produces a list of command line arguments to feed to deepspeed.launcher.runner.main
+* NeoXArgs.consume_deepy_args(): entry point for deepy.py configuring and consuming command line arguments (i.e. user_script, conf_dir, conf_file, wandb_group, wandb_run_name, wandb_team); neox_args.get_deepspeed_main_args() produces a list of command line arguments to feed to deepspeed.launcher.runner.main
 * NeoXArgs.consume_neox_args(): In the call stack deepy.py -> deepspeed -> pretrain_gpt2.py; arguments are passed to pretrain_gpt2.py by neox_args.get_deepspeed_main_args(). So produced arguments can be read with consume_neox_args() to instantiate a NeoXArgs instance.
 
 

--- a/megatron/neox_arguments/arguments.py
+++ b/megatron/neox_arguments/arguments.py
@@ -336,6 +336,12 @@ class NeoXArgs(*BASE_CLASSES):
             help='Weights & Biases group name - used to group together "runs".',
         )
         group.add_argument(
+            "--wandb_run_name",
+            type=str,
+            default=None,
+            help="Weights & Biases run name for the current experiment.",
+        )
+        group.add_argument(
             "--wandb_team",
             type=str,
             default=None,

--- a/megatron/neox_arguments/neox_args.py
+++ b/megatron/neox_arguments/neox_args.py
@@ -624,6 +624,7 @@ class NeoXArgsLogging(NeoXArgsTemplate):
     Logging Arguments
     """
 
+    ### BEGIN WANDB ARGS ###
     use_wandb: bool = None
     """Flag indicating if wandb is to be used."""
 
@@ -644,6 +645,7 @@ class NeoXArgsLogging(NeoXArgsTemplate):
 
     wandb_init_all_ranks: bool = False
     """Initialize wandb on all ranks."""
+    ### END WANDB ARGS ###
 
     git_hash: str = get_git_commit_hash()
     """current git hash of repository"""
@@ -653,6 +655,7 @@ class NeoXArgsLogging(NeoXArgsTemplate):
     Directory to save logs to.
     """
 
+    ### BEGIN TENSORBOARD ARGS ###
     tensorboard_writer = None
     """
     initialized tensorboard writer
@@ -662,7 +665,9 @@ class NeoXArgsLogging(NeoXArgsTemplate):
     """
     Write TensorBoard logs to this directory.
     """
+    ### END TENSORBOARD ARGS ###
 
+    ### BEGIN COMET ARGS ###
     use_comet: bool = None
     """Flag indicating if comet is to be used."""
 
@@ -695,6 +700,12 @@ class NeoXArgsLogging(NeoXArgsTemplate):
     """
     Initialized comet experiment object used to log data
     """
+    ### END COMET ARGS ###
+
+    peak_theoretical_tflops: float = None
+    """
+    The peak hardware flops with which to compute MFU and HFU, in units of teraflops. Automatic detection is more trouble than it's worth, so this is left to the user. Helpful table listed at https://github.com/stas00/ml-engineering/tree/master/compute/accelerator#tflops-comparison-table
+    """
 
     log_interval: int = 100
     """
@@ -714,8 +725,7 @@ class NeoXArgsLogging(NeoXArgsTemplate):
     log_grad_norm: bool = False
     """
     Log the frob norm of the gradients to wandb / tensorboard (useful for debugging).
-    (N.B - this will only work with pp = 0 for now, as we don't have access to the gradients of the model because
-    deepspeed.)
+    (N.B - this will only work with pp = 0 for now, as we don't have access to the gradients of the model because deepspeed.)
     """
 
     log_optimizer_states: bool = False
@@ -738,6 +748,7 @@ class NeoXArgsLogging(NeoXArgsTemplate):
     Whether to offload the buffered gradients to cpu when measuring gradient noise scale.
     """
 
+    ### BEGIN PROFILING ARGS
     memory_profiling: bool = False
     """
     Whether to take a memory snapshot of the model. Useful for debugging memory issues.
@@ -770,6 +781,7 @@ class NeoXArgsLogging(NeoXArgsTemplate):
     """
     Step to stop profiling at.
     """
+    ### END PROFILING ARGS ###
 
 
 @dataclass

--- a/megatron/neox_arguments/neox_args.py
+++ b/megatron/neox_arguments/neox_args.py
@@ -630,6 +630,9 @@ class NeoXArgsLogging(NeoXArgsTemplate):
     wandb_group: str = None
     """Weights and Biases group name - used to group together "runs"."""
 
+    wandb_run_name: str = None
+    """Weights and Biases run name for the current experiment"""
+
     wandb_team: str = None
     """Team name for Weights and Biases."""
 

--- a/megatron/utils.py
+++ b/megatron/utils.py
@@ -166,12 +166,12 @@ def init_wandb(neox_args):
         neox_args.update_value("use_wandb", use_wandb)
     if neox_args.use_wandb:
         group_name = neox_args.wandb_group
-        name = f"{socket.gethostname()}-{local_rank()}" if group_name else None
+        run_name = neox_args.wandb_run_name
         try:
             wandb.init(
                 project=neox_args.wandb_project,
                 group=group_name,
-                name=name,
+                name=run_name,
                 save_code=False,
                 force=False,
                 entity=neox_args.wandb_team,


### PR DESCRIPTION
- Logs MFU/HFU if the user passes `neox_args.peak_theoretical_tflops`
- Log tokens_per_sec, iters_per_sec to wandb, comet, and tensorboard
- Add ability to manually specify wandb experiment name