### PR TITLE
Update to latest deepspeed

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-deepspeed@git+https://github.com/EleutherAI/DeeperSpeed.git@02e2ebf7dee6aaab3d89094ed470a4609763c742#egg=deepspeed
+deepspeed@git+https://github.com/EleutherAI/DeeperSpeed.git@91d1c55ba037b5ada99ae14884dff87a4dc5b9ea#egg=deepspeed
 ftfy>=6.0.1
 huggingface_hub>=0.11.0
 jinja2==3.1.4


### PR DESCRIPTION
DeeperSpeed is now on latest v0.16.5 (https://github.com/EleutherAI/DeeperSpeed/releases/tag/v3.0)