### PR TITLE
Fix issues with Llama HF->NeoX conversion

### DIFF
--- a/megatron/model/norms.py
+++ b/megatron/model/norms.py
@@ -60,7 +60,7 @@ def get_norm(neox_args):
 
 
 class RMSNorm(torch.nn.Module):
-    def __init__(self, dim, p=-1.0, eps=1e-8, bias=False, alt=False):
+    def __init__(self, dim, p=-1.0, eps=1e-8, bias=False):
         """
             Root Mean Square Layer Normalization
         :param dim: model size
@@ -75,7 +75,6 @@ class RMSNorm(torch.nn.Module):
         self.d = dim
         self.p = p
         self.bias = bias
-        self.alt = alt
 
         self.scale = torch.nn.Parameter(torch.ones(dim))
         self.register_parameter("scale", self.scale)

--- a/tools/ckpts/convert_hf_llama_to_neox.py
+++ b/tools/ckpts/convert_hf_llama_to_neox.py
@@ -62,11 +62,7 @@ def convert_model(hf_state_dict, hf_config, tp_ranks):
             # The GQA code simply expects concatenated q,k,v weights for each tp partition
             conv_state_dicts[i][
                 f"sequential.{layer_num+2}.attention.query_key_value.weight"
-            ] = (
-                torch.cat([q_chunk, k_chunk, v_chunk], dim=0)
-                .clone()
-                .detach()
-            )
+            ] = (torch.cat([q_chunk, k_chunk, v_chunk], dim=0).clone().detach())
         print(
             f"model.layers.{layer_num}.self_attn.(q/k/v)_proj.weight",
             hf_state_dict[f"model.layers.{layer_num}.self_attn.q_proj.weight"].shape,

--- a/tools/ckpts/convert_hf_llama_to_neox.py
+++ b/tools/ckpts/convert_hf_llama_to_neox.py
@@ -51,11 +51,7 @@ def convert_model(hf_state_dict, hf_config, tp_ranks):
         q = hf_state_dict[f"model.layers.{layer_num}.self_attn.q_proj.weight"]
         k = hf_state_dict[f"model.layers.{layer_num}.self_attn.k_proj.weight"]
         v = hf_state_dict[f"model.layers.{layer_num}.self_attn.v_proj.weight"]
-        # The GQA code splits the heads by the num_q_heads so we also do that
-        # here to ensure it matches...
-        q = q.view(num_q_heads, -1, q.shape[-1])
-        k = k.view(num_q_heads, -1, q.shape[-1])
-        v = v.view(num_q_heads, -1, q.shape[-1])
+
         # Chunk for tensor parallelism...
         for i, q_chunk, k_chunk, v_chunk in zip(
             range(tp_ranks),
@@ -63,12 +59,11 @@ def convert_model(hf_state_dict, hf_config, tp_ranks):
             torch.chunk(k, tp_ranks, dim=0),
             torch.chunk(v, tp_ranks, dim=0),
         ):
-            # Need to join the heads across q, k, v...
+            # The GQA code simply expects concatenated q,k,v weights for each tp partition
             conv_state_dicts[i][
                 f"sequential.{layer_num+2}.attention.query_key_value.weight"
             ] = (
-                torch.cat([q_chunk, k_chunk, v_chunk], dim=1)
-                .view(-1, q.shape[-1])
+                torch.cat([q_chunk, k_chunk, v_chunk], dim=0)
                 .clone()
                 .detach()
             )

--- a/tools/ckpts/convert_neox_to_hf.py
+++ b/tools/ckpts/convert_neox_to_hf.py
@@ -626,9 +626,6 @@ def convert(
                     sequential=sequential,
                 )
             )
-            # print(state_dict)
-            # exit()
-        
         # load state_dict into layer
         hf_layer.load_state_dict(state_dict)
 


### PR DESCRIPTION
Resolves #1337 and #1342

- Following #1315, the GQA code no longer splits heads based on num_q_heads. This PR updates tools/ckpts/convert_hf_llama_to_neox.py to concatenate tp-partitioned q, k, and v weights without per-head splitting.
- The current RMSNorm implementation incorrectly adds epsilon to the RMS instead of the variance. Fix is the same as #1342, but ensures compatibility with partial RMSNorm.
