### PR TITLE
NeoX+TE --> HF Conversion 

### DIFF
--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -1037,7 +1037,8 @@ class ParallelTransformerLayer(nn.Module):
         # Layernorm on the output of the attention layer.
         # If GPT-J residuals are used, this is surpurfulous but leaving it in
         # leads to cleaner code
-        self.post_attention_layernorm = norm(neox_args.hidden_size, eps=eps)
+        if not self.neox_args.te_layernorm_mlp:
+            self.post_attention_layernorm = norm(neox_args.hidden_size, eps=eps)
 
         # MLP
         def get_mlp(**kw):

--- a/tools/ckpts/convert_neox_to_hf.py
+++ b/tools/ckpts/convert_neox_to_hf.py
@@ -363,7 +363,7 @@ def create_config(neox_config, architecture="neox", is_rm=False, pad_token_id=-1
             {
                 "rotary_pct": get_key(neox_config, "rotary-pct", default=1.0),
                 "rotary_emb_base": get_key(
-                    neox_config, "rotary-emb-base", default=1000.0
+                    neox_config, "rotary-emb-base", default=10000.0
                 ),
                 "use_parallel_residual": get_key(neox_config, "gpt-j-residual", False),
                 "layer_norm_eps": get_key(neox_config, "layernorm-epsilon", 1e-5),

--- a/tools/ckpts/convert_neox_to_hf.py
+++ b/tools/ckpts/convert_neox_to_hf.py
@@ -105,6 +105,7 @@ MODEL_KEYS = {
                 "norm.bias": "bias",
             },
         },
+        ## TODO: Specify mapping dynamically based on TE modules enabled.
         "transformer_engine": {
             "COLUMN_PARALLEL_LINEAR_KEYS": {
                 "mlp.fc1_weight": "mlp.dense_h_to_4h.weight",

--- a/tools/ckpts/convert_neox_to_hf.py
+++ b/tools/ckpts/convert_neox_to_hf.py
@@ -105,6 +105,39 @@ MODEL_KEYS = {
                 "norm.bias": "bias",
             },
         },
+        "transformer_engine": {
+            "COLUMN_PARALLEL_LINEAR_KEYS": {
+                "mlp.fc1_weight": "mlp.dense_h_to_4h.weight",
+                "mlp.fc1_bias": "mlp.dense_h_to_4h.bias",
+                "attention.qkv.weight": "attention.query_key_value.weight",
+                "attention.qkv.bias": "attention.query_key_value.bias",
+            },
+            "ROW_PARALLEL_LINEAR_KEYS": {
+                "attention.proj.weight": "attention.dense.weight",
+                "mlp.fc2_weight": "mlp.dense_4h_to_h.weight",
+            },
+            "ROW_PARALLEL_BIAS_KEYS": {
+                "mlp.fc2_bias": "mlp.dense_4h_to_h.bias",
+                "attention.proj.bias": "attention.dense.bias",
+            },
+            "NORM_KEYS": {
+                "input_layernorm.weight": "input_layernorm.weight",
+                "input_layernorm.bias": "input_layernorm.bias",
+                "mlp.layer_norm_weight": "post_attention_layernorm.weight",
+                "mlp.layer_norm_bias": "post_attention_layernorm.bias",
+            },
+            "FINAL_NORM_KEYS": {
+                "norm.weight": "weight",
+                "norm.bias": "bias",
+            },
+            # These keys are Transformer Engine specific and can be ignored
+            "IGNORE_KEYS": [
+                "attention.qkv._extra_state",
+                "attention.core_attention._extra_state",
+                "attention.proj._extra_state",
+                "mlp._extra_state",
+            ],
+        },
     },
     "llama": {
         "new": {
@@ -443,24 +476,21 @@ def reshard_and_split_qkv(
 
 
 def get_mlp_naming_convention(loaded_tp_ranks, layer_idx, sequential):
-    """Determine whether the checkpoint uses the legacy or new MLP naming convention."""
-    print(list(loaded_tp_ranks[0]["module"].keys()))
-    if any(
-        [
-            ["mlp.linear1.weight" in key for key in list(state_dict["module"].keys())]
-            for state_dict in loaded_tp_ranks
-        ]
-    ):
+    """Determine whether the checkpoint uses the legacy, new, or Transformer Engine naming convention."""
+    if sequential:
+        key_list = (
+            loaded_tp_ranks[0]["module"].keys()
+            if "module" in loaded_tp_ranks[0]
+            else loaded_tp_ranks[0].keys()
+        )
+    else:
+        key_list = loaded_tp_ranks[0].keys()
+
+    if any(["mlp.fc1_weight" in key for key in key_list]):
+        return "transformer_engine"
+    elif any(["mlp.linear1.weight" in key for key in key_list]):
         return "new"
-    elif any(
-        [
-            [
-                "mlp.dense_h_to_4h.weight" in key
-                for key in list(state_dict["module"].keys())
-            ]
-            for state_dict in loaded_tp_ranks
-        ]
-    ):
+    elif any(["mlp.dense_h_to_4h.weight" in key for key in key_list]):
         return "legacy"
     else:
         raise ValueError("Unable to determine MLP naming convention in checkpoint")
@@ -592,6 +622,20 @@ def convert(
                 layer_idx=layer_i + 2,
                 sequential=sequential,
             )
+
+        # Skip keys that should be ignored
+        if "IGNORE_KEYS" in ARCH:
+            # Just for logging purposes, check if the ignore keys exist
+            for key in ARCH["IGNORE_KEYS"]:
+                try:
+                    _ = get_state(
+                        loaded_tp_ranks,
+                        key,
+                        layer_idx=layer_i + 2,
+                        sequential=sequential,
+                    )
+                except Exception:
+                    pass
 
         # + 2 bc of embed layer and a dummy _pre_transformer_block
         state_dict = {}


### PR DESCRIPTION
Resolves #1353

- Updates the conversion script to correctly map NeoX+TE model weights to HF without the need for a custom class.
- Removes the unused `post_attention_layernorm` layer when `TELayerNormMLP` is used.

The updated conversion script works for NeoX+TE models whether or not `post_attention_layernorm` was initialized. I removed this layer to make sure we avoid redundant memory allocation and unused parameter keys when using TE.

@Kyle1668 @Quentin-Anthony 