### PR TITLE
Fix neoxargs consume without config dir test

### DIFF
--- a/tests/neox_args/test_neoxargs_commandline.py
+++ b/tests/neox_args/test_neoxargs_commandline.py
@@ -23,7 +23,7 @@ from ..common import get_root_directory, get_config_directory, get_configs_with_
 
 
 @pytest.mark.cpu
-def test_neoxargs_consume_deepy_args_with_config_dir():
+def test_neoxargs_consume_deepy_args_without_config_dir():
     """
     verify consume_deepy_args processes command line arguments without config dir
     """


### PR DESCRIPTION
# PR Summary
Currently `test_neoxargs_commandline.py` contains two tests with same name `test_neoxargs_consume_deepy_args_with_config_dir`. This PR fixes the neoxargs consume without config dir test so it won't be silently ignored.