### PR TITLE
Default to only applying QK norm over the head dimension

### DIFF
--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -490,6 +490,14 @@ Model Arguments
 
 
 
+- **qk_layernorm_over_heads**: bool
+
+    Default = False
+
+    Apply QK normalization over [\*, N, H] instead of [\*, H].
+
+
+
 - **layernorm_epsilon**: float
 
     Default = 1e-05

--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -490,11 +490,29 @@ Model Arguments
 
 
 
-- **qk_layernorm_over_heads**: bool
+- **qk_layernorm_type**: typing.Literal['per_head', 'across_heads']
+
+    Default = per_head
+
+    How to apply QK Normalization when `use_qk_layernorm` is set. Choose from:
+        - "per_head": normalize each head independently over the head dimension,
+          i.e. over [*, H] (Qwen3 / Megatron-core / TorchTitan style). Works for
+          both MHA and GQA.
+        - "across_heads": normalize over all heads jointly, i.e. over [*, N, H]
+          (OLMo2 style). For GQA the query and key projections have different
+          numbers of heads (N vs. KV heads), so separate query/key norms with
+          differently sized parameters are constructed automatically.
+
+
+
+- **qk_layernorm_separate**: bool
 
     Default = False
 
-    Apply QK normalization over [\*, N, H] instead of [\*, H].
+    Use separate (independently learned) norms for the query and key projections
+    when `use_qk_layernorm` is set. When False, query and key share a single
+    norm where possible. Has no effect when using GQA with "across_heads" QK
+    normalization, which always uses separate norms due to parameter shapes.
 
 
 

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -309,15 +309,18 @@ class ParallelSelfAttention(nn.Module):
         self.pos_emb = neox_args.pos_emb
 
         self.use_qk_layernorm = neox_args.use_qk_layernorm
+        self.qk_layernorm_over_heads = neox_args.qk_layernorm_over_heads
         if self.use_qk_layernorm:
             norm, eps = get_norm(neox_args)
-            self.qk_layernorm = norm(
+            norm_dims = (
                 [
                     self.num_attention_heads_per_partition,
                     self.hidden_size_per_attention_head,
-                ],
-                eps=eps,
+                ]
+                if self.qk_layernorm_over_heads
+                else [self.hidden_size_per_attention_head]
             )
+            self.qk_layernorm = norm(norm_dims, eps=eps)
 
         self.sliding_window_width = neox_args.sliding_window_width
 

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -309,18 +309,7 @@ class ParallelSelfAttention(nn.Module):
         self.pos_emb = neox_args.pos_emb
 
         self.use_qk_layernorm = neox_args.use_qk_layernorm
-        self.qk_layernorm_over_heads = neox_args.qk_layernorm_over_heads
-        if self.use_qk_layernorm:
-            norm, eps = get_norm(neox_args)
-            norm_dims = (
-                [
-                    self.num_attention_heads_per_partition,
-                    self.hidden_size_per_attention_head,
-                ]
-                if self.qk_layernorm_over_heads
-                else [self.hidden_size_per_attention_head]
-            )
-            self.qk_layernorm = norm(norm_dims, eps=eps)
+        self.qk_layernorm_type = neox_args.qk_layernorm_type
 
         self.sliding_window_width = neox_args.sliding_window_width
 
@@ -341,6 +330,45 @@ class ParallelSelfAttention(nn.Module):
         else:
             self.num_kv_heads_per_partition = self.num_attention_heads_per_partition
             self.kv_hidden_size = neox_args.hidden_size
+
+        # QK Normalization https://arxiv.org/abs/2302.05442
+        if self.use_qk_layernorm:
+            norm, eps = get_norm(neox_args)
+            # All neox norms reduce over the *last* dimension, so the normalized
+            # size is expressed as a 1-D shape
+
+            if self.qk_layernorm_type == "per_head":
+                # "per_head": normalize over [*, H]
+                q_norm_size = self.hidden_size_per_attention_head
+                k_norm_size = self.hidden_size_per_attention_head
+
+            elif self.qk_layernorm_type == "across_heads":
+                # "across_heads": normalize over [*, N * H]
+                # With GQA the query and key have different head counts, so the
+                # two norm sizes differ. Without GQA q_norm_size == k_norm_size
+                q_norm_size = (
+                    self.num_attention_heads_per_partition
+                    * self.hidden_size_per_attention_head
+                )
+                k_norm_size = (
+                    self.num_kv_heads_per_partition
+                    * self.hidden_size_per_attention_head
+                )
+
+            else:
+                raise ValueError(
+                    f"Invalid qk_layernorm_type {self.qk_layernorm_type!r}; "
+                    "expected 'per_head' or 'across_heads'."
+                )
+
+            self.qk_layernorm_separate = (
+                neox_args.qk_layernorm_separate or q_norm_size != k_norm_size
+            )
+            self.q_layernorm = norm([q_norm_size], eps=eps)
+            if self.qk_layernorm_separate:
+                self.k_layernorm = norm([k_norm_size], eps=eps)
+            else:
+                self.k_layernorm = self.q_layernorm
 
         if not self.gqa:
             # Strided linear layer.
@@ -714,6 +742,27 @@ class ParallelSelfAttention(nn.Module):
             attn_scores = self.attention_dropout(attn_scores)
         return attn_scores
 
+    def qk_layernorm(self, query_layer, key_layer):
+        # [sq, b, np, hn], [sq, b, kvp, hn]
+        if not self.use_qk_layernorm:
+            return query_layer, key_layer
+        if self.qk_layernorm_type == "per_head":
+            query_layer = self.q_layernorm(query_layer)
+            key_layer = self.k_layernorm(key_layer)
+        elif self.qk_layernorm_type == "across_heads":
+            # Flatten heads into the last dim so the norm reduces over [*, N * H]
+            q_shape, k_shape = query_layer.shape, key_layer.shape
+            query_layer = self.q_layernorm(query_layer.reshape(*q_shape[:-2], -1))
+            key_layer = self.k_layernorm(key_layer.reshape(*k_shape[:-2], -1))
+            query_layer = query_layer.view(*q_shape)
+            key_layer = key_layer.view(*k_shape)
+        else:
+            raise ValueError(
+                f"Invalid qk_layernorm_type {self.qk_layernorm_type!r}; "
+                "expected 'per_head' or 'across_heads'."
+            )
+        return query_layer, key_layer
+
     def gqa_project(self, hidden_states, attention_mask, layer_past=None):
         # QKV projection and separation into separate Q/K/V layers for GQA,
         # where KV projections may be smaller than Q projection.
@@ -766,6 +815,9 @@ class ParallelSelfAttention(nn.Module):
 
         value_layer = value_layer.view(*new_kv_shape)
 
+        # QK norm before repeating KV heads
+        query_layer, key_layer = self.qk_layernorm(query_layer, key_layer)
+
         # if not using Flash attention, we repeat K/V heads to match Q head counts
         if not self.use_flash_attention:
             key_layer = torch.repeat_interleave(
@@ -810,18 +862,16 @@ class ParallelSelfAttention(nn.Module):
             (query_layer, key_layer, value_layer) = mpu.split_tensor_along_last_dim(
                 mixed_x_layer, 3
             )
+            query_layer, key_layer = self.qk_layernorm(query_layer, key_layer)
         else:
             # Grouped Query Attention (GQA) - specific logic for performing QKV proj
             # and separating out Q, K, and V outputs.
 
+            # gqa_project does qk layernorm inside
             # output shapes: 1 x [sq, b, np, hn], 2 x [sq, b, kvp, hn] if using flash
             query_layer, key_layer, value_layer = self.gqa_project(
                 hidden_states, attention_mask, layer_past=layer_past
             )
-        # QK Normalization https://arxiv.org/abs/2302.05442
-        if self.use_qk_layernorm:
-            query_layer = self.qk_layernorm(query_layer)
-            key_layer = self.qk_layernorm(key_layer)
 
         if exists(self.rotary_emb):
             if exists(self.rotary_ndims):

--- a/megatron/neox_arguments/neox_args.py
+++ b/megatron/neox_arguments/neox_args.py
@@ -189,6 +189,11 @@ class NeoXArgsModel(NeoXArgsTemplate):
     Use QK Normalization
     """
 
+    qk_layernorm_over_heads: bool = False
+    """
+    Apply QK normalization over [*, N, H] instead of [*, H].
+    """
+
     layernorm_epsilon: float = 1.0e-5
     """
     Layer norm epsilon.

--- a/megatron/neox_arguments/neox_args.py
+++ b/megatron/neox_arguments/neox_args.py
@@ -189,9 +189,24 @@ class NeoXArgsModel(NeoXArgsTemplate):
     Use QK Normalization
     """
 
-    qk_layernorm_over_heads: bool = False
+    qk_layernorm_type: Literal["per_head", "across_heads"] = "per_head"
     """
-    Apply QK normalization over [*, N, H] instead of [*, H].
+    How to apply QK Normalization when `use_qk_layernorm` is set. Choose from:
+        - "per_head": normalize each head independently over the head dimension,
+          i.e. over [*, H] (Qwen3 / Megatron-core / TorchTitan style). Works for
+          both MHA and GQA.
+        - "across_heads": normalize over all heads jointly, i.e. over [*, N, H]
+          (OLMo2 style). For GQA the query and key projections have different
+          numbers of heads (N vs. KV heads), so separate query/key norms with
+          differently sized parameters are constructed automatically.
+    """
+
+    qk_layernorm_separate: bool = False
+    """
+    Use separate (independently learned) norms for the query and key projections
+    when `use_qk_layernorm` is set. When False, query and key share a single
+    norm where possible. Has no effect when using GQA with "across_heads" QK
+    normalization, which always uses separate norms due to parameter shapes.
     """
 
     layernorm_epsilon: float = 1.0e-5


### PR DESCRIPTION
Before this change, the default application of QK norm was to apply it to dimensions `[*, N, H]`. This caused problems with GQA, in which the K tensor is of shape `[T, B, N_kv, H]`, which doesn't match. This PR fixes that by changing QK norm to normalize over `[*, H]` by default, as in e.g. Gemma3 and the original QK norm paper, with the option to go back to using `[*, N, H]` available as `qk_layernorm_over_heads`.