### PR TITLE
fix: correct inverted Sinkhorn early-stop condition

### DIFF
--- a/megatron/model/router.py
+++ b/megatron/model/router.py
@@ -74,7 +74,7 @@ class SinkhornRouter(torch.nn.Module):
             d1 = (1 / d1.size(0)) * 1 / (torch.sum(d0.unsqueeze(1) * cost, 0) + eps)
             error = torch.mean(torch.abs(d1_old - d1))
             d1_old = d1
-            if error > tol:
+            if error < tol:
                 break
         return d1 * cost * d0.unsqueeze(1)
 


### PR DESCRIPTION
## Bug
The Sinkhorn iteration early-stop convergence check has an inverted comparison operator, causing it to stop when error is large (not converged) and continue when error is small (already converged).

## Fix
Flipped the comparison operator so early stopping triggers when the change falls below the threshold.