### PR TITLE
fix: undefined self.args in TopKTokenChoiceRouter.jitter

### DIFF
--- a/megatron/model/router.py
+++ b/megatron/model/router.py
@@ -223,8 +223,8 @@ class TopKTokenChoiceRouter(torch.nn.Module):
         Returns:
             torch.Tensor: Jittered input tensor.
         """
-        low = 1.0 - self.args.moe_jitter_eps
-        high = 1.0 + self.args.moe_jitter_eps
+        low = 1.0 - self.jitter_eps
+        high = 1.0 + self.jitter_eps
         noise = torch.rand(x.size(), dtype=x.dtype, device=x.device)
         return low + noise * (high - low)
 


### PR DESCRIPTION
## Bug

`TopKTokenChoiceRouter.jitter()` references `self.args.moe_jitter_eps`, but `self.args` is never assigned in the constructor. This causes an `AttributeError` at runtime when jitter noise is applied during training.

The constructor already stores the value as `self.jitter_eps = neox_args.moe_jitter_eps`, but the `jitter()` method does not use it.

## Fix

Changed `self.args.moe_jitter_eps` to `self.jitter_eps` in the `jitter()` method to reference the attribute that is actually set in `__init__`.