### PR TITLE
fix: replace 9 bare except clauses with except Exception

### DIFF
--- a/megatron/model/fused_layer_norm.py
+++ b/megatron/model/fused_layer_norm.py
@@ -18,7 +18,7 @@ try:
     from apex.contrib.layer_norm.layer_norm import FastLayerNormFN
 
     HAVE_PERSIST_LAYER_NORM = True
-except:
+except Exception:
     HAVE_PERSIST_LAYER_NORM = False
 
 from apex.normalization.fused_layer_norm import (

--- a/tools/ckpts/convert_neox_to_hf.py
+++ b/tools/ckpts/convert_neox_to_hf.py
@@ -285,7 +285,7 @@ def create_config(neox_config, architecture="neox", is_rm=False, pad_token_id=-1
     tokenizer = build_tokenizer(args)
     try:  # GPT2TokenizerFast raises NotImplementedError
         pad_token = tokenizer.pad
-    except:
+    except Exception:
         pad_token = (
             1  # pad defaulting to 1. follows convention from GPT-NeoX-20b tokenizer
         )
@@ -505,14 +505,14 @@ def convert(
                 if fp16["enabled"]:
                     hf_model.half()
                     print("Saving weights in fp16 precision...")
-            except:
+            except Exception:
                 try:
                     # attempt to access bf16 dict in yaml file, if fp16 not enabled
                     bf16 = get_key(loaded_config, "bf16")
                     if bf16:
                         hf_model.to(dtype=torch.bfloat16)
                         print("Saving weights in bf16 precision...")
-                except:
+                except Exception:
                     hf_model.to(dtype=torch.float)
                     print(
                         "Model not trained in fp16 / bf16 mixed precision, saving weights in fp32..."

--- a/tools/ckpts/convert_neox_to_mamba_ssm.py
+++ b/tools/ckpts/convert_neox_to_mamba_ssm.py
@@ -78,7 +78,7 @@ def create_config(neox_config):
     tokenizer = build_tokenizer(args)
     try:  # GPT2TokenizerFast raises NotImplementedError
         pad_token = tokenizer.pad
-    except:
+    except Exception:
         pad_token = (
             1  # pad defaulting to 1. follows convention from GPT-NeoX-20b tokenizer
         )
@@ -127,14 +127,14 @@ def convert(
                 if fp16["enabled"]:
                     dtype = torch.float16
                     print("Saving weights in fp16 precision...")
-            except:
+            except Exception:
                 try:
                     # attempt to access bf16 dict in yaml file, if fp16 not enabled
                     bf16 = get_key(loaded_config, "bf16")
                     if bf16:
                         dtype = torch.bfloat16
                         print("Saving weights in bf16 precision...")
-                except:
+                except Exception:
                     dtype = torch.float
                     print(
                         "Model not trained in fp16 / bf16 mixed precision, saving weights in fp32..."

--- a/tools/ckpts/upload.py
+++ b/tools/ckpts/upload.py
@@ -22,7 +22,7 @@ repo_name = sys.argv[2]
 branch_name = sys.argv[3]
 try:
     create_repo(repo_name, repo_type="model", private=False)
-except:
+except Exception:
     print("repo {repo_name} already exists!")
     pass
 
@@ -36,7 +36,7 @@ if branch_name != "main":
             repo_type="model",
             branch=branch_name,
         )
-    except:
+    except Exception:
         print(f"branch {branch_name} already exists, try again...")
 print(f"to upload: {files}")
 for file in files:


### PR DESCRIPTION
## What
Replace 9 bare `except:` clauses with `except Exception:`.

## Why
Bare `except:` catches `BaseException`, including `KeyboardInterrupt` and `SystemExit`, which can prevent clean process shutdown and mask critical errors. Using `except Exception:` catches all application-level errors while allowing system-level exceptions to propagate correctly.