### PR TITLE
Add ability to log loss/PPL per validation/test set

### DIFF
--- a/configs/neox_arguments.md
+++ b/configs/neox_arguments.md
@@ -1227,6 +1227,20 @@ Training Arguments
 
     List of paths to validation reward datasets
 
+- **valid_data_names**: list
+
+    Default = None
+
+    Optional names for validation dataset subsets when eval_loss_logging uses separate logging.
+    Defaults to valid_0, valid_1, ...
+
+- **test_data_names**: list
+
+    Default = None
+
+    Optional names for test dataset subsets when eval_loss_logging uses separate logging.
+    Defaults to test_0, test_1, ...
+
 - **pos_train_data_paths**: list
 
     Default = None
@@ -1307,6 +1321,14 @@ Training Arguments
 
     List of 'weights' that decide how often to sample from each test dataset when blending datasets. If None, defaults to equal weighting.
     Should be a list the same length as `test_data_paths`
+
+- **eval_loss_logging**: typing.Literal['blended', 'separate', 'blended_and_separate']
+
+    Default = blended
+
+    Validation/test loss logging mode. "blended" preserves the historical blended metric;
+    "separate" logs each validation/test subset independently; "blended_and_separate"
+    logs each subset and synthesizes a blended metric from subset losses.
 
 - **weight_by_num_documents**: bool
 

--- a/megatron/data/data_utils.py
+++ b/megatron/data/data_utils.py
@@ -285,6 +285,31 @@ def get_normalized_weights_and_num_samples(
     return weights, weighted_num_samples
 
 
+def is_separate_eval_enabled(neox_args):
+    return neox_args.eval_loss_logging in ("separate", "blended_and_separate")
+
+
+def get_eval_subset_names(neox_args, split, num_datasets):
+    configured_names = getattr(neox_args, f"{split}_data_names")
+    if configured_names is not None:
+        return list(configured_names)
+    return [f"{split}_{i}" for i in range(num_datasets)]
+
+
+def get_named_eval_datasets(neox_args, split, datasets, weights):
+    names = get_eval_subset_names(neox_args, split, len(datasets))
+    return dict(zip(names, datasets)), dict(zip(names, weights))
+
+
+def make_named_data_loaders(datasets, neox_args):
+    if not datasets:
+        return {}
+    return {
+        name: make_data_loader(dataset, neox_args=neox_args)
+        for name, dataset in datasets.items()
+    }
+
+
 def build_weighted_datasets(
     neox_args,
     train_num_samples,
@@ -522,6 +547,9 @@ def build_train_valid_test_data_loaders(neox_args):
     validate_train_epochs(neox_args)
 
     (train_dataloader, valid_dataloader, test_dataloader) = (None, None, None)
+    valid_separate_dataloaders = {}
+    test_separate_dataloaders = {}
+    eval_weights = {"valid": {}, "test": {}}
 
     print_rank_0("> building train, validation, and test datasets ...")
 
@@ -603,6 +631,7 @@ def build_train_valid_test_data_loaders(neox_args):
             train_val_test_num_samples = [None, None, None]
             train_val_test_epochs = [1, 1, 1]
 
+        train_ds, valid_ds, test_ds = None, None, None
         if (neox_args.train_data_paths) or (neox_args.pos_train_data_paths):
             # when individual train / valid / test data paths are provided
             # normalize weight values and get num samples for each dataset
@@ -677,10 +706,26 @@ def build_train_valid_test_data_loaders(neox_args):
 
             if train_datasets:
                 train_ds = BlendableDataset(train_datasets, train_weights)
-            if valid_datasets:
+            if valid_datasets and not is_separate_eval_enabled(neox_args):
                 valid_ds = BlendableDataset(valid_datasets, valid_weights)
-            if test_datasets:
+            if test_datasets and not is_separate_eval_enabled(neox_args):
                 test_ds = BlendableDataset(test_datasets, test_weights)
+            if valid_datasets and is_separate_eval_enabled(neox_args):
+                valid_named_datasets, valid_named_weights = get_named_eval_datasets(
+                    neox_args, "valid", valid_datasets, valid_weights
+                )
+                valid_separate_dataloaders = make_named_data_loaders(
+                    valid_named_datasets, neox_args=neox_args
+                )
+                eval_weights["valid"] = valid_named_weights
+            if test_datasets and is_separate_eval_enabled(neox_args):
+                test_named_datasets, test_named_weights = get_named_eval_datasets(
+                    neox_args, "test", test_datasets, test_weights
+                )
+                test_separate_dataloaders = make_named_data_loaders(
+                    test_named_datasets, neox_args=neox_args
+                )
+                eval_weights["test"] = test_named_weights
         else:
             # when just data_path is provided
             # split dataset into train, valid and test from data_path
@@ -706,12 +751,16 @@ def build_train_valid_test_data_loaders(neox_args):
         # Flags to know if we need to do training/validation/testing.
         if neox_args.train_epochs:
             do_train = train_dataloader is not None
-            do_valid = valid_dataloader is not None
-            do_test = test_dataloader is not None
+            do_valid = valid_dataloader is not None or bool(valid_separate_dataloaders)
+            do_test = test_dataloader is not None or bool(test_separate_dataloaders)
         else:
             do_train = train_dataloader is not None and neox_args.train_iters > 0
-            do_valid = valid_dataloader is not None and neox_args.eval_iters > 0
-            do_test = test_dataloader is not None and neox_args.eval_iters > 0
+            do_valid = (
+                valid_dataloader is not None or bool(valid_separate_dataloaders)
+            ) and neox_args.eval_iters > 0
+            do_test = (
+                test_dataloader is not None or bool(test_separate_dataloaders)
+            ) and neox_args.eval_iters > 0
 
         # Need to broadcast num_tokens and num_type_tokens.
         flags = torch.cuda.LongTensor([int(do_train), int(do_valid), int(do_test)])
@@ -732,10 +781,38 @@ def build_train_valid_test_data_loaders(neox_args):
     neox_args.do_train = flags[0].item()
     neox_args.do_valid = flags[1].item()
     neox_args.do_test = flags[2].item()
+
+    if is_separate_eval_enabled(neox_args):
+        if not valid_separate_dataloaders:
+            valid_names = get_eval_subset_names(
+                neox_args,
+                "valid",
+                len(neox_args.valid_data_paths or neox_args.pos_valid_data_paths or []),
+            )
+            valid_separate_dataloaders = {name: None for name in valid_names}
+            valid_weights = neox_args.valid_data_weights or [1.0] * len(valid_names)
+            valid_weights, _ = get_normalized_weights_and_num_samples(
+                valid_weights, None
+            )
+            eval_weights["valid"] = dict(zip(valid_names, valid_weights))
+        if not test_separate_dataloaders:
+            test_names = get_eval_subset_names(
+                neox_args,
+                "test",
+                len(neox_args.test_data_paths or neox_args.pos_test_data_paths or []),
+            )
+            test_separate_dataloaders = {name: None for name in test_names}
+            test_weights = neox_args.test_data_weights or [1.0] * len(test_names)
+            test_weights, _ = get_normalized_weights_and_num_samples(test_weights, None)
+            eval_weights["test"] = dict(zip(test_names, test_weights))
+
     data_loaders = {
         "train": train_dataloader,
         "valid": valid_dataloader,
         "test": test_dataloader,
+        "valid_separate": valid_separate_dataloaders,
+        "test_separate": test_separate_dataloaders,
+        "eval_weights": eval_weights,
     }
     return data_loaders
 
@@ -745,6 +822,8 @@ def shift_and_wrap_data_loaders(neox_args, data_loaders, loop=True):
     train_dataloader = data_loaders["train"]
     valid_dataloader = data_loaders["valid"]
     test_dataloader = data_loaders["test"]
+    valid_separate_dataloaders = data_loaders.get("valid_separate", {})
+    test_separate_dataloaders = data_loaders.get("test_separate", {})
 
     # Shift the start iterations.
     if train_dataloader is not None:
@@ -767,6 +846,19 @@ def shift_and_wrap_data_loaders(neox_args, data_loaders, loop=True):
         print_rank_0(
             "setting validation data start iteration to {}".format(
                 valid_dataloader.batch_sampler.start_iter
+            )
+        )
+    for name, dataloader in valid_separate_dataloaders.items():
+        if dataloader is None:
+            continue
+        start_iter_val = (
+            (neox_args.iteration * neox_args.gradient_accumulation_steps)
+            // neox_args.eval_interval
+        ) * neox_args.eval_iters
+        dataloader.batch_sampler.start_iter = start_iter_val % len(dataloader)
+        print_rank_0(
+            "setting validation data start iteration for {} to {}".format(
+                name, dataloader.batch_sampler.start_iter
             )
         )
 
@@ -800,6 +892,21 @@ def shift_and_wrap_data_loaders(neox_args, data_loaders, loop=True):
             test_data_iterator = iter(test_dataloader)
     else:
         test_data_iterator = None
+
+    def wrap_named_data_loaders(named_data_loaders):
+        return {
+            name: (cycle(dataloader) if loop else iter(dataloader))
+            if dataloader is not None
+            else None
+            for name, dataloader in named_data_loaders.items()
+        }
+
+    valid_separate_data_iterators = wrap_named_data_loaders(valid_separate_dataloaders)
+    test_separate_data_iterators = wrap_named_data_loaders(test_separate_dataloaders)
+    if valid_separate_data_iterators:
+        valid_data_iterator = valid_separate_data_iterators
+    if test_separate_data_iterators:
+        test_data_iterator = test_separate_data_iterators
 
     return train_data_iterator, valid_data_iterator, test_data_iterator
 

--- a/megatron/data/data_utils.py
+++ b/megatron/data/data_utils.py
@@ -895,7 +895,7 @@ def shift_and_wrap_data_loaders(neox_args, data_loaders, loop=True):
 
     def wrap_named_data_loaders(named_data_loaders):
         return {
-            name: (cycle(dataloader) if loop else iter(dataloader))
+            name: (loop_iterator(dataloader) if loop else iter(dataloader))
             if dataloader is not None
             else None
             for name, dataloader in named_data_loaders.items()

--- a/megatron/model/transformer_engine.py
+++ b/megatron/model/transformer_engine.py
@@ -651,7 +651,7 @@ class TEDelayedScaling(te.common.recipe.DelayedScaling):
         override_linear_precision = (False, False, not neox_args.te_fp8_wgrad)
 
         super().__init__(
-            margin=neox_args.fp8_margin,
+            margin=neox_args.te_fp8_margin,
             fp8_format=te_fp8_format,
             amax_compute_algo=neox_args.te_fp8_amax_compute_algo,
             amax_history_len=neox_args.te_fp8_amax_history_len,

--- a/megatron/neox_arguments/arguments.py
+++ b/megatron/neox_arguments/arguments.py
@@ -1362,6 +1362,46 @@ class NeoXArgs(*BASE_CLASSES):
         if self.test_data_paths is not None:
             assert len(self.test_data_paths) == len(self.test_data_weights)
 
+        eval_subset_path_fields = {
+            "valid": self.valid_data_paths or self.pos_valid_data_paths,
+            "test": self.test_data_paths or self.pos_test_data_paths,
+        }
+        for split, paths in eval_subset_path_fields.items():
+            names = getattr(self, f"{split}_data_names")
+            if names is None:
+                continue
+            if paths is None:
+                raise ValueError(
+                    f"{split}_data_names requires explicit {split}_data_paths."
+                )
+            if len(names) != len(paths):
+                raise ValueError(
+                    f"{split}_data_names length ({len(names)}) must match "
+                    f"{split}_data_paths length ({len(paths)})."
+                )
+            if len(set(names)) != len(names):
+                raise ValueError(f"{split}_data_names entries must be unique.")
+            if not all(isinstance(name, str) and name for name in names):
+                raise ValueError(f"{split}_data_names entries must be non-empty strings.")
+
+        if self.eval_loss_logging != "blended":
+            if self.data_path is not None:
+                raise ValueError(
+                    "eval_loss_logging='separate' or 'blended_and_separate' requires "
+                    "explicit train/valid/test data path lists; data_path plus split only "
+                    "supports blended evaluation."
+                )
+            if self.valid_data_paths is None and self.pos_valid_data_paths is None:
+                raise ValueError(
+                    "eval_loss_logging='separate' or 'blended_and_separate' requires "
+                    "explicit validation dataset paths."
+                )
+            if self.test_data_paths is None and self.pos_test_data_paths is None:
+                raise ValueError(
+                    "eval_loss_logging='separate' or 'blended_and_separate' requires "
+                    "explicit test dataset paths."
+                )
+
         return True
 
     def validate_types(self):

--- a/megatron/neox_arguments/arguments.py
+++ b/megatron/neox_arguments/arguments.py
@@ -1382,7 +1382,9 @@ class NeoXArgs(*BASE_CLASSES):
             if len(set(names)) != len(names):
                 raise ValueError(f"{split}_data_names entries must be unique.")
             if not all(isinstance(name, str) and name for name in names):
-                raise ValueError(f"{split}_data_names entries must be non-empty strings.")
+                raise ValueError(
+                    f"{split}_data_names entries must be non-empty strings."
+                )
 
         if self.eval_loss_logging != "blended":
             if self.data_path is not None:
@@ -1395,11 +1397,6 @@ class NeoXArgs(*BASE_CLASSES):
                 raise ValueError(
                     "eval_loss_logging='separate' or 'blended_and_separate' requires "
                     "explicit validation dataset paths."
-                )
-            if self.test_data_paths is None and self.pos_test_data_paths is None:
-                raise ValueError(
-                    "eval_loss_logging='separate' or 'blended_and_separate' requires "
-                    "explicit test dataset paths."
                 )
 
         return True

--- a/megatron/neox_arguments/neox_args.py
+++ b/megatron/neox_arguments/neox_args.py
@@ -1067,6 +1067,18 @@ class NeoXArgsTraining(NeoXArgsTemplate):
     List of paths to validation reward datasets
     """
 
+    valid_data_names: list = None
+    """
+    Optional names for validation dataset subsets when eval_loss_logging uses separate logging.
+    Defaults to valid_0, valid_1, ...
+    """
+
+    test_data_names: list = None
+    """
+    Optional names for test dataset subsets when eval_loss_logging uses separate logging.
+    Defaults to test_0, test_1, ...
+    """
+
     pos_train_data_paths: list = None
     neg_train_data_paths: list = None
     """
@@ -1119,6 +1131,20 @@ class NeoXArgsTraining(NeoXArgsTemplate):
     """
     List of 'weights' that decide how often to sample from each test dataset when blending datasets. If None, defaults to equal weighting.
     Should be a list the same length as `test_data_paths`
+    """
+
+    eval_loss_logging: Literal["blended", "separate", "blended_and_separate"] = (
+        "blended"
+    )
+    """
+    Validation/test loss logging mode. "blended" preserves the historical blended metric;
+    "separate" logs each validation/test subset independently; "blended_and_separate"
+    logs each subset and synthesizes a blended metric from subset losses.
+    """
+
+    eval_loss_aggregate: Literal["weighted_mix"] = "weighted_mix"
+    """
+    Aggregation mode for synthesized blended validation/test loss.
     """
 
     weight_by_num_documents: bool = False

--- a/megatron/neox_arguments/neox_args.py
+++ b/megatron/neox_arguments/neox_args.py
@@ -1133,18 +1133,13 @@ class NeoXArgsTraining(NeoXArgsTemplate):
     Should be a list the same length as `test_data_paths`
     """
 
-    eval_loss_logging: Literal["blended", "separate", "blended_and_separate"] = (
-        "blended"
-    )
+    eval_loss_logging: Literal[
+        "blended", "separate", "blended_and_separate"
+    ] = "blended"
     """
     Validation/test loss logging mode. "blended" preserves the historical blended metric;
     "separate" logs each validation/test subset independently; "blended_and_separate"
     logs each subset and synthesizes a blended metric from subset losses.
-    """
-
-    eval_loss_aggregate: Literal["weighted_mix"] = "weighted_mix"
-    """
-    Aggregation mode for synthesized blended validation/test loss.
     """
 
     weight_by_num_documents: bool = False

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -1808,10 +1808,6 @@ def evaluate_named_data_iterators(
         )
 
     if neox_args.eval_loss_logging == "blended_and_separate":
-        if neox_args.eval_loss_aggregate != "weighted_mix":
-            raise NotImplementedError(
-                f"eval_loss_aggregate={neox_args.eval_loss_aggregate!r} is not implemented."
-            )
         blended_results = synthesize_weighted_mix_eval_results(
             named_eval_results, weights=weights
         )

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -310,21 +310,37 @@ def pretrain(neox_args):
             lr_scheduler=lr_scheduler,
             train_data_iterator=train_data_iterator,
             valid_data_iterator=valid_data_iterator,
+            valid_eval_weights=data_loaders.get("eval_weights", {}).get("valid", {}),
         )
 
     if neox_args.do_valid:
         prefix = "the end of training for val data"
-        evaluate_and_print_results(
-            neox_args=neox_args,
-            prefix=prefix,
-            forward_step_func=forward_step,
-            data_iterator=valid_data_iterator,
-            model=model,
-            iteration=iteration,
-            verbose=False,
-            timers=timers,
-            reference_model=reference_model,
-        )
+        if isinstance(valid_data_iterator, dict):
+            evaluate_named_data_iterators(
+                neox_args=neox_args,
+                prefix=prefix,
+                forward_step_func=forward_step,
+                named_data_iterators=valid_data_iterator,
+                model=model,
+                iteration=iteration,
+                verbose=False,
+                timers=timers,
+                chart_name="validation",
+                weights=data_loaders.get("eval_weights", {}).get("valid", {}),
+                reference_model=reference_model,
+            )
+        else:
+            evaluate_and_print_results(
+                neox_args=neox_args,
+                prefix=prefix,
+                forward_step_func=forward_step,
+                data_iterator=valid_data_iterator,
+                model=model,
+                iteration=iteration,
+                verbose=False,
+                timers=timers,
+                reference_model=reference_model,
+            )
 
     if neox_args.save and iteration != 0:
         save_checkpoint(
@@ -338,18 +354,33 @@ def pretrain(neox_args):
     if neox_args.do_test:
         # Run on test data.
         prefix = "the end of training for test data"
-        evaluate_and_print_results(
-            neox_args=neox_args,
-            prefix=prefix,
-            forward_step_func=forward_step,
-            data_iterator=test_data_iterator,
-            model=model,
-            iteration=iteration,
-            verbose=True,
-            timers=timers,
-            chart_name="test",
-            reference_model=reference_model,
-        )
+        if isinstance(test_data_iterator, dict):
+            evaluate_named_data_iterators(
+                neox_args=neox_args,
+                prefix=prefix,
+                forward_step_func=forward_step,
+                named_data_iterators=test_data_iterator,
+                model=model,
+                iteration=iteration,
+                verbose=True,
+                timers=timers,
+                chart_name="test",
+                weights=data_loaders.get("eval_weights", {}).get("test", {}),
+                reference_model=reference_model,
+            )
+        else:
+            evaluate_and_print_results(
+                neox_args=neox_args,
+                prefix=prefix,
+                forward_step_func=forward_step,
+                data_iterator=test_data_iterator,
+                model=model,
+                iteration=iteration,
+                verbose=True,
+                timers=timers,
+                chart_name="test",
+                reference_model=reference_model,
+            )
 
 
 def _get_batch(neox_args, tokenizer, keys, data, datatype, label_mask_zero=False):
@@ -1440,6 +1471,7 @@ def train(
     lr_scheduler,
     train_data_iterator,
     valid_data_iterator,
+    valid_eval_weights=None,
 ):
     """Train the model function."""
 
@@ -1542,17 +1574,32 @@ def train(
             and neox_args.do_valid
         ):
             prefix = "iteration {}".format(iteration)
-            evaluate_and_print_results(
-                neox_args=neox_args,
-                prefix=prefix,
-                forward_step_func=forward_step,
-                data_iterator=valid_data_iterator,
-                model=model,
-                iteration=iteration,
-                verbose=False,
-                timers=timers,
-                reference_model=reference_model,
-            )
+            if isinstance(valid_data_iterator, dict):
+                evaluate_named_data_iterators(
+                    neox_args=neox_args,
+                    prefix=prefix,
+                    forward_step_func=forward_step,
+                    named_data_iterators=valid_data_iterator,
+                    model=model,
+                    iteration=iteration,
+                    verbose=False,
+                    timers=timers,
+                    chart_name="validation",
+                    weights=valid_eval_weights,
+                    reference_model=reference_model,
+                )
+            else:
+                evaluate_and_print_results(
+                    neox_args=neox_args,
+                    prefix=prefix,
+                    forward_step_func=forward_step,
+                    data_iterator=valid_data_iterator,
+                    model=model,
+                    iteration=iteration,
+                    verbose=False,
+                    timers=timers,
+                    reference_model=reference_model,
+                )
 
         if neox_args.exit_interval and iteration % neox_args.exit_interval == 0:
             torch.distributed.barrier()
@@ -1659,33 +1706,39 @@ def evaluate(
     return eval_results
 
 
+def normalize_named_eval_weights(names, weights=None):
+    if weights is None:
+        weights = {}
+    if not names:
+        return {}
+    named_weights = {name: float(weights.get(name, 1.0)) for name in names}
+    weight_sum = sum(named_weights.values())
+    if weight_sum <= 0.0:
+        raise ValueError("Evaluation subset weights must sum to a positive value.")
+    return {name: weight / weight_sum for name, weight in named_weights.items()}
+
+
+def synthesize_weighted_mix_eval_results(named_eval_results, weights=None):
+    names = list(named_eval_results.keys())
+    normalized_weights = normalize_named_eval_weights(names, weights)
+    lm_loss = sum(
+        normalized_weights[name] * named_eval_results[name]["lm_loss"] for name in names
+    )
+    return {"lm_loss": lm_loss, "lm_loss_ppl": math.exp(lm_loss)}
+
+
 def collect_loss_for_unit_test(lm_ss):
     # Logic moved to separate function to allow tracking in unit tests with unittest.mock.patch
     pass
 
 
-def evaluate_and_print_results(
+def log_eval_results(
     neox_args,
     prefix,
-    forward_step_func,
-    data_iterator,
-    model,
+    total_loss_dict,
     iteration,
-    verbose=False,
-    timers=None,
     chart_name="validation",
-    reference_model=None,
 ):
-    """Helper function to evaluate and dump results on screen."""
-    total_loss_dict = evaluate(
-        neox_args=neox_args,
-        forward_step_fn=forward_step_func,
-        data_iterator=data_iterator,
-        model=model,
-        verbose=verbose,
-        timers=timers,
-        reference_model=reference_model,
-    )
     string = f" {chart_name} results at {prefix} | "
     for k, v in total_loss_dict.items():
         if isinstance(v, dict):
@@ -1718,6 +1771,91 @@ def evaluate_and_print_results(
     print_rank_0("-" * length)
     print_rank_0(string)
     print_rank_0("-" * length)
+
+
+def evaluate_named_data_iterators(
+    neox_args,
+    prefix,
+    forward_step_func,
+    named_data_iterators,
+    model,
+    iteration,
+    verbose=False,
+    timers=None,
+    chart_name="validation",
+    weights=None,
+    reference_model=None,
+):
+    """Evaluate each named iterator, log subset metrics, and optionally synthesize a blended result."""
+    named_eval_results = {}
+    for name, data_iterator in named_data_iterators.items():
+        total_loss_dict = evaluate(
+            neox_args=neox_args,
+            forward_step_fn=forward_step_func,
+            data_iterator=data_iterator,
+            model=model,
+            verbose=verbose,
+            timers=timers,
+            reference_model=reference_model,
+        )
+        named_eval_results[name] = total_loss_dict
+        log_eval_results(
+            neox_args=neox_args,
+            prefix=prefix,
+            total_loss_dict=total_loss_dict,
+            iteration=iteration,
+            chart_name=f"{chart_name}/{name}",
+        )
+
+    if neox_args.eval_loss_logging == "blended_and_separate":
+        if neox_args.eval_loss_aggregate != "weighted_mix":
+            raise NotImplementedError(
+                f"eval_loss_aggregate={neox_args.eval_loss_aggregate!r} is not implemented."
+            )
+        blended_results = synthesize_weighted_mix_eval_results(
+            named_eval_results, weights=weights
+        )
+        log_eval_results(
+            neox_args=neox_args,
+            prefix=prefix,
+            total_loss_dict=blended_results,
+            iteration=iteration,
+            chart_name=f"{chart_name}/blended",
+        )
+        named_eval_results["blended"] = blended_results
+
+    return named_eval_results
+
+
+def evaluate_and_print_results(
+    neox_args,
+    prefix,
+    forward_step_func,
+    data_iterator,
+    model,
+    iteration,
+    verbose=False,
+    timers=None,
+    chart_name="validation",
+    reference_model=None,
+):
+    """Helper function to evaluate and dump results on screen."""
+    total_loss_dict = evaluate(
+        neox_args=neox_args,
+        forward_step_fn=forward_step_func,
+        data_iterator=data_iterator,
+        model=model,
+        verbose=verbose,
+        timers=timers,
+        reference_model=reference_model,
+    )
+    log_eval_results(
+        neox_args=neox_args,
+        prefix=prefix,
+        total_loss_dict=total_loss_dict,
+        iteration=iteration,
+        chart_name=chart_name,
+    )
 
 
 def save_snapshot(neox_args):

--- a/tests/neox_args/test_neoxargs_commandline.py
+++ b/tests/neox_args/test_neoxargs_commandline.py
@@ -34,13 +34,13 @@ def test_neoxargs_consume_deepy_args_without_config_dir():
     with patch(
         "sys.argv",
         [str(get_root_directory() / "deepy.py"), "train.py"]
-        + get_configs_with_path(["125M.yml", "local_setup.yml"]),
+        + get_configs_with_path(["125M.yml", "local_setup.yml", "cpu_mock_config.yml"]),
     ):
         args_loaded_consume = NeoXArgs.consume_deepy_args()
 
     # load neox args directly from yaml files
     args_loaded_yamls = NeoXArgs.from_ymls(
-        get_configs_with_path(["125M.yml", "local_setup.yml"])
+        get_configs_with_path(["125M.yml", "local_setup.yml", "cpu_mock_config.yml"])
     )
 
     # update values from yaml files that cannot otherwise be matched

--- a/tests/unit/test_arguments.py
+++ b/tests/unit/test_arguments.py
@@ -17,7 +17,11 @@ from tests.common import BASE_CONFIG, DistributedTest
 
 
 def test_main_constructor():
-    input_args = ["train.py", "tests/config/test_setup.yml", "configs/cpu_mock_config.yml"]
+    input_args = [
+        "train.py",
+        "tests/config/test_setup.yml",
+        "configs/cpu_mock_config.yml",
+    ]
     neox_args = NeoXArgs.consume_deepy_args(input_args)
     deepspeed_main_args = neox_args.get_deepspeed_main_args()
     neox_args = NeoXArgs.consume_neox_args(input_args=deepspeed_main_args)

--- a/tests/unit/test_arguments.py
+++ b/tests/unit/test_arguments.py
@@ -17,7 +17,7 @@ from tests.common import BASE_CONFIG, DistributedTest
 
 
 def test_main_constructor():
-    input_args = ["train.py", "tests/config/test_setup.yml"]
+    input_args = ["train.py", "tests/config/test_setup.yml", "configs/cpu_mock_config.yml"]
     neox_args = NeoXArgs.consume_deepy_args(input_args)
     deepspeed_main_args = neox_args.get_deepspeed_main_args()
     neox_args = NeoXArgs.consume_neox_args(input_args=deepspeed_main_args)
@@ -28,7 +28,9 @@ class test_constructor_from_ymls_class(DistributedTest):
     world_size = 2
 
     def test(self):
-        neox_args = NeoXArgs.from_ymls(["tests/config/test_setup.yml"])
+        neox_args = NeoXArgs.from_ymls(
+            ["tests/config/test_setup.yml", "configs/cpu_mock_config.yml"]
+        )
         neox_args.configure_distributed_args()
 
 
@@ -41,7 +43,9 @@ class test_constructor_from_dict_class(DistributedTest):
     world_size = 2
 
     def test(self):
-        neox_args = NeoXArgs.from_dict(BASE_CONFIG)
+        config = BASE_CONFIG.copy()
+        config["global_num_gpus"] = 1
+        neox_args = NeoXArgs.from_dict(config)
 
 
 def test_constructor_from_dict():

--- a/tests/unit/test_eval_loss_logging.py
+++ b/tests/unit/test_eval_loss_logging.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, EleutherAI
+# Copyright (c) 2026, EleutherAI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,8 +28,17 @@ from megatron.training import (
 from tests.common import BASE_CONFIG
 
 
-def explicit_eval_path_config(**overrides):
+def cpu_arg_config():
     config = deepcopy(BASE_CONFIG)
+    # Avoid hardware discovery in NeoXArgs.calculate_derived during CPU unit tests.
+    # Without this, configs with hostfile/include fall through to torch.cuda.device_count()
+    # and crash on systems with no visible GPUs.
+    config["global_num_gpus"] = 1
+    return config
+
+
+def explicit_eval_path_config(**overrides):
+    config = cpu_arg_config()
     config.pop("data_path", None)
     config.update(
         {
@@ -47,7 +56,7 @@ def explicit_eval_path_config(**overrides):
 
 @pytest.mark.cpu
 def test_eval_loss_logging_defaults_to_blended():
-    neox_args = NeoXArgs.from_dict(BASE_CONFIG)
+    neox_args = NeoXArgs.from_dict(cpu_arg_config())
 
     assert neox_args.eval_loss_logging == "blended"
     assert neox_args.eval_loss_aggregate == "weighted_mix"
@@ -85,7 +94,7 @@ def test_eval_loss_logging_invalid_name_length_fails():
 
 @pytest.mark.cpu
 def test_eval_loss_logging_rejects_data_path_split_for_separate_mode():
-    config = deepcopy(BASE_CONFIG)
+    config = cpu_arg_config()
     config["eval_loss_logging"] = "separate"
 
     with pytest.raises(ValueError, match="data_path plus split only supports blended"):

--- a/tests/unit/test_eval_loss_logging.py
+++ b/tests/unit/test_eval_loss_logging.py
@@ -59,7 +59,6 @@ def test_eval_loss_logging_defaults_to_blended():
     neox_args = NeoXArgs.from_dict(cpu_arg_config())
 
     assert neox_args.eval_loss_logging == "blended"
-    assert neox_args.eval_loss_aggregate == "weighted_mix"
     assert not is_separate_eval_enabled(neox_args)
 
 
@@ -123,7 +122,6 @@ def test_weighted_mix_aggregates_loss_before_perplexity():
 def test_evaluate_named_data_iterators_logs_subsets_and_blended_metric():
     neox_args = SimpleNamespace(
         eval_loss_logging="blended_and_separate",
-        eval_loss_aggregate="weighted_mix",
     )
 
     def fake_evaluate(*, data_iterator, **_kwargs):

--- a/tests/unit/test_eval_loss_logging.py
+++ b/tests/unit/test_eval_loss_logging.py
@@ -1,0 +1,165 @@
+# Copyright (c) 2025, EleutherAI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+from copy import deepcopy
+from types import SimpleNamespace
+from unittest.mock import call, patch
+
+import pytest
+
+from megatron.neox_arguments import NeoXArgs
+from megatron.data.data_utils import get_eval_subset_names, is_separate_eval_enabled
+from megatron.training import (
+    evaluate_named_data_iterators,
+    synthesize_weighted_mix_eval_results,
+)
+from tests.common import BASE_CONFIG
+
+
+def explicit_eval_path_config(**overrides):
+    config = deepcopy(BASE_CONFIG)
+    config.pop("data_path", None)
+    config.update(
+        {
+            "train_data_paths": ["train_code", "train_math"],
+            "valid_data_paths": ["valid_code", "valid_math"],
+            "test_data_paths": ["test_code", "test_math"],
+            "train_data_weights": [0.7, 0.3],
+            "valid_data_weights": [0.7, 0.3],
+            "test_data_weights": [0.7, 0.3],
+        }
+    )
+    config.update(overrides)
+    return config
+
+
+@pytest.mark.cpu
+def test_eval_loss_logging_defaults_to_blended():
+    neox_args = NeoXArgs.from_dict(BASE_CONFIG)
+
+    assert neox_args.eval_loss_logging == "blended"
+    assert neox_args.eval_loss_aggregate == "weighted_mix"
+    assert not is_separate_eval_enabled(neox_args)
+
+
+@pytest.mark.cpu
+def test_eval_loss_logging_uses_configured_subset_names():
+    neox_args = NeoXArgs.from_dict(
+        explicit_eval_path_config(
+            eval_loss_logging="separate",
+            valid_data_names=["code", "math"],
+            test_data_names=["code_eval", "math_eval"],
+        )
+    )
+
+    assert is_separate_eval_enabled(neox_args)
+    assert get_eval_subset_names(neox_args, "valid", 2) == ["code", "math"]
+    assert get_eval_subset_names(neox_args, "test", 2) == [
+        "code_eval",
+        "math_eval",
+    ]
+
+
+@pytest.mark.cpu
+def test_eval_loss_logging_invalid_name_length_fails():
+    with pytest.raises(ValueError, match="valid_data_names length"):
+        NeoXArgs.from_dict(
+            explicit_eval_path_config(
+                eval_loss_logging="separate",
+                valid_data_names=["code"],
+            )
+        )
+
+
+@pytest.mark.cpu
+def test_eval_loss_logging_rejects_data_path_split_for_separate_mode():
+    config = deepcopy(BASE_CONFIG)
+    config["eval_loss_logging"] = "separate"
+
+    with pytest.raises(ValueError, match="data_path plus split only supports blended"):
+        NeoXArgs.from_dict(config)
+
+
+@pytest.mark.cpu
+def test_weighted_mix_aggregates_loss_before_perplexity():
+    eval_results = {
+        "code": {"lm_loss": 2.0, "lm_loss_ppl": math.exp(2.0)},
+        "math": {"lm_loss": 4.0, "lm_loss_ppl": math.exp(4.0)},
+    }
+
+    blended = synthesize_weighted_mix_eval_results(
+        eval_results, weights={"code": 0.75, "math": 0.25}
+    )
+
+    expected_loss = 2.5
+    direct_ppl_average = 0.75 * math.exp(2.0) + 0.25 * math.exp(4.0)
+    assert blended["lm_loss"] == pytest.approx(expected_loss)
+    assert blended["lm_loss_ppl"] == pytest.approx(math.exp(expected_loss))
+    assert blended["lm_loss_ppl"] != pytest.approx(direct_ppl_average)
+
+
+@pytest.mark.cpu
+def test_evaluate_named_data_iterators_logs_subsets_and_blended_metric():
+    neox_args = SimpleNamespace(
+        eval_loss_logging="blended_and_separate",
+        eval_loss_aggregate="weighted_mix",
+    )
+
+    def fake_evaluate(*, data_iterator, **_kwargs):
+        losses = {"code_iter": 2.0, "math_iter": 4.0}
+        loss = losses[data_iterator]
+        return {"lm_loss": loss, "lm_loss_ppl": math.exp(loss)}
+
+    with patch("megatron.training.evaluate", side_effect=fake_evaluate), patch(
+        "megatron.training.log_eval_results"
+    ) as log_eval_results:
+        results = evaluate_named_data_iterators(
+            neox_args=neox_args,
+            prefix="iteration 10",
+            forward_step_func=object(),
+            named_data_iterators={"code": "code_iter", "math": "math_iter"},
+            model=object(),
+            iteration=10,
+            chart_name="validation",
+            weights={"code": 0.75, "math": 0.25},
+        )
+
+    assert results["blended"]["lm_loss"] == pytest.approx(2.5)
+    assert results["blended"]["lm_loss_ppl"] == pytest.approx(math.exp(2.5))
+    log_eval_results.assert_has_calls(
+        [
+            call(
+                neox_args=neox_args,
+                prefix="iteration 10",
+                total_loss_dict=results["code"],
+                iteration=10,
+                chart_name="validation/code",
+            ),
+            call(
+                neox_args=neox_args,
+                prefix="iteration 10",
+                total_loss_dict=results["math"],
+                iteration=10,
+                chart_name="validation/math",
+            ),
+            call(
+                neox_args=neox_args,
+                prefix="iteration 10",
+                total_loss_dict=results["blended"],
+                iteration=10,
+                chart_name="validation/blended",
+            ),
+        ]
+    )


### PR DESCRIPTION
As discussed on Discord

The PR would benefit from first merging https://github.com/EleutherAI/gpt-neox/pull/1387, https://github.com/EleutherAI/gpt-neox/pull/1389 and https://github.com/EleutherAI/gpt-neox/pull/1356

These PRs fix eval which is currently fully broken and all runs crash when pipe parallel size is set to 1. One of the PRs also aligns args which is not contingent but would be nice to align args once and for all for future PRs.

In my testing it works well and logs separately as expected. Design Doc is just for reference and will be removed post review/ can be removed even before that if preferred