### PR TITLE
Qwen 2 Dense Model Training Configs

### DIFF
--- a/configs/qwen2/0-5B.yml
+++ b/configs/qwen2/0-5B.yml
@@ -1,0 +1,33 @@
+# Based on https://huggingface.co/Qwen/Qwen2-0.5B/blob/main/config.json
+
+{
+  "pipe_parallel_size": 1,
+  "model_parallel_size": 1,
+  "make_vocab_size_divisible_by": 1,
+
+  # model settings
+  "num_layers": 24,
+  "hidden_size": 896,
+  "intermediate_size": 14592, # 4864*3 as 3x needed for swiglu with neox
+  "num_attention_heads": 14,
+  "num_kv_heads": 2,
+  "seq_length": 131072,
+  "max_position_embeddings": 131072,
+  "pos_emb": "rotary",
+  "rotary_pct": 1,
+  "rotary_emb_base": 1000000.0,
+  "no_weight_tying": false,
+  "gpt_j_residual": false,
+  "output_layer_parallelism": "column",
+  "norm": "rmsnorm",
+  "rms_norm_epsilon": 1.0e-6,
+
+  "scaled_upper_triang_masked_softmax_fusion": true,
+  "bias_gelu_fusion": false,
+  "use_bias_in_norms": false,
+  "use_bias_in_attn_linear": false,
+  "activation": "swiglu", # Mentioned here - https://huggingface.co/Qwen/Qwen2-72B#model-details
+  "mlp_multiple_of": 256,
+
+  "init_method_std": 0.02
+}

--- a/configs/qwen2/1-5B.yml
+++ b/configs/qwen2/1-5B.yml
@@ -1,0 +1,33 @@
+# Based on https://huggingface.co/Qwen/Qwen2-1.5B/blob/main/config.json
+
+{
+  "pipe_parallel_size": 1,
+  "model_parallel_size": 1,
+  "make_vocab_size_divisible_by": 1,
+
+  # model settings
+  "num_layers": 28,
+  "hidden_size": 1536,
+  "intermediate_size": 26880, # 8960*3 as 3x needed for swiglu with neox
+  "num_attention_heads": 12,
+  "num_kv_heads": 2,
+  "seq_length": 131072,
+  "max_position_embeddings": 131072,
+  "pos_emb": "rotary",
+  "rotary_pct": 1,
+  "rotary_emb_base": 1000000.0,
+  "no_weight_tying": false,
+  "gpt_j_residual": false,
+  "output_layer_parallelism": "column",
+  "norm": "rmsnorm",
+  "rms_norm_epsilon": 1.0e-6,
+
+  "scaled_upper_triang_masked_softmax_fusion": true,
+  "bias_gelu_fusion": false,
+  "use_bias_in_norms": false,
+  "use_bias_in_attn_linear": false,
+  "activation": "swiglu", # Mentioned here - https://huggingface.co/Qwen/Qwen2-72B#model-details
+  "mlp_multiple_of": 256,
+
+  "init_method_std": 0.02
+}

--- a/configs/qwen2/72B.yml
+++ b/configs/qwen2/72B.yml
@@ -1,0 +1,33 @@
+# Based on https://huggingface.co/Qwen/Qwen2-72B/blob/main/config.json
+
+{
+  "pipe_parallel_size": 1,
+  "model_parallel_size": 1,
+  "make_vocab_size_divisible_by": 1,
+
+  # model settings
+  "num_layers": 80,
+  "hidden_size": 8192,
+  "intermediate_size": 88704, # 29568*3 as 3x needed for swiglu with neox
+  "num_attention_heads": 64,
+  "num_kv_heads": 8,
+  "seq_length": 131072,
+  "max_position_embeddings": 131072,
+  "pos_emb": "rotary",
+  "rotary_pct": 1,
+  "rotary_emb_base": 1000000.0,
+  "no_weight_tying": false,
+  "gpt_j_residual": false,
+  "output_layer_parallelism": "column",
+  "norm": "rmsnorm",
+  "rms_norm_epsilon": 1.0e-5,
+
+  "scaled_upper_triang_masked_softmax_fusion": true,
+  "bias_gelu_fusion": false,
+  "use_bias_in_norms": false,
+  "use_bias_in_attn_linear": false,
+  "activation": "swiglu", # Mentioned here - https://huggingface.co/Qwen/Qwen2-72B#model-details
+  "mlp_multiple_of": 256,
+
+  "init_method_std": 0.02
+}

--- a/configs/qwen2/7B.yml
+++ b/configs/qwen2/7B.yml
@@ -1,0 +1,33 @@
+# Based on https://huggingface.co/Qwen/Qwen2-7B/blob/main/config.json
+
+{
+  "pipe_parallel_size": 1,
+  "model_parallel_size": 1,
+  "make_vocab_size_divisible_by": 1,
+
+  # model settings
+  "num_layers": 28,
+  "hidden_size": 3584,
+  "intermediate_size": 56832, # 18944*3 as 3x needed for swiglu with neox
+  "num_attention_heads": 28,
+  "num_kv_heads": 4,
+  "seq_length": 131072,
+  "max_position_embeddings": 131072,
+  "pos_emb": "rotary",
+  "rotary_pct": 1,
+  "rotary_emb_base": 1000000.0,
+  "no_weight_tying": false,
+  "gpt_j_residual": false,
+  "output_layer_parallelism": "column",
+  "norm": "rmsnorm",
+  "rms_norm_epsilon": 1.0e-6,
+
+  "scaled_upper_triang_masked_softmax_fusion": true,
+  "bias_gelu_fusion": false,
+  "use_bias_in_norms": false,
+  "use_bias_in_attn_linear": false,
+  "activation": "swiglu", # Mentioned here - https://huggingface.co/Qwen/Qwen2-72B#model-details
+  "mlp_multiple_of": 256,
+
+  "init_method_std": 0.02
+}


### PR DESCRIPTION
Adding configs to support training models which follow the dense models in the Qwen 2 series.
Addresses part of https://github.com/EleutherAI/gpt-neox/issues/1394