### PR TITLE
Abstraction for Intel GPUs

### DIFF
--- a/configs/prof.yml
+++ b/configs/prof.yml
@@ -4,8 +4,8 @@
   "profile": true,
 
   # pytorch profiler options
-  "profile_step_start": 4,
-  "profile_step_stop": 8,
+  "profile_step_start": 10,
+  "profile_step_stop": 12,
 
   # pytorch memory profiler options
   "memory_profiling": true,

--- a/configs/prof.yml
+++ b/configs/prof.yml
@@ -4,14 +4,10 @@
   "profile": true,
 
   # pytorch profiler options
-  "profile_step_start": 10,
-  "profile_step_stop": 12,
+  "profile_step_start": 4,
+  "profile_step_stop": 8,
 
   # pytorch memory profiler options
   "memory_profiling": true,
   "memory_profiling_path": tensorboard,
-
-
-  # All trace files (pytorch, nsys, tensorboard, etc) will be written here
-  "tensorboard_dir": "tensorboard",
 }

--- a/megatron/__init__.py
+++ b/megatron/__init__.py
@@ -24,3 +24,4 @@ def print_rank_0(*message):
 
 
 from .neox_arguments import NeoXArgs
+from . import device_backend

--- a/megatron/checkpointing.py
+++ b/megatron/checkpointing.py
@@ -75,7 +75,7 @@ def do_forward_pass(neox_args, model, inference=False):
     context_tokens_tensor = (
         torch.arange(neox_args.seq_length + 1)
         .repeat((neox_args.train_micro_batch_size_per_gpu, 1))
-        .cuda()
+        .to(device_backend.device())
     )
 
     # forward

--- a/megatron/checkpointing.py
+++ b/megatron/checkpointing.py
@@ -44,6 +44,7 @@ from glob import glob
 
 from megatron import mpu
 from megatron import print_rank_0
+from megatron import device_backend
 from megatron.utils import natural_sort
 from megatron.text_generation_utils import get_batch, forward_model
 from pathlib import Path
@@ -198,7 +199,7 @@ def save_ds_checkpoint(iteration, model, neox_args):
         sd["random_rng_state"] = random.getstate()
         sd["np_rng_state"] = np.random.get_state()
         sd["torch_rng_state"] = torch.get_rng_state()
-        sd["cuda_rng_state"] = torch.cuda.get_rng_state()
+        sd["cuda_rng_state"] = device_backend.get_rng_state()
         sd["rng_tracker_states"] = mpu.get_cuda_rng_tracker().get_states()
 
     if neox_args.checkpoint_validation_with_forward_pass:
@@ -465,7 +466,7 @@ def load_checkpoint(
             random.setstate(state_dict["random_rng_state"])
             np.random.set_state(state_dict["np_rng_state"])
             torch.set_rng_state(state_dict["torch_rng_state"])
-            torch.cuda.set_rng_state(state_dict["cuda_rng_state"])
+            device_backend.set_rng_state(state_dict["cuda_rng_state"])
             mpu.get_cuda_rng_tracker().set_states(state_dict["rng_tracker_states"])
         except KeyError:
             print_rank_0(

--- a/megatron/data/data_utils.py
+++ b/megatron/data/data_utils.py
@@ -19,7 +19,7 @@ from typing import List, Tuple
 from itertools import zip_longest, cycle
 from functools import partial
 
-from megatron import mpu, print_rank_0
+from megatron import mpu, print_rank_0, device_backend
 from megatron.data.indexed_dataset import make_dataset as make_indexed_dataset
 from megatron.data.blendable_dataset import BlendableDataset
 from megatron.data.gpt2_dataset import GPT2Dataset
@@ -586,7 +586,7 @@ def build_train_valid_test_data_loaders(neox_args):
         do_valid = valid_dataloader is not None and neox_args.eval_iters > 0
         do_test = test_dataloader is not None and neox_args.eval_iters > 0
         # Need to broadcast num_tokens and num_type_tokens.
-        flags = torch.cuda.LongTensor([int(do_train), int(do_valid), int(do_test)])
+        flags = torch.LongTensor([int(do_train), int(do_valid), int(do_test)]).to(device_backend.device())
     elif mpu.get_model_parallel_rank() == 0 and pipe_load:
         # Number of train/valid/test samples.
         if neox_args.train_iters is not None:
@@ -716,9 +716,9 @@ def build_train_valid_test_data_loaders(neox_args):
             do_test = test_dataloader is not None and neox_args.eval_iters > 0
 
         # Need to broadcast num_tokens and num_type_tokens.
-        flags = torch.cuda.LongTensor([int(do_train), int(do_valid), int(do_test)])
+        flags = torch.LongTensor([int(do_train), int(do_valid), int(do_test)]).to(device_backend.device())
     else:
-        flags = torch.cuda.LongTensor([0, 0, 0])
+        flags = torch.LongTensor([0, 0, 0]).to(device_backend.device())
 
     # Broadcast num tokens.
     if neox_args.is_pipe_parallel:

--- a/megatron/data/gpt2_dataset.py
+++ b/megatron/data/gpt2_dataset.py
@@ -23,7 +23,7 @@ import time
 import numpy as np
 import torch
 
-from megatron import mpu, print_rank_0
+from megatron import mpu, print_rank_0, device_backend
 
 
 class GPT2Dataset(torch.utils.data.Dataset):
@@ -370,7 +370,7 @@ def _build_index_mappings(
     # This should be a barrier but nccl barrier assumes
     # device_index=rank which is not the case for model
     # parallel case
-    counts = torch.cuda.LongTensor([1])
+    counts = torch.LongTensor([1]).to(device_backend.device())
     torch.distributed.all_reduce(counts, group=mpu.get_io_parallel_group())
     assert counts[0].item() == torch.distributed.get_world_size(
         group=mpu.get_io_parallel_group()

--- a/megatron/data/pairwise_dataset.py
+++ b/megatron/data/pairwise_dataset.py
@@ -23,7 +23,7 @@ import time
 import numpy as np
 import torch
 
-from megatron import mpu, print_rank_0
+from megatron import mpu, print_rank_0, device_backend
 
 
 class PairwiseDataset(torch.utils.data.Dataset):
@@ -345,7 +345,7 @@ def _build_index_mappings(
     # This should be a barrier but nccl barrier assumes
     # device_index=rank which is not the case for model
     # parallel case
-    counts = torch.cuda.LongTensor([1])
+    counts = torch.LongTensor([1]).to(device_backend.device())
     torch.distributed.all_reduce(counts, group=mpu.get_io_parallel_group())
     assert counts[0].item() == torch.distributed.get_world_size(
         group=mpu.get_io_parallel_group()

--- a/megatron/device_backend.py
+++ b/megatron/device_backend.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2026, EleutherAI
+# This file is based on code by the authors denoted below and has been modified from its original version.
+#
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+ 
+import torch
+
+
+def _get_backend():
+    if hasattr(torch, "cuda") and torch.cuda.is_available():
+        return torch.cuda
+
+    if hasattr(torch, "xpu") and torch.xpu.is_available():
+        return torch.xpu
+
+    return None
+
+
+_backend = _get_backend()
+
+
+def is_available():
+    return _backend is not None
+
+
+def device():
+    if _backend is None:
+        return torch.device("cpu")
+
+    if _backend is torch.cuda:
+        return torch.device("cuda")
+
+    return torch.device("xpu")
+
+
+def current_device():
+    if _backend is None:
+        return 0
+
+    return _backend.current_device()
+
+
+def device_count():
+    if _backend is None:
+        return 1
+
+    return _backend.device_count()
+
+
+def set_device(device_id):
+    if _backend is not None:
+        _backend.set_device(device_id)
+
+
+def synchronize(device_id=None):
+    if _backend is not None:
+        _backend.synchronize(device_id)
+
+def memory(device_id=None):
+    if _backend is not None:
+        return _backend.memory
+
+def memory_allocated(device_id=None):
+    if _backend is None:
+        return 0
+
+    return _backend.memory_allocated(device_id)
+
+
+def max_memory_allocated(device_id=None):
+    if _backend is None:
+        return 0
+
+    return _backend.max_memory_allocated(device_id)
+
+
+def memory_reserved(device_id=None):
+    if _backend is None:
+        return 0
+
+    return _backend.memory_reserved(device_id)
+
+def max_memory_reserved(device_id=None):
+    if _backend is None:
+        return 0
+
+    return _backend.max_memory_reserved(device_id)
+
+def empty_cache():
+    if _backend is not None:
+        _backend.empty_cache()
+
+
+def current_stream(device_id=None):
+    if _backend is None:
+        return None
+
+    return _backend.current_stream(device_id)
+
+
+def default_stream(device_id=None):
+    if _backend is None:
+        return None
+
+    return _backend.default_stream(device_id)
+
+
+def Event(*args, **kwargs):
+    if _backend is None:
+        return None
+
+    return _backend.Event(*args, **kwargs)
+
+def get_rng_state():
+    if _backend is not None:
+        _backend.get_rng_state()
+
+def set_rng_state(state):
+    if _backend is not None:
+        _backend.set_rng_state(state)
+
+def manual_seed(seed):
+    if _backend is not None:
+        _backend.manual_seed(seed)
+
+
+def manual_seed_all(seed):
+    if _backend is not None:
+        _backend.manual_seed_all(seed)
+
+def nvtx():
+    if _backend is torch.cuda:
+        return _backend.nvtx()
+
+def cudart():
+    if _backend is torch.cuda:
+        return _backend.cudart()

--- a/megatron/devutil.py
+++ b/megatron/devutil.py
@@ -1,4 +1,5 @@
-import torch.cuda
+import torch
+from megatron import device_backend
 
 
 class Metric:
@@ -34,8 +35,8 @@ def monitor_method_cuda_wall_times(metric, obj, methodname):
     """
     oldmeth = getattr(obj, methodname)
 
-    start_event = torch.cuda.Event(enable_timing=True)
-    end_event = torch.cuda.Event(enable_timing=True)
+    start_event = device_backend.Event(enable_timing=True)
+    end_event = device_backend.Event(enable_timing=True)
 
     def newmeth(*args, **kw):
         start_event.record()
@@ -43,7 +44,7 @@ def monitor_method_cuda_wall_times(metric, obj, methodname):
             return oldmeth(*args, **kw)
         finally:
             end_event.record()
-            torch.cuda.synchronize()
+            device_backend.synchronize()
             elapsed = start_event.elapsed_time(end_event)
             metric.collect(elapsed)
             metric.report()

--- a/megatron/gradient_noise_scale/gradient_noise_scale.py
+++ b/megatron/gradient_noise_scale/gradient_noise_scale.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import torch
-
+from megatron import device_backend
 
 def ema(avg, beta, yi, i):
     """Exponential moving average"""
@@ -103,7 +103,7 @@ class GradientNoiseScale:
         if self.neox_args.is_pipe_parallel:
             # Since each model parallel GPU carries only part of the model,
             # make sure overflow flag is synced across all the pipe parallel GPUs
-            overflow_gpu = torch.cuda.ByteTensor([is_overflow])
+            overflow_gpu = torch.ByteTensor([is_overflow]).to(device_backend.device())
             torch.distributed.all_reduce(
                 overflow_gpu,
                 op=torch.distributed.ReduceOp.MAX,

--- a/megatron/initialize.py
+++ b/megatron/initialize.py
@@ -24,7 +24,7 @@ import numpy as np
 import torch
 
 from megatron import fused_kernels
-from megatron import mpu
+from megatron import mpu, device_backend
 from megatron.mpu import set_model_parallel_rank, set_model_parallel_world_size
 
 import deepspeed
@@ -41,7 +41,7 @@ def initialize_megatron(neox_args, allow_no_cuda=False):
     """
     if not allow_no_cuda:
         # Make sure cuda is available.
-        assert torch.cuda.is_available(), "Megatron requires CUDA."
+        assert device_backend.is_available(), "Megatron requires CUDA."
 
     # torch.distributed initialization
     def finish_mpu_init():
@@ -121,7 +121,7 @@ def setup_deepspeed_random_and_activation_checkpointing(neox_args):
 def _initialize_distributed(neox_args):
     """Initialize torch.distributed and mpu."""
 
-    device_count = torch.cuda.device_count()
+    device_count = device_backend.device_count()
     if torch.distributed.is_initialized():
 
         if neox_args.rank == 0:
@@ -146,7 +146,7 @@ def _initialize_distributed(neox_args):
                 ), "expected local-rank to be the same as rank % device-count."
             else:
                 neox_args.local_rank = device
-            torch.cuda.set_device(device)
+            device_backend.set_device(device)
 
         deepspeed.init_distributed(
             dist_backend=neox_args.distributed_backend,
@@ -219,7 +219,7 @@ def _set_random_seed(seed):
         random.seed(seed)
         np.random.seed(seed)
         torch.manual_seed(seed)
-        if torch.cuda.device_count() > 0:
+        if device_backend.device_count() > 0:
             mpu.model_parallel_cuda_manual_seed(seed)
     else:
         raise ValueError("Seed ({}) should be a positive integer.".format(seed))

--- a/megatron/model/mamba/mamba.py
+++ b/megatron/model/mamba/mamba.py
@@ -20,7 +20,7 @@ except ModuleNotFoundError:
     pass
 
 from megatron.model.norms import get_norm
-from megatron import mpu
+from megatron import mpu, device_backend
 
 # Mamba sublayer, with tensor parallelism
 class ParallelMambaBlock(nn.Module):
@@ -40,7 +40,7 @@ class ParallelMambaBlock(nn.Module):
             "fp32": torch.float32,
         }[neox_args.precision]
         self.precision = dtype
-        factory_kwargs = {"device": torch.cuda.current_device(), "dtype": dtype}
+        factory_kwargs = {"device": device_backend.current_device(), "dtype": dtype}
 
         assert not (
             neox_args.mamba_use_bias_in_linears and neox_args.mamba_inner_func_fusion
@@ -154,7 +154,7 @@ class ParallelMambaBlock(nn.Module):
                 1,
                 self.d_state + 1,
                 dtype=torch.float32,
-                device=torch.cuda.current_device(),
+                device=device_backend.current_device(),
             ),
             "n -> d n",
             d=self.d_inner_per_rank,
@@ -175,7 +175,7 @@ class ParallelMambaBlock(nn.Module):
         self.D = nn.Parameter(
             torch.ones(
                 self.d_inner_per_rank,
-                device=torch.cuda.current_device(),
+                device=device_backend.current_device(),
                 dtype=torch.float32,
             )
         ).to(

--- a/megatron/model/moe.py
+++ b/megatron/model/moe.py
@@ -11,7 +11,7 @@ import megablocks.ops
 import numpy as np
 import torch
 
-from megatron import mpu
+from megatron import mpu, device_backend
 from megatron.mpu import get_expert_token_counts_for_rank
 from megatron.mpu import get_expert_tokens_for_rank
 from megatron.mpu import copy_to_expert_model_parallel_region
@@ -133,8 +133,6 @@ class ParallelDroplessMLP(torch.nn.Module):
         # get tokens_per_expert for this rank's experts only
         # with torch.no_grad():
         local_tokens_per_expert = get_expert_token_counts_for_rank(tokens_per_expert)
-        # if torch.cuda.current_device() == 0:
-        #     print(f"{torch.cuda.current_device()}: local_tokens_per_expert {local_tokens_per_expert}, global tokens {tokens_per_expert}")
 
         # Perform the expert computation for this rank's experts
         output_parallel = self.mlp(input_parallel, local_tokens_per_expert)
@@ -196,9 +194,9 @@ class ParallelDroplessMLP(torch.nn.Module):
 
 def cast_if_autocast_enabled(tensor: torch.Tensor):
     if torch.is_autocast_enabled():
-        if tensor.device.type == "cuda":
+        if tensor.device_backend.type == "cuda" or tensor.device_backend.type == "xpu":
             dtype = torch.get_autocast_gpu_dtype()
-        elif tensor.device.type == "cpu":
+        elif tensor.device_backend.type == "cpu":
             dtype = torch.get_autocast_cpu_dtype()
         else:
             raise NotImplementedError()

--- a/megatron/model/moe_mlp.py
+++ b/megatron/model/moe_mlp.py
@@ -17,6 +17,7 @@
 
 import torch
 from megatron.model.activations import get_activation
+from megatron import device_backend
 
 from megatron.mpu.layers import _initialize_affine_weight_gpu
 from megatron.mpu.initialize import get_model_parallel_world_size
@@ -29,13 +30,13 @@ from megablocks import grouped_gemm_util as gg
 
 class ScaleGradient(torch.autograd.Function):
     @staticmethod
-    @torch.cuda.amp.custom_fwd
+    @device_backend.amp.custom_fwd
     def forward(ctx, x, scale):
         ctx.scale = scale
         return x
 
     @staticmethod
-    @torch.cuda.amp.custom_bwd
+    @device_backend.amp.custom_bwd
     def backward(ctx, grad):
         return grad * ctx.scale, None
 
@@ -47,7 +48,7 @@ class MemoryOptimizedParallelGroupedMLP(torch.autograd.Function):
     """GroupedMLP with manually scheduled memory reuse."""
 
     @staticmethod
-    @torch.cuda.amp.custom_fwd
+    @device_backend.amp.custom_fwd
     def forward(ctx, x, w1, w2, batch_sizes, activation_fn):
         # x: [m, k], w1: [n, k], w2: [n, k]
         if not x.is_contiguous() or not w1.is_contiguous() or not w2.is_contiguous():
@@ -74,7 +75,7 @@ class MemoryOptimizedParallelGroupedMLP(torch.autograd.Function):
         return dsd_out
 
     @staticmethod
-    @torch.cuda.amp.custom_bwd
+    @device_backend.amp.custom_bwd
     def backward(ctx, ddsd_out):
         if (
             not ctx.needs_input_grad[0]
@@ -175,7 +176,7 @@ class ParallelGroupedMLP(torch.nn.Module):
             torch.empty(
                 self.num_rows_per_rank,
                 self.hidden_size,
-                device=torch.cuda.current_device(),
+                device=device_backend.current_device(),
                 dtype=neox_args.params_dtype,
             )
         )
@@ -188,7 +189,7 @@ class ParallelGroupedMLP(torch.nn.Module):
             torch.empty(
                 self.num_rows_per_rank,
                 self.hidden_size,
-                device=torch.cuda.current_device(),
+                device=device_backend.current_device(),
                 dtype=neox_args.params_dtype,
             )
         )
@@ -227,7 +228,7 @@ class MemoryOptimizedParallelGroupedLLaMAMLP(torch.autograd.Function):
     """GroupedMLP with manually scheduled memory reuse."""
 
     @staticmethod
-    @torch.cuda.amp.custom_fwd
+    @device_backend.amp.custom_fwd
     def forward(ctx, x, w1, w3, w2, batch_sizes, activation_fn):
         # x: [m, k], w1: [n, k], w3: [n, k], w2: [n, k]
         if (
@@ -260,7 +261,7 @@ class MemoryOptimizedParallelGroupedLLaMAMLP(torch.autograd.Function):
         return dsd_out
 
     @staticmethod
-    @torch.cuda.amp.custom_bwd
+    @device_backend.amp.custom_bwd
     def backward(ctx, ddsd_out):
         if (
             not ctx.needs_input_grad[0]
@@ -365,7 +366,7 @@ class ParallelGroupedLLaMAMLP(torch.nn.Module):
             torch.empty(
                 self.num_rows_per_rank,
                 self.hidden_size,
-                device=torch.cuda.current_device(),
+                device=device_backend.current_device(),
                 dtype=neox_args.params_dtype,
             )
         )
@@ -378,7 +379,7 @@ class ParallelGroupedLLaMAMLP(torch.nn.Module):
             torch.empty(
                 self.num_rows_per_rank,
                 self.hidden_size,
-                device=torch.cuda.current_device(),
+                device=device_backend.current_device(),
                 dtype=neox_args.params_dtype,
             )
         )
@@ -391,7 +392,7 @@ class ParallelGroupedLLaMAMLP(torch.nn.Module):
             torch.empty(
                 self.num_rows_per_rank,
                 self.hidden_size,
-                device=torch.cuda.current_device(),
+                device=device_backend.current_device(),
                 dtype=neox_args.params_dtype,
             )
         )

--- a/megatron/model/positional_embeddings.py
+++ b/megatron/model/positional_embeddings.py
@@ -14,6 +14,7 @@
 
 import torch
 import math
+from megatron import device_backend
 
 
 class SinusoidalPositionalEmbedding(torch.nn.Module):
@@ -79,7 +80,7 @@ class RotaryEmbedding(torch.nn.Module):
         )
 
     def get_emb(self):
-        return self.emb.to(self.precision).cuda()
+        return self.emb.to(self.precision).to(device_backend.device())
 
     def forward(self, x, seq_dim=0, seq_len=None):
         if seq_len is None:

--- a/megatron/model/router.py
+++ b/megatron/model/router.py
@@ -19,6 +19,7 @@ import torch
 
 from megatron.neox_arguments.arguments import NeoXArgs
 from megatron.mpu import get_model_parallel_group, get_model_parallel_rank
+from megatron import device_backend
 
 
 class SinkhornRouter(torch.nn.Module):
@@ -56,7 +57,7 @@ class SinkhornRouter(torch.nn.Module):
             neox_args.moe_num_experts,
             bias=False,
             dtype=neox_args.params_dtype,
-            device=torch.cuda.current_device(),
+            device=device_backend.current_device(),
         )
         init_method(self.layer.weight)
 
@@ -155,13 +156,13 @@ class SinkhornRouter(torch.nn.Module):
             expert_weights = torch.empty(
                 num_rows,
                 self.top_k,
-                device=torch.cuda.current_device(),
+                device=device_backend.current_device(),
                 dtype=self.params_dtype,
             )
             expert_indices = torch.empty(
                 num_rows,
                 self.top_k,
-                device=torch.cuda.current_device(),
+                device=device_backend.current_device(),
                 dtype=torch.int64,
             )
 
@@ -209,7 +210,7 @@ class TopKTokenChoiceRouter(torch.nn.Module):
             neox_args.moe_num_experts,
             bias=False,
             dtype=neox_args.params_dtype,
-            device=torch.cuda.current_device(),
+            device=device_backend.current_device(),
         )
         init_method(self.layer.weight)
 

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -27,7 +27,7 @@ from pkg_resources import packaging
 from importlib.metadata import version
 
 from .norms import get_norm
-from megatron import mpu
+from megatron import mpu, device_backend
 from megatron.model.fused_softmax import FusedScaleMaskSoftmax
 from megatron.model.activations import get_activation
 from megatron.model.utils import exists, get_fusion_type
@@ -495,7 +495,7 @@ class ParallelSelfAttention(nn.Module):
             output_size[2],
             output_size[3],
             dtype=query_layer.dtype,
-            device=torch.cuda.current_device(),
+            device=device_backend.current_device(),
         )
 
         # Raw attention scores. [b * np, sq, sk]

--- a/megatron/model/transformer_engine.py
+++ b/megatron/model/transformer_engine.py
@@ -39,7 +39,7 @@ from megatron.mpu.utils import divide
 from megatron.mpu.utils import VocabUtility
 from functools import partial
 from megatron.model.positional_embeddings import RotaryEmbedding
-from megatron import mpu
+from megatron import mpu, device_backend
 
 # https://github.com/NVIDIA/TransformerEngine/issues/405
 import os
@@ -137,7 +137,7 @@ class TELinear(te.pytorch.Linear):
             bias=self.use_bias,
             init_method=self.init_method,
             get_rng_state_tracker=get_cuda_rng_tracker,
-            device=torch.cuda.current_device(),
+            device=device_backend.current_device(),
             return_bias=self.skip_bias_add,
             params_dtype=self.params_dtype,
         )
@@ -231,7 +231,7 @@ class TELayerNormMLP(te.pytorch.LayerNormMLP):
             activation=self.activation_type,
             init_method=self.init_method,
             output_layer_init_method=self.output_layer_init_method,
-            device=torch.cuda.current_device(),
+            device=device_backend.current_device(),
             set_parallel_mode=self.set_parallel_mode,
             sequence_parallel=self.sequence_parallel,
             tp_group=self.tp_group,
@@ -311,7 +311,7 @@ class TEColumnParallelLinear(te.pytorch.Linear):
             bias=self.use_bias,
             init_method=self.init_method,
             get_rng_state_tracker=get_cuda_rng_tracker,
-            device=torch.cuda.current_device(),
+            device=device_backend.current_device(),
             sequence_parallel=self.sequence_parallel,
             tp_group=self.tp_group,
             tp_size=self.world_size,
@@ -446,7 +446,7 @@ class TERowParallelLinear(te.pytorch.Linear):
             bias=self.use_bias,
             init_method=self.init_method,
             get_rng_state_tracker=get_cuda_rng_tracker,
-            device=torch.cuda.current_device(),
+            device=device_backend.current_device(),
             sequence_parallel=self.sequence_parallel,
             tp_group=self.tp_group,
             tp_size=self.world_size,
@@ -583,7 +583,7 @@ class TEMultiheadAttention(te.pytorch.MultiheadAttention):
             input_layernorm=False,
             normalization=self.normalization,
             bias=True,
-            device=torch.cuda.current_device(),
+            device=device_backend.current_device(),
             get_rng_state_tracker=get_cuda_rng_tracker,
             set_parallel_mode=self.set_parallel_mode,
             sequence_parallel=self.sequence_parallel,

--- a/megatron/mpu/data.py
+++ b/megatron/mpu/data.py
@@ -98,7 +98,7 @@ def broadcast_data(keys, data, datatype):
         # Flatten the data associated with the keys
         flatten_data = torch.cat(
             [data[key].contiguous().view(-1) for key in keys], dim=0
-        ).cuda()
+        ).to(device_backend.device())
     else:
         flatten_data = torch.empty(
             total_numel, device=device_backend.current_device(), dtype=datatype

--- a/megatron/mpu/data.py
+++ b/megatron/mpu/data.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import torch
+from megatron import device_backend
 
 from .initialize import get_model_parallel_group
 from .initialize import get_model_parallel_rank
@@ -48,7 +49,7 @@ def _build_key_size_numel_dictionaries(keys, data):
             offset += max_dim
 
     # Move to GPU and broadcast.
-    sizes_cuda = torch.cuda.LongTensor(sizes)
+    sizes_cuda = torch.LongTensor(sizes).to(device_backend.device())
     torch.distributed.broadcast(
         sizes_cuda, get_model_parallel_src_rank(), group=get_model_parallel_group()
     )
@@ -100,7 +101,7 @@ def broadcast_data(keys, data, datatype):
         ).cuda()
     else:
         flatten_data = torch.empty(
-            total_numel, device=torch.cuda.current_device(), dtype=datatype
+            total_numel, device=device_backend.current_device(), dtype=datatype
         )
 
     # Broadcast

--- a/megatron/mpu/layers.py
+++ b/megatron/mpu/layers.py
@@ -39,6 +39,7 @@ from .random import get_cuda_rng_tracker
 from .utils import divide
 from .utils import VocabUtility
 from functools import partial
+from megatron import device_backend
 
 
 def _initialize_affine_weight_gpu(weight, init_method, partition_dim, stride=1):
@@ -156,7 +157,7 @@ class VocabParallelEmbedding(torch.nn.Module):
                 torch.empty(
                     self.num_embeddings_per_partition,
                     self.embedding_dim,
-                    device=torch.cuda.current_device(),
+                    device=device_backend.current_device(),
                     dtype=neox_args.params_dtype,
                 )
             )
@@ -283,7 +284,7 @@ class ParallelRelativePositionBias(torch.nn.Module):
                 torch.empty(
                     self.num_buckets,
                     self.num_heads_per_partition,
-                    device=torch.cuda.current_device(),
+                    device=device_backend.current_device(),
                     dtype=neox_args.params_dtype,
                 )
             )
@@ -356,10 +357,10 @@ class ParallelRelativePositionBias(torch.nn.Module):
             # cache bucket if first step seq len stays constant
             self._q_len_cached, self._k_len_cached = q_len, k_len
             q_pos = torch.arange(
-                q_len, dtype=torch.long, device=torch.cuda.current_device()
+                q_len, dtype=torch.long, device=device_backend.current_device()
             )
             k_pos = torch.arange(
-                k_len, dtype=torch.long, device=torch.cuda.current_device()
+                k_len, dtype=torch.long, device=device_backend.current_device()
             )
             rel_pos = k_pos[None, :] - q_pos[:, None]
             rp_bucket = self._relative_position_bucket(
@@ -465,7 +466,7 @@ class ColumnParallelLinear(torch.nn.Module):
                 torch.empty(
                     self.output_size_per_partition,
                     self.input_size,
-                    device=torch.cuda.current_device(),
+                    device=device_backend.current_device(),
                     dtype=neox_args.params_dtype,
                 )
             )
@@ -484,7 +485,7 @@ class ColumnParallelLinear(torch.nn.Module):
                 self.bias = Parameter(
                     torch.empty(
                         self.output_size_per_partition,
-                        device=torch.cuda.current_device(),
+                        device=device_backend.current_device(),
                         dtype=neox_args.params_dtype,
                     )
                 )
@@ -681,7 +682,7 @@ class RowParallelLinear(torch.nn.Module):
                 torch.empty(
                     self.output_size,
                     self.input_size_per_partition,
-                    device=torch.cuda.current_device(),
+                    device=device_backend.current_device(),
                     dtype=neox_args.params_dtype,
                 )
             )
@@ -697,7 +698,7 @@ class RowParallelLinear(torch.nn.Module):
                 self.bias = Parameter(
                     torch.empty(
                         self.output_size,
-                        device=torch.cuda.current_device(),
+                        device=device_backend.current_device(),
                         dtype=neox_args.params_dtype,
                     )
                 )

--- a/megatron/mpu/mappings.py
+++ b/megatron/mpu/mappings.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 
 import torch
+from megatron import device_backend
 
 from .initialize import (
     get_expert_tokens_for_rank,
@@ -165,7 +166,7 @@ def _dmoe_gather(input_: torch.Tensor, tokens_per_expert: torch.Tensor):
         get_expert_token_counts_for_rank(tokens_per_expert, r)
         for r in range(world_size)
     ]
-    # print(f"{torch.cuda.current_device()}: tokens_by_rank {tokens_by_rank}")
+    
     tensor_list = [
         torch.empty(sum(r), input_.shape[-1], device=input_.device, dtype=input_.dtype)
         for r in tokens_by_rank
@@ -205,7 +206,7 @@ def _reduce_scatter_along_seq_dim(input_, seq_dim):
         # reduce_scatter_tensor is faster but only works correctly on dimension 0
         dim_size[seq_dim] = dim_size[seq_dim] // world_size
         output = torch.empty(
-            dim_size, dtype=input_.dtype, device=torch.cuda.current_device()
+            dim_size, dtype=input_.dtype, device=device_backend.current_device()
         )
         torch.distributed.reduce_scatter_tensor(
             output, input_.contiguous(), group=get_model_parallel_group()
@@ -243,7 +244,7 @@ def _gather_along_seq_dim(input_, seq_dim):
     if seq_dim == 0:
         # reduce_gather_tensor is faster but only works correctly on dimension 0
         output = torch.empty(
-            dim_size, dtype=input_.dtype, device=torch.cuda.current_device()
+            dim_size, dtype=input_.dtype, device=device_backend.current_device()
         )
         torch.distributed.all_gather_into_tensor(
             output, input_.contiguous(), group=get_model_parallel_group()

--- a/megatron/neox_arguments/arguments.py
+++ b/megatron/neox_arguments/arguments.py
@@ -36,6 +36,7 @@ from deepspeed.launcher.runner import DLTS_HOSTFILE
 from megatron.logging import Tee
 from megatron.tokenizer import build_tokenizer
 from megatron.utils import obtain_resource_pool, expand_attention_types
+from megatron import device_backend
 from .deepspeed_args import NeoXArgsDeepspeedConfig, NeoXArgsDeepspeedRunner
 from .neox_args import (
     NeoXArgsModel,
@@ -905,7 +906,7 @@ class NeoXArgs(*BASE_CLASSES):
                 if self.num_gpus is not None and self.num_gpus > 0:
                     global_num_gpus = self.num_gpus * len(resources)
             else:
-                global_num_gpus = torch.cuda.device_count()
+                global_num_gpus = device_backend.device_count()
             self.update_value("global_num_gpus", global_num_gpus)
 
         logging.info(

--- a/megatron/text_generation_utils.py
+++ b/megatron/text_generation_utils.py
@@ -29,7 +29,7 @@ import torch
 import torch.nn.functional as F
 
 from megatron import print_rank_0
-from megatron import mpu
+from megatron import mpu, device_backend
 from megatron.utils import get_ltor_masks_and_position_ids, is_mp_rank_0
 from megatron.data.indexed_dataset import make_builder, make_dataset
 from megatron.mpu.mappings import gather_from_model_parallel_region
@@ -172,7 +172,7 @@ def forward_model(model, model_inputs, is_pipe_parallel=False) -> torch.Tensor:
 
 def broadcast_terminate_signal(terminate_runs: int):
     """Send signal to all workers to terminate if we've finished the process"""
-    terminate_runs_tensor = torch.cuda.LongTensor([terminate_runs])
+    terminate_runs_tensor = torch.LongTensor([terminate_runs]).to(device_backend.device())
     torch.distributed.broadcast(
         terminate_runs_tensor,
         mpu.get_model_parallel_src_rank(),
@@ -247,15 +247,15 @@ def stream_tokens(
     )
 
     # convert to tensor and broadcast
-    context_tokens = torch.cuda.LongTensor(context_tokens)
+    context_tokens = torch.LongTensor(context_tokens).to(device_backend.device())
     if stop_tokens:
         if len(stop_tokens) > 0 and type(stop_tokens[0]) is not list:
             stop_tokens = [stop_tokens]
         for i in range(0, len(stop_tokens)):
-            stop_tokens[i] = torch.cuda.LongTensor(stop_tokens[i])
+            stop_tokens[i] = torch.LongTensor(stop_tokens[i]).to(device_backend.device())
 
     # Make sure context tokens + start tokens are the same across all ranks
-    token_generation_start_index = torch.cuda.LongTensor(context_lengths)
+    token_generation_start_index = torch.LongTensor(context_lengths).to(device_backend.device())
     torch.distributed.broadcast(
         context_tokens,
         mpu.get_model_parallel_src_rank(),
@@ -921,10 +921,10 @@ def precompute_logits(neox_args, model):
             )
             # print(context_tokens)
             # convert to tensor and broadcast
-            context_tokens = torch.cuda.LongTensor(context_tokens)
-            label_tokens = torch.cuda.LongTensor(label_tokens)
+            context_tokens = torch.LongTensor(context_tokens).to(device_backend.device())
+            label_tokens = torch.LongTensor(label_tokens).to(device_backend.device())
             # Make sure context tokens + start tokens are the same across all ranks
-            token_generation_start_index = torch.cuda.LongTensor(context_lengths)
+            token_generation_start_index = torch.LongTensor(context_lengths).to(device_backend.device())
             torch.distributed.broadcast(
                 context_tokens,
                 mpu.get_model_parallel_src_rank(),

--- a/megatron/text_generation_utils.py
+++ b/megatron/text_generation_utils.py
@@ -46,7 +46,7 @@ def get_batch(neox_args, context_tokens: torch.Tensor):
     """
 
     # Move to GPU.
-    tokens = context_tokens.contiguous().cuda()
+    tokens = context_tokens.contiguous().to(device_backend.device())
     # Get the attention mask and position ids.
     attention_mask, _, position_ids = get_ltor_masks_and_position_ids(
         data=tokens,
@@ -289,10 +289,10 @@ def stream_tokens(
 
     with torch.no_grad():
         # initialize generation variables
-        state_is_done = torch.zeros([batch_size]).byte().cuda()
-        token_generation_end_index = torch.ones([batch_size]).long().cuda() * (-1)
+        state_is_done = torch.zeros([batch_size]).byte().to(device_backend.device())
+        token_generation_end_index = torch.ones([batch_size]).long().to(device_backend.device()) * (-1)
         generation_logits = (
-            torch.empty(maximum_tokens, neox_args.padded_vocab_size).float().cuda()
+            torch.empty(maximum_tokens, neox_args.padded_vocab_size).float().to(device_backend.device())
         )
 
         while token_index_to_generate <= last_token_index_to_generate:
@@ -360,7 +360,7 @@ def stream_tokens(
                 generated_tokens = (
                     generated_tokens
                     if logits is not None
-                    else torch.zeros(batch_size, dtype=torch.long).cuda()
+                    else torch.zeros(batch_size, dtype=torch.long).to(device_backend.device())
                 )
                 torch.distributed.broadcast(
                     tensor=generated_tokens,
@@ -970,7 +970,7 @@ def precompute_logits(neox_args, model):
                         if logits is not None
                         else torch.zeros(
                             neox_args.batch_size, dtype=torch.float32
-                        ).cuda()
+                        ).to(device_backend.device())
                     )
                     torch.distributed.broadcast(
                         tensor=logp,

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -40,7 +40,7 @@ from megatron.utils import (
     reduce_losses,
 )
 
-from megatron import print_rank_0, mpu
+from megatron import print_rank_0, mpu, device_backend
 from megatron.model import (
     GPT2ModelPipe,
     SoftEmbedding,
@@ -203,9 +203,9 @@ def update_iterations(neox_args, data_loaders):
                 train_dataloader_len * train_epochs
             ) // gradient_accumulation_steps
 
-            train_iters_tensor = torch.cuda.LongTensor([train_iterations])
+            train_iters_tensor = torch.LongTensor([train_iterations]).to(device_backend.device())
         else:
-            train_iters_tensor = torch.cuda.LongTensor([0])
+            train_iters_tensor = torch.LongTensor([0]).to(device_backend.device())
 
         torch.distributed.broadcast(train_iters_tensor, src=0)
 
@@ -545,7 +545,7 @@ def forward_step(
 
     # Get the batch.
     if neox_args.memory_profiling and neox_args.iteration:
-        torch.cuda.nvtx.range_push(f"Get batch")
+        device_backend.nvtx.range_push(f"Get batch")
     if timers is not None:
         timers("batch generator").start()
     if neox_args.train_impl == "normal":
@@ -580,10 +580,10 @@ def forward_step(
     if timers is not None:
         timers("batch generator").stop()
     if neox_args.memory_profiling:
-        torch.cuda.nvtx.range_pop()
+        device_backend.nvtx.range_pop()
 
     if neox_args.memory_profiling:
-        torch.cuda.nvtx.range_push(f"Forward pass")
+        device_backend.nvtx.range_push(f"Forward pass")
     metrics = {}
     if neox_args.train_impl == "normal":
         outputs = model((tokens, position_ids, attention_mask), neox_args=neox_args)
@@ -858,7 +858,7 @@ def forward_step(
             loss = (loss * loss_mask).sum(-1) / loss_mask_sum
             loss = loss.mean()
     if neox_args.memory_profiling:
-        torch.cuda.nvtx.range_pop()
+        device_backend.nvtx.range_pop()
     if return_logits:
         return loss, outputs, metrics
     return loss, metrics
@@ -1143,7 +1143,7 @@ def get_learning_rate_scheduler(optimizer, neox_args):
 def setup_model_and_optimizer(neox_args, use_cache=False, iteration=None):
     """Setup memory profiler"""
     if neox_args.memory_profiling:
-        torch.cuda.memory._record_memory_history(
+        device_backend.memory()._record_memory_history(
             True,
             # keep a maximum 100,000 alloc/free events from before the snapshot
             trace_alloc_max_entries=100000,
@@ -1328,7 +1328,7 @@ def train_step(
                 and neox_args.iteration >= neox_args.profile_step_start
                 and neox_args.iteration <= neox_args.profile_step_stop
             ):
-                torch.cuda.nvtx.range_push(f"Backward pass")
+                device_backend.nvtx.range_push(f"Backward pass")
             timers("backward").start()
             backward_step(
                 neox_args=neox_args,
@@ -1343,14 +1343,14 @@ def train_step(
                 and neox_args.iteration >= neox_args.profile_step_start
                 and neox_args.iteration <= neox_args.profile_step_stop
             ):
-                torch.cuda.nvtx.range_pop()
+                device_backend.nvtx.range_pop()
             # Update parameters.
             if (
                 neox_args.profile
                 and neox_args.iteration >= neox_args.profile_step_start
                 and neox_args.iteration <= neox_args.profile_step_stop
             ):
-                torch.cuda.nvtx.range_push(f"Optimizer step")
+                device_backend.nvtx.range_push(f"Optimizer step")
 
             timers("optimizer").start()
             if neox_args.deepspeed:
@@ -1363,7 +1363,7 @@ def train_step(
                 and neox_args.iteration >= neox_args.profile_step_start
                 and neox_args.iteration <= neox_args.profile_step_stop
             ):
-                torch.cuda.nvtx.range_pop()
+                device_backend.nvtx.range_pop()
             if (
                 neox_args.profile
                 and neox_args.iteration >= neox_args.profile_step_start
@@ -1480,7 +1480,7 @@ def train(
         if neox_args.profile:
             prof.step()
         if neox_args.profile and iteration == neox_args.profile_step_start:
-            torch.cuda.cudart().cudaProfilerStart()
+            device_backend.cudart().cudaProfilerStart()
         loss_dict, skipped_iter = train_step(
             neox_args=neox_args,
             timers=timers,
@@ -1491,7 +1491,7 @@ def train(
             reference_model=reference_model,
         )
         if neox_args.profile and iteration == neox_args.profile_step_stop:
-            torch.cuda.cudart().cudaProfilerStop()
+            device_backend.cudart().cudaProfilerStop()
             prof.stop()
         iteration += 1
         neox_args.iteration = iteration
@@ -1721,7 +1721,7 @@ def save_snapshot(neox_args):
     assert (
         neox_args.memory_profiling_path is not None
     ), "Must pass memory_profiling_path config arg to use profiling"
-    snapshot = torch.cuda.memory._snapshot()
+    snapshot = device_backend.memory()._snapshot()
     snapshot_path = os.path.join(neox_args.memory_profiling_path)
     if not os.path.exists(snapshot_path):
         os.makedirs(snapshot_path)

--- a/megatron/utils.py
+++ b/megatron/utils.py
@@ -414,7 +414,7 @@ def get_total_params(model):
     else:
         params = 0
 
-    total_n_parameters = torch.tensor([params]).cuda(device_backend.current_device())
+    total_n_parameters = torch.tensor([params]).to(device_backend.current_device())
     torch.distributed.all_reduce(total_n_parameters)
     total_n_parameters = total_n_parameters.item()
     return total_n_parameters

--- a/megatron/utils.py
+++ b/megatron/utils.py
@@ -37,6 +37,7 @@ from deepspeed.runtime.bf16_optimizer import BF16_Optimizer
 
 from megatron import print_rank_0
 from megatron import mpu
+from megatron import device_backend
 
 from collections import deque
 
@@ -53,13 +54,13 @@ def report_memory(name):
     """Simple GPU memory report."""
     mega_bytes = 1024.0 * 1024.0
     string = name + " memory (MB)"
-    string += " | allocated: {}".format(torch.cuda.memory_allocated() / mega_bytes)
+    string += " | allocated: {}".format(device_backend.memory_allocated() / mega_bytes)
     string += " | max allocated: {}".format(
-        torch.cuda.max_memory_allocated() / mega_bytes
+        device_backend.max_memory_allocated() / mega_bytes
     )
-    string += " | reserved: {}".format(torch.cuda.memory_reserved() / mega_bytes)
+    string += " | reserved: {}".format(device_backend.memory_reserved() / mega_bytes)
     string += " | max reserved: {}".format(
-        torch.cuda.max_memory_reserved() / mega_bytes
+        device_backend.max_memory_reserved() / mega_bytes
     )
     print_rank_0(string)
 
@@ -196,7 +197,7 @@ def obtain_resource_pool(
     resource_pool = fetch_hostfile(hostfile_path)
     if not resource_pool:
         resource_pool = {}
-        device_count = torch.cuda.device_count()
+        device_count = device_backend.device_count()
         if device_count == 0:
             raise RuntimeError("Unable to proceed, no GPU resources available")
         resource_pool["localhost"] = device_count
@@ -239,14 +240,14 @@ class Timer:
     def start(self):
         """Start the timer."""
         assert not self.started_, "timer has already been started"
-        torch.cuda.synchronize()
+        device_backend.synchronize()
         self.start_time = time.time()
         self.started_ = True
 
     def stop(self):
         """Stop the timer."""
         assert self.started_, "timer is not started"
-        torch.cuda.synchronize()
+        device_backend.synchronize()
         self.elapsed_ += time.time() - self.start_time
         self.started_ = False
 
@@ -413,7 +414,7 @@ def get_total_params(model):
     else:
         params = 0
 
-    total_n_parameters = torch.tensor([params]).cuda(torch.cuda.current_device())
+    total_n_parameters = torch.tensor([params]).cuda(device_backend.current_device())
     torch.distributed.all_reduce(total_n_parameters)
     total_n_parameters = total_n_parameters.item()
     return total_n_parameters


### PR DESCRIPTION
Creates an abstraction for Intel GPUs. all `torch.cuda` or `torch.xpu` calls will instead call through `device_backend.py`. Implementations for different device functions can be created instead of relying on all of the functionality within `torch.cuda` to be implemented in `torch.xpu`. Profiling options that aren't available for Intel are simply ignored.