### PR TITLE
Fix: Size mismatch in EmbeddingPipe

### DIFF
--- a/megatron/model/word_embeddings.py
+++ b/megatron/model/word_embeddings.py
@@ -249,3 +249,6 @@ class SoftEmbedding(torch.nn.Module):
                 embedding = embedding[:, : self.neox_args.seq_length, ...]
             # otherwise, we're in incremental mode, and just want to forward the single embedding (since the soft prompt has already been cached)
             return embedding, layer_past, attention_mask
+
+# Fix size mismatch for word_embeddings.weight by ensuring compatible loading dimensions
+

--- a/megatron/model/word_embeddings.py
+++ b/megatron/model/word_embeddings.py
@@ -16,7 +16,7 @@ import torch
 import math
 from torch.nn.parameter import Parameter
 
-from megatron import mpu
+from megatron import mpu, print_rank_0
 from megatron.model.positional_embeddings import SinusoidalPositionalEmbedding
 from megatron.model.init_functions import get_init_methods
 
@@ -136,6 +136,51 @@ class Embedding(torch.nn.Module):
         # Initialize the token-type embeddings.
         self.init_method(self.tokentype_embeddings.weight)
 
+    def _load_from_state_dict(
+        self,
+        state_dict,
+        prefix,
+        local_metadata,
+        strict,
+        missing_keys,
+        unexpected_keys,
+        error_msgs,
+    ):
+        """Loads a word_embeddings.weight whose vocab dimension doesn't match this
+        model's (usually because the model pads the tokenizer's vocab size up to a
+        multiple of make_vocab_size_divisible_by, e.g. checkpoint 25216 rows vs
+        model 50304). Slices the checkpoint's full embedding table to this rank's
+        [vocab_start_index:vocab_end_index) partition, zero-filling any rows past
+        the checkpoint's vocab size, instead of letting the shape mismatch raise.
+        """
+        key = prefix + "word_embeddings.weight"
+        if key in state_dict:
+            checkpoint_weight = state_dict[key]
+            embedding = self.word_embeddings
+            if checkpoint_weight.shape[0] != embedding.num_embeddings:
+                print_rank_0(
+                    f"[Embedding] checkpoint word_embeddings.weight has vocab size "
+                    f"{checkpoint_weight.shape[0]}, model expects {embedding.num_embeddings} "
+                    f"(padded vocab size); resizing to load. Rows beyond the checkpoint's "
+                    f"vocab size keep their initialized (untrained) values."
+                )
+                resized = embedding.weight.data.clone()
+                checkpoint_vocab_size = checkpoint_weight.shape[0]
+                start, end = embedding.vocab_start_index, embedding.vocab_end_index
+                overlap_end = min(end, checkpoint_vocab_size)
+                if overlap_end > start:
+                    resized[: overlap_end - start] = checkpoint_weight[start:overlap_end]
+                state_dict[key] = resized
+        super()._load_from_state_dict(
+            state_dict,
+            prefix,
+            local_metadata,
+            strict,
+            missing_keys,
+            unexpected_keys,
+            error_msgs,
+        )
+
     def forward(self, input_ids, position_ids, tokentype_ids=None):
         # Embeddings.
         words_embeddings = self.word_embeddings(input_ids)
@@ -249,6 +294,4 @@ class SoftEmbedding(torch.nn.Module):
                 embedding = embedding[:, : self.neox_args.seq_length, ...]
             # otherwise, we're in incremental mode, and just want to forward the single embedding (since the soft prompt has already been cached)
             return embedding, layer_past, attention_mask
-
-# Fix size mismatch for word_embeddings.weight by ensuring compatible loading dimensions
 

--- a/tests/model/test_model_checkpoint.py
+++ b/tests/model/test_model_checkpoint.py
@@ -134,3 +134,91 @@ if __name__ == "__main__":
         )
     )
     test_train(params[0])
+
+
+class TestEmbeddingLoadStateDictVocabResize:
+    """A checkpoint's word_embeddings.weight vocab size can differ from the model's
+    padded vocab size (see issue #645: a slim/unpadded 25216-row checkpoint loaded
+    into a model padded to 50304 rows raised a hard state_dict size mismatch).
+    Embedding._load_from_state_dict must resize instead of raising.
+    """
+
+    def setup_method(self):
+        import torch.distributed as dist
+        from megatron import mpu
+
+        if not dist.is_initialized():
+            dist.init_process_group(
+                backend="gloo", init_method="tcp://127.0.0.1:29505", rank=0, world_size=1
+            )
+        mpu.destroy_model_parallel()
+        mpu.initialize_model_parallel(1)
+
+    def teardown_method(self):
+        from megatron import mpu
+
+        mpu.destroy_model_parallel()
+
+    def _make_embedding(self, vocab_size, hidden_size=8):
+        import types
+        from megatron.model.word_embeddings import Embedding
+        from megatron.model.init_functions import init_method_normal
+
+        neox_args = types.SimpleNamespace(
+            sequence_parallel=False,
+            use_mup=False,
+            mup_embedding_mult=1.0,
+            mup_rp_embedding_mult=1.0,
+            use_bnb_optimizer=False,
+            use_cpu_initialization=True,
+            params_dtype=torch.float32,
+            model_parallel_size=1,
+        )
+        return Embedding(
+            neox_args=neox_args,
+            hidden_size=hidden_size,
+            vocab_size=vocab_size,
+            max_sequence_length=16,
+            embedding_dropout_prob=0.0,
+            init_method=init_method_normal(0.02),
+            use_pos_emb=False,
+        )
+
+    def test_loads_smaller_checkpoint_vocab_into_larger_padded_model(self):
+        checkpoint_vocab_size = 25216
+        padded_vocab_size = 50304
+
+        checkpoint_embedding = self._make_embedding(checkpoint_vocab_size)
+        checkpoint_state = checkpoint_embedding.state_dict()
+
+        model_embedding = self._make_embedding(padded_vocab_size)
+        original_padding_rows = model_embedding.word_embeddings.weight.data[
+            checkpoint_vocab_size:
+        ].clone()
+
+        # Must not raise a state_dict size mismatch.
+        model_embedding.load_state_dict(checkpoint_state, strict=True)
+
+        loaded = model_embedding.word_embeddings.weight.data
+        assert torch.equal(
+            loaded[:checkpoint_vocab_size],
+            checkpoint_state["word_embeddings.weight"],
+        ), "checkpoint rows must load exactly"
+        assert torch.equal(
+            loaded[checkpoint_vocab_size:], original_padding_rows
+        ), "rows beyond the checkpoint's vocab must keep the model's own initialized values"
+
+    def test_loads_larger_checkpoint_vocab_into_smaller_model_by_truncating(self):
+        checkpoint_vocab_size = 50304
+        smaller_vocab_size = 25216
+
+        checkpoint_embedding = self._make_embedding(checkpoint_vocab_size)
+        checkpoint_state = checkpoint_embedding.state_dict()
+
+        model_embedding = self._make_embedding(smaller_vocab_size)
+        model_embedding.load_state_dict(checkpoint_state, strict=True)
+
+        loaded = model_embedding.word_embeddings.weight.data
+        assert torch.equal(
+            loaded, checkpoint_state["word_embeddings.weight"][:smaller_vocab_size]
+        )


### PR DESCRIPTION
Fixes #645. This ensures that the state_dict for word_embeddings.weight is correctly handled without size mismatch errors.