### PR TITLE
CI: install dependencies before preparing test data

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -48,13 +48,13 @@ jobs:
         with:
           python-version: "3.10.13"
           cache-dependency-path: "**/requirements*.txt"
-      - name: prepare data
-        run: python3 prepare_data.py
       - name: install pytest
         run: python3 -m pip install pytest pytest-forked pyyaml requests wandb
       - name: install torch
         run: python3 -m pip install torch
       - name: install requirements
         run: pip install -r requirements/requirements.txt
+      - name: prepare data
+        run: python3 prepare_data.py
       - name: Run Tests
         run: pytest --forked tests


### PR DESCRIPTION
## Summary

- install pytest, PyTorch, and project requirements before running `prepare_data.py`
- align the pull-request test job with the dependency-before-data order already used by `cpu_ci.yml`

`prepare_data.py` imports the dataset preprocessing stack, including third-party packages installed by these steps, so a clean runner can otherwise fail before reaching dependency installation.

Closes #1413

## Validation

- `pre-commit run --files .github/workflows/pull_request.yml`
- parsed the workflow YAML and verified `install requirements` precedes `prepare data`, which precedes `Run Tests`