### PR TITLE
fix(mpu): ColumnParallelLinear.mup_reinitialize_weights raises NameError on keep_master_weight_for_test

### DIFF
--- a/megatron/mpu/layers.py
+++ b/megatron/mpu/layers.py
@@ -434,6 +434,7 @@ class ColumnParallelLinear(torch.nn.Module):
 
         self.init_method = init_method
         self.stride = stride
+        self.keep_master_weight_for_test = keep_master_weight_for_test
         self.mup_rescale_parameters = mup_rescale_parameters
         self.use_mup = neox_args.use_mup
 
@@ -537,7 +538,7 @@ class ColumnParallelLinear(torch.nn.Module):
                 0,
                 partial(self.init_method, use_mup=True),
                 stride=self.stride,
-                return_master_weight=keep_master_weight_for_test,
+                return_master_weight=self.keep_master_weight_for_test,
             )
         else:
             _initialize_affine_weight_gpu(


### PR DESCRIPTION
## Problem

`ColumnParallelLinear.mup_reinitialize_weights` (`megatron/mpu/layers.py:540`)
reads a bare `keep_master_weight_for_test`:

```python
def mup_reinitialize_weights(self, neox_args):
    if neox_args.use_cpu_initialization:
        self.master_weight = _initialize_affine_weight_cpu(
            ...
            stride=self.stride,
            return_master_weight=keep_master_weight_for_test,   # <- undefined here
        )
```

That name only exists as an `__init__` parameter (line 416) and is never
assigned to the instance, so the method raises as soon as it is entered with
CPU initialization on:

```
NameError: name 'keep_master_weight_for_test' is not defined
```

`pyflakes` on `main` reports exactly this and nothing else in the file:

```
megatron/mpu/layers.py:540:38: undefined name 'keep_master_weight_for_test'
```

## Reachability

`megatron/training.py:82` walks every module and calls the method on anything
that defines it:

```python
if has_method(layer, "mup_reinitialize_weights"):
    layer.mup_reinitialize_weights(neox_args)
```

so under μP (`use_mup: true`) the first `ColumnParallelLinear` reached is enough
to abort the run. `use_cpu_initialization` is a documented config flag
(`neox_args.py:362`) and is also forced on by `megatron/initialize.py:66` when
`lazy_mpu_init` is set.

## Fix

Mirror `RowParallelLinear`, which already does the right thing in the same file:

```python
# RowParallelLinear.__init__, line 652
self.keep_master_weight_for_test = keep_master_weight_for_test
...
# RowParallelLinear.mup_reinitialize_weights, line 750
return_master_weight=self.keep_master_weight_for_test,
```

Both TE wrappers in `megatron/model/transformer_engine.py` (lines 352 and 487)
read `self.keep_master_weight_for_test` as well, so `ColumnParallelLinear` was
the only one of the four still on the bare name.

The two other `return_master_weight=keep_master_weight_for_test` occurrences in
this file (lines 462 and 678) are inside `__init__`, where the name is a real
local, and are left untouched.

+1/-1 lines. `pyflakes` is clean on the patched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
