### PR TITLE
fix(neox_args): mamba/rwkv hidden_dropout assertions never fire (1-tuple always truthy)

### DIFF
--- a/megatron/neox_arguments/arguments.py
+++ b/megatron/neox_arguments/arguments.py
@@ -1112,7 +1112,7 @@ class NeoXArgs(*BASE_CLASSES):
             if isinstance(self.zero_stage, int):
                 assert self.zero_stage <= 2, "Zero stage 3 not compatible with Mamba"
             assert (
-                self.hidden_dropout == 0.0,
+                self.hidden_dropout == 0.0
             ), "Mamba does not yet have dropout implemented"
         if "rwkv" in self.attention_config:
             assert (
@@ -1121,7 +1121,7 @@ class NeoXArgs(*BASE_CLASSES):
             if isinstance(self.zero_stage, int):
                 assert self.zero_stage <= 2, "Zero stage 3 not compatible with RWKV"
             assert (
-                self.hidden_dropout == 0.0,
+                self.hidden_dropout == 0.0
             ), "RWKV does not yet have dropout implemented"
 
         # Sparsity config


### PR DESCRIPTION
### The bug

Both dropout guards in `NeoXArgsOther.calculate_derived` wrap their condition in a parenthesised **1-tuple**:

```python
if "mamba" in self.attention_config:
    ...
    assert (
        self.hidden_dropout == 0.0,          # <-- trailing comma
    ), "Mamba does not yet have dropout implemented"
```

The trailing comma makes the asserted object a `tuple` of one element, which is always truthy, so the assertion **can never fail** and its message is never shown. Configuring `hidden_dropout > 0` alongside a `mamba` or `rwkv` `attention_config` is accepted silently, and training proceeds with a dropout value the implementation ignores — which is exactly what the guard was written to prevent.

CPython flags both lines at compile time:

```
megatron/neox_arguments/arguments.py:1114: SyntaxWarning: assertion is always true, perhaps remove parentheses?
megatron/neox_arguments/arguments.py:1123: SyntaxWarning: assertion is always true, perhaps remove parentheses?
```

### The fix

Drop the trailing comma on both. This is the form the **two sibling guards in the very same block** already use, so the change only makes the dropout guards consistent with their neighbours:

```python
assert (
    not self.partition_activations
), "GMLP Blocks are not compatible with partition activations"     # L1108

assert (
    self.model_parallel_size == 1
), "RWKV not currently compatible with model parallelism"          # L1118
```

Diff is 2 lines, `-2` characters.

### Verification

I extracted the two `assert` statements from this file via `ast`, and replayed them against a stub with the relevant attribute set (no hand-copied repro):

| `hidden_dropout` | before | after |
|---|---|---|
| `0.1` (L1114, mamba) | no `AssertionError` — check silently skipped | `AssertionError("Mamba does not yet have dropout implemented")` |
| `0.1` (L1123, rwkv) | no `AssertionError` — check silently skipped | `AssertionError("RWKV does not yet have dropout implemented")` |
| `0.0` (the default) | silent | silent |

The last row is the important one: `hidden_dropout` defaults to `0.0` (`neox_args.py:1410`), so every currently-valid configuration is unaffected. The only configs that begin to fail are the ones the assertion was written to reject.

`pyflakes` reports both lines before the change and neither after. `black==22.3.0` (the rev pinned in `.pre-commit-config.yaml`) leaves the file unchanged both before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
